### PR TITLE
fix: update local branch ref correctly when creating worktrees

### DIFF
--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -42,9 +42,12 @@ func (s *GitService) ListBranches(ctx context.Context, repoPath string) ([]strin
 }
 
 func (s *GitService) Pull(ctx context.Context, repoPath string, branch string) error {
-	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "pull", "origin", branch)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git pull failed: %s: %w", string(output), err)
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "fetch", "origin", branch+":"+branch)
+	if _, err := cmd.CombinedOutput(); err != nil {
+		fallback := exec.CommandContext(ctx, "git", "-C", repoPath, "pull", "origin", branch)
+		if output, err := fallback.CombinedOutput(); err != nil {
+			return fmt.Errorf("git pull failed: %s: %w", string(output), err)
+		}
 	}
 	return nil
 }

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -50,6 +50,7 @@ func (s *SessionService) resolveWorkspaceName(session *Session) {
 	}
 	ws, err := s.workspaceStore.GetByID(session.WorkspaceID)
 	if err != nil {
+		slog.Warn("failed to resolve workspace name", "session", session.ID, "workspace_id", session.WorkspaceID, "error", err)
 		return
 	}
 	session.WorkspaceName = ws.Name

--- a/internal/workspace/workspacestore.go
+++ b/internal/workspace/workspacestore.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -225,6 +226,7 @@ func (s *WorkspaceStore) OnAppEnd(ctx context.Context) error {
 func (s *WorkspaceStore) discoverWorkspaces() ([]*Workspace, error) {
 	cfg, err := s.loadConfig()
 	if err != nil {
+		slog.Warn("failed to load workspace config, no workspaces will be available", "error", err)
 		return nil, nil
 	}
 


### PR DESCRIPTION
Pull was using `git pull origin <branch>` which merges into the currently checked-out branch, not the target branch. Now uses `git fetch origin <branch>:<branch>` to update the local ref directly, with fallback to pull when the branch is checked out.

Also adds warning logs for silent workspace resolution failures to make "no workspace" display issues diagnosable.