### PR TITLE
fix: reserve needs_attention status for permission prompts only

### DIFF
--- a/internal/claude/claudeservice.go
+++ b/internal/claude/claudeservice.go
@@ -30,7 +30,7 @@ func (s *ClaudeService) HandleHookEvent(ctx context.Context, req *HookEventReque
 		return s.upsertWithStatus(req, StatusWorking)
 
 	case "Stop":
-		return s.upsertWithStatus(req, StatusNeedsAttention)
+		return s.upsertWithStatus(req, StatusCompleted)
 
 	case "Notification":
 		if req.NotificationType == "permission_prompt" {


### PR DESCRIPTION
Map Stop event to StatusCompleted instead of StatusNeedsAttention so the TUI distinguishes permission prompts from Claude finishing its turn.