### PR TITLE
feat(tui): use build-time ldflags for default port and pipe name

### DIFF
--- a/Taskfile.tui.yml
+++ b/Taskfile.tui.yml
@@ -8,17 +8,18 @@ tasks:
     sources:
       - 'internal/**/*.go'
       - 'cmd/tui/main.go'
+    vars:
+      LDFLAGS: >-
+        -X main.defaultPort={{.UTENA_PORT | default "3333"}}
+        -X main.defaultPipeName={{.UTENA_PIPE_NAME | default "utena-commands"}}
     cmds:
-      - go build -o out/tui cmd/tui/main.go
+      - go build -ldflags '{{.LDFLAGS}}' -o out/tui cmd/tui/main.go
   install:
     deps:
       - build
     cmds:
       - cp ./out/tui /usr/local/bin/utena
   run:
-    env:
-      UTENA_PORT: '{{.UTENA_PORT | default "3333"}}'
-      UTENA_PIPE_NAME: '{{.UTENA_PIPE_NAME | default ""}}'
     deps:
       - build
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -54,6 +54,9 @@ tasks:
   dev:tui:
     cmds:
       - task: tui:build
+        vars:
+          UTENA_PORT: '{{.DEV_PORT}}'
+          UTENA_PIPE_NAME: '{{.DEV_PIPE_NAME}}'
 
   dev:plugin:build:
     cmds:

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -13,6 +13,11 @@ import (
 	"github.com/eleonorayaya/utena/internal/tui"
 )
 
+var (
+	defaultPort     = "3333"
+	defaultPipeName = "utena-commands"
+)
+
 func main() {
 	rootCmd := &cobra.Command{
 		Use:          "utena",
@@ -21,8 +26,8 @@ func main() {
 		RunE:         runTUI,
 	}
 
-	rootCmd.Flags().String("port", "", "daemon port")
-	rootCmd.Flags().String("pipe-name", "", "zellij pipe name")
+	rootCmd.Flags().String("port", defaultPort, "daemon port")
+	rootCmd.Flags().String("pipe-name", defaultPipeName, "zellij pipe name")
 
 	rootCmd.AddCommand(shellInitCmd())
 

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -27,20 +26,7 @@ var baseURL string
 var pipeName string
 
 func Configure(port, pipe string) {
-	if port == "" {
-		port = os.Getenv("UTENA_PORT")
-	}
-	if port == "" {
-		port = "3333"
-	}
 	baseURL = fmt.Sprintf("http://localhost:%s", port)
-
-	if pipe == "" {
-		pipe = os.Getenv("UTENA_PIPE_NAME")
-	}
-	if pipe == "" {
-		pipe = "utena-commands"
-	}
 	pipeName = pipe
 }
 


### PR DESCRIPTION
Replace runtime env var configuration with Go ldflags so defaults are baked into the binary at build time. CLI args remain as the only runtime override.