### PR TITLE
feat(tui): filter dead sessions from list by default

### DIFF
--- a/internal/tui/sessionlist/keys.go
+++ b/internal/tui/sessionlist/keys.go
@@ -6,25 +6,27 @@ import (
 )
 
 type keyMap struct {
-	Select key.Binding
-	Close  key.Binding
-	New    key.Binding
-	Todos  key.Binding
+	Select     key.Binding
+	Close      key.Binding
+	New        key.Binding
+	Todos      key.Binding
+	ToggleDead key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Select, k.Close, k.New, k.Todos}
+	return []key.Binding{k.Select, k.Close, k.New, k.Todos, k.ToggleDead}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.Select, k.Close, k.New, k.Todos}}
+	return [][]key.Binding{{k.Select, k.Close, k.New, k.Todos, k.ToggleDead}}
 }
 
 var keys = keyMap{
-	Select: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
-	Close:  key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "close")),
-	New:    key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
-	Todos:  key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "todos")),
+	Select:     key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+	Close:      key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "close")),
+	New:        key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
+	Todos:      key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "todos")),
+	ToggleDead: key.NewBinding(key.WithKeys("."), key.WithHelp(".", "toggle dead")),
 }
 
 var _ help.KeyMap = keys

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -16,6 +16,7 @@ type Model struct {
 	sessions        []session.Session
 	claudeSessions  map[string][]claude.ClaudeSession
 	pendingDeleteID string
+	showDead        bool
 }
 
 func New() Model {
@@ -41,6 +42,9 @@ func (m *Model) rebuildItems() tea.Cmd {
 	var items []list.Item
 	for _, s := range m.sessions {
 		if s.IsDeleted {
+			continue
+		}
+		if s.IsDead && !m.showDead {
 			continue
 		}
 		status := aggregateClaudeStatus(m.claudeSessions[s.ID])
@@ -87,6 +91,9 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 		m.pendingDeleteID = ""
 	}
 	switch {
+	case key.Matches(msg, keys.ToggleDead):
+		m.showDead = !m.showDead
+		return m, m.rebuildItems(), true
 	case key.Matches(msg, keys.New):
 		return m, router.NavigateTo(router.SessionFormView), true
 	case key.Matches(msg, keys.Todos):


### PR DESCRIPTION
## Summary
- Dead sessions are hidden from the TUI session list by default
- Press `.` to toggle showing/hiding dead sessions
- Adds `ToggleDead` key binding with help text

## Test plan
- [ ] Launch TUI with some dead sessions — verify they are hidden by default
- [ ] Press `.` — verify dead sessions appear in the list
- [ ] Press `.` again — verify dead sessions are hidden again
- [ ] Verify help bar shows the `.` / `toggle dead` binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)