### PR TITLE
feat: workspace-prefixed session IDs with display name

### DIFF
--- a/.claude/plans/transient-munching-brooks.md
+++ b/.claude/plans/transient-munching-brooks.md
@@ -1,0 +1,103 @@
+# Plan: Workspace-Prefixed Session IDs with Display Name
+
+## Context
+
+Session IDs are globally unique and used directly as Zellij session names. Creating a "main" session in workspace "utena" prevents creating "main" in workspace "other". Solution: encode workspace name into `session.ID` (e.g., `utena-main`) so it remains globally unique, and add a `Name` field for the user-visible short name (e.g., `main`).
+
+**Data flow change:**
+- Current: user enters "main" → `ID = "main"` → Zellij session = "main"
+- New: user enters "main" in workspace "utena" → `Name = "main"`, `ID = "utena-main"` → Zellij session = "utena-main"
+
+No store, API route, or Zellij integration changes needed — `ID` remains the globally unique key everywhere.
+
+## Changes
+
+### 1. Session model — add Name field
+
+**File:** `internal/session/session.go`
+
+Add `Name string` field to `Session` struct. Add `BuildSessionID(workspaceName, name string) string` helper: sanitize workspace name (lowercase, spaces→hyphens), return `{sanitized}-{name}`.
+
+### 2. SessionService — compute ID from workspace + name
+
+**File:** `internal/session/sessionservice.go`
+
+In `CreateSession`, after workspace lookup: if `session.Name` is set and workspace exists, compute `session.ID = BuildSessionID(ws.Name, session.Name)`. If no workspace, `session.ID = session.Name`.
+
+### 3. TUI client — send Name, parse back ID
+
+**File:** `internal/tui/client.go`
+
+- `createSession` — send `name` field in request body (the short name). Parse `id` from response (the computed prefixed ID).
+- `sessionCreatedMsg` — add `id` field (the full prefixed session ID).
+
+### 4. TUI app — use response ID for activation/pipes
+
+**File:** `internal/tui/app.go`
+
+- `sessionCreatedMsg` handler — use `msg.id` for `activateSession()` call and store in pending
+- `sessionActivatedMsg` handler — use the ID (prefixed) for pipe commands
+- `pendingSession` — add `id` field to carry the server-assigned prefixed ID
+
+### 5. TUI session list — display Name, operate on ID
+
+**File:** `internal/tui/sessionlist.go`
+
+- `sessionItem.Title()` — use `session.Name` if set, fall back to `session.ID`
+- `FilterValue()` — use `session.Name` if set, fall back to `session.ID`
+- All operational messages (activate, delete) — keep using `session.ID` (unchanged)
+- Status messages to user — show `session.Name` instead of `session.ID`
+
+### 6. TUI name input — emit Name, not ID
+
+**File:** `internal/tui/nameinput.go`
+
+`createSessionMsg` already sends `name` — no structural change needed. The name input captures the short name; the server computes the full ID.
+
+### 7. Session types — add Name to request
+
+**File:** `internal/session/types.go`
+
+No changes needed — `CreateSessionRequest` embeds `*Session`, which now has `Name`. The `Name` field will be sent in the JSON body and bound automatically.
+
+### 8. ZellijService — no changes
+
+Zellij matching already uses `sess.ID`. Since `ID` is now the prefixed name, Zellij sessions naturally match. Sessions discovered from Zellij (not created by utena) get `ID` = raw Zellij name, `Name` = same.
+
+### 9. Validation — validate Name, not ID
+
+**File:** `internal/session/validation.go`
+
+`ValidateSession` should validate `session.Name` (user input) rather than `session.ID` (computed). The ID is system-generated and may contain characters from workspace name. Add `ValidateSessionName` call on `session.Name` when it's set.
+
+### 10. SessionStore migration
+
+**File:** `internal/session/sessionstore.go`
+
+In `OnAppStart`, for loaded sessions missing `Name`, set `Name = ID` (backward compat — old sessions where ID was the user-entered name).
+
+### 11. Tests — minor updates
+
+Set `Name` on test sessions. For sessions created through the service, verify `ID` is computed as `{workspace}-{name}`. Existing tests that add directly to store just need `Name` populated.
+
+## File Summary
+
+| File | Action |
+|------|--------|
+| `internal/session/session.go` | Add `Name` field, `BuildSessionID()` helper |
+| `internal/session/sessionservice.go` | Compute `ID` from workspace + `Name` in `CreateSession` |
+| `internal/session/sessionstore.go` | Migration: set `Name = ID` for old sessions |
+| `internal/session/validation.go` | Validate `Name` instead of `ID` in `ValidateSession` |
+| `internal/tui/client.go` | Send `name`, parse `id` from response |
+| `internal/tui/app.go` | Use response ID for activation, add `id` to pending |
+| `internal/tui/sessionlist.go` | Display `Name`, operate on `ID` |
+| Test files | Set `Name` on test sessions, verify ID computation |
+
+## Verification
+
+1. `task daemon:build tui:build` — compilation
+2. `task test` — all tests pass
+3. Manual: create "main" in workspace A and workspace B — both succeed
+4. Manual: Zellij sessions named `{workspace}-main`
+5. Manual: TUI shows short name "main" with workspace in description
+6. Manual: delete/switch operates on correct prefixed session

--- a/Taskfile.daemon.yml
+++ b/Taskfile.daemon.yml
@@ -13,6 +13,7 @@ tasks:
       - 'cmd/daemon/main.go'
     cmds:
       - go build -o out/daemon cmd/daemon/main.go
+
   run:
     env:
       UTENA_LOG_PRETTY: 'true'
@@ -23,6 +24,7 @@ tasks:
       - build
     cmds:
       - ./out/daemon
+
   install:
     desc: Install the daemon as a launchd user agent
     deps:
@@ -34,10 +36,12 @@ tasks:
       - sed -e 's|__DAEMON_PATH__|{{.DAEMON_BIN}}|g' -e 's|__LOG_DIR__|{{.LOG_DIR}}|g' config/launchd/{{.PLIST_NAME}} > {{shellQuote .PLIST_DEST}}
       - launchctl bootout gui/$(id -u) {{shellQuote .PLIST_DEST}} 2>/dev/null || true
       - launchctl bootstrap gui/$(id -u) {{shellQuote .PLIST_DEST}}
+
   logs:
     desc: Tail the daemon logs
     cmds:
       - tail -f {{shellQuote .LOG_DIR}}/daemon.stdout.log {{shellQuote .LOG_DIR}}/daemon.stderr.log
+
   uninstall:
     desc: Uninstall the daemon launchd user agent
     cmds:

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/eleonorayaya/utena/internal/session"
 	"github.com/eleonorayaya/utena/internal/workspace"
@@ -77,16 +76,7 @@ func TestDaemon_GetWorkspaceByID(t *testing.T) {
 func TestDaemon_CreateAndGetSession(t *testing.T) {
 	_, router := setupTestRouter(t)
 
-	// Create session
-	sess := &session.Session{
-		ID:          "test-session-1",
-		WorkspaceID: "ws-1",
-		IsAttached:  true,
-		IsActive:    true,
-		LastUsedAt:  time.Now(),
-	}
-	body, err := json.Marshal(sess)
-	require.NoError(t, err)
+	body := []byte(`{"name":"test-session-1","workspace_id":"ws-1"}`)
 
 	req := httptest.NewRequest("POST", "/sessions", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -96,8 +86,13 @@ func TestDaemon_CreateAndGetSession(t *testing.T) {
 
 	require.Equal(t, http.StatusCreated, w.Code)
 
-	// Get session
-	req = httptest.NewRequest("GET", "/sessions/test-session-1", nil)
+	var createResp session.SessionResponse
+	err := json.Unmarshal(w.Body.Bytes(), &createResp)
+	require.NoError(t, err)
+	require.Equal(t, "utena-test-session-1", createResp.ID)
+	require.Equal(t, "test-session-1", createResp.Name)
+
+	req = httptest.NewRequest("GET", "/sessions/utena-test-session-1", nil)
 	w = httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)
@@ -107,33 +102,20 @@ func TestDaemon_CreateAndGetSession(t *testing.T) {
 	var response session.SessionResponse
 	err = json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
-	require.Equal(t, "test-session-1", response.ID)
+	require.Equal(t, "utena-test-session-1", response.ID)
 	require.Equal(t, "ws-1", response.WorkspaceID)
-	require.True(t, response.IsAttached)
 }
 
 func TestDaemon_ListSessions(t *testing.T) {
 	_, router := setupTestRouter(t)
 
-	// Create multiple sessions
-	sessions := []*session.Session{
-		{
-			ID:          "session-1",
-			WorkspaceID: "ws-1",
-			LastUsedAt:  time.Now().Add(-1 * time.Hour),
-		},
-		{
-			ID:          "session-2",
-			WorkspaceID: "ws-2",
-			LastUsedAt:  time.Now(),
-		},
+	bodies := []string{
+		`{"name":"session-1","workspace_id":"ws-1"}`,
+		`{"name":"session-2","workspace_id":"ws-2"}`,
 	}
 
-	for _, sess := range sessions {
-		body, err := json.Marshal(sess)
-		require.NoError(t, err)
-
-		req := httptest.NewRequest("POST", "/sessions", bytes.NewReader(body))
+	for _, b := range bodies {
+		req := httptest.NewRequest("POST", "/sessions", bytes.NewReader([]byte(b)))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
 
@@ -141,7 +123,6 @@ func TestDaemon_ListSessions(t *testing.T) {
 		require.Equal(t, http.StatusCreated, w.Code)
 	}
 
-	// List sessions
 	req := httptest.NewRequest("GET", "/sessions", nil)
 	w := httptest.NewRecorder()
 
@@ -154,9 +135,12 @@ func TestDaemon_ListSessions(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, response.Sessions, 2)
 
-	// Verify MRU sorting (most recent first)
-	require.Equal(t, "session-2", response.Sessions[0].ID)
-	require.Equal(t, "session-1", response.Sessions[1].ID)
+	ids := make(map[string]bool)
+	for _, s := range response.Sessions {
+		ids[s.ID] = true
+	}
+	require.True(t, ids["utena-session-1"])
+	require.True(t, ids["other-session-2"])
 }
 
 func TestDaemon_ZellijSessionUpdate(t *testing.T) {
@@ -228,32 +212,13 @@ func findSessionByID(sessions []session.Session, id string) *session.Session {
 func TestDaemon_ZellijSessionUpdate_MarkDeadSessions(t *testing.T) {
 	_, router := setupTestRouter(t)
 
-	sess1 := &session.Session{
-		ID:          "old-session-1",
-		WorkspaceID: "ws-1",
-		IsActive:    true,
-		IsDead:      false,
-		LastUsedAt:  time.Now(),
-	}
-	sess2 := &session.Session{
-		ID:          "old-session-2",
-		WorkspaceID: "ws-1",
-		IsActive:    true,
-		IsDead:      false,
-		LastUsedAt:  time.Now(),
-	}
-
-	body1, err := json.Marshal(sess1)
-	require.NoError(t, err)
-	req1 := httptest.NewRequest("POST", "/sessions", bytes.NewReader(body1))
+	req1 := httptest.NewRequest("POST", "/sessions", bytes.NewReader([]byte(`{"name":"old-session-1","workspace_id":"ws-1"}`)))
 	req1.Header.Set("Content-Type", "application/json")
 	w1 := httptest.NewRecorder()
 	router.ServeHTTP(w1, req1)
 	require.Equal(t, http.StatusCreated, w1.Code)
 
-	body2, err := json.Marshal(sess2)
-	require.NoError(t, err)
-	req2 := httptest.NewRequest("POST", "/sessions", bytes.NewReader(body2))
+	req2 := httptest.NewRequest("POST", "/sessions", bytes.NewReader([]byte(`{"name":"old-session-2","workspace_id":"ws-1"}`)))
 	req2.Header.Set("Content-Type", "application/json")
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, req2)
@@ -262,7 +227,7 @@ func TestDaemon_ZellijSessionUpdate_MarkDeadSessions(t *testing.T) {
 	updateReq := &zellij.UpdateSessionsRequest{
 		Sessions: []zellij.SessionUpdate{
 			{
-				Name:             "old-session-1",
+				Name:             "utena-old-session-1",
 				ConnectedClients: 1,
 			},
 			{
@@ -295,12 +260,12 @@ func TestDaemon_ZellijSessionUpdate_MarkDeadSessions(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, sessionsResponse.Sessions, 3)
 
-	oldSession1 := findSessionByID(sessionsResponse.Sessions, "old-session-1")
+	oldSession1 := findSessionByID(sessionsResponse.Sessions, "utena-old-session-1")
 	require.NotNil(t, oldSession1)
 	require.True(t, oldSession1.IsAttached)
 	require.False(t, oldSession1.IsDead)
 
-	oldSession2 := findSessionByID(sessionsResponse.Sessions, "old-session-2")
+	oldSession2 := findSessionByID(sessionsResponse.Sessions, "utena-old-session-2")
 	require.NotNil(t, oldSession2)
 	require.True(t, oldSession2.IsDead)
 

--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -61,6 +61,25 @@ func (s *GitService) CreateWorktree(ctx context.Context, repoPath string, name s
 	return worktreePath, nil
 }
 
+func (s *GitService) CheckoutWorktree(ctx context.Context, repoPath string, branch string) (string, error) {
+	sanitized := strings.ReplaceAll(branch, "/", "-")
+	worktreePath := filepath.Join(repoPath, ".worktrees", sanitized)
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "worktree", "add", worktreePath, branch)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("git worktree add failed: %s: %w", string(output), err)
+	}
+	return worktreePath, nil
+}
+
+func (s *GitService) CurrentBranch(ctx context.Context, repoPath string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "branch", "--show-current")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current branch: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
 func (s *GitService) RemoveWorktree(ctx context.Context, repoPath string, worktreePath string) error {
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "worktree", "remove", worktreePath, "--force")
 	if output, err := cmd.CombinedOutput(); err != nil {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -15,7 +15,9 @@ type Session struct {
 	ID            string    `json:"id"`
 	WorkspaceID   string    `json:"workspace_id"`
 	WorkspaceName string    `json:"workspace_name,omitempty"`
+	Branch        string    `json:"branch,omitempty"`
 	BaseBranch    string    `json:"base_branch,omitempty"`
+	BranchCreated bool      `json:"branch_created,omitempty"`
 	WorktreePath  string    `json:"worktree_path,omitempty"`
 	IsAttached    bool      `json:"is_attached"`
 	IsActive      bool      `json:"is_active"`

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -13,6 +14,7 @@ var ErrSessionDead = errors.New("cannot activate dead session")
 
 type Session struct {
 	ID            string    `json:"id"`
+	Name          string    `json:"name,omitempty"`
 	WorkspaceID   string    `json:"workspace_id"`
 	WorkspaceName string    `json:"workspace_name,omitempty"`
 	Branch        string    `json:"branch,omitempty"`
@@ -31,4 +33,13 @@ type Cleanup struct {
 	ZellijSessionKilled bool `json:"zellij_session_killed"`
 	WorktreeRemoved     bool `json:"worktree_removed"`
 	BranchDeleted       bool `json:"branch_deleted"`
+}
+
+func BuildSessionID(workspaceName, name string) string {
+	sanitized := strings.ToLower(strings.ReplaceAll(workspaceName, " ", "-"))
+	return sanitized + "-" + name
+}
+
+func sanitizeBranchName(branch string) string {
+	return strings.ReplaceAll(branch, "/", "-")
 }

--- a/internal/session/sessioncontroller.go
+++ b/internal/session/sessioncontroller.go
@@ -70,7 +70,15 @@ func (c *SessionController) CreateSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if err := c.service.CreateSession(ctx, data.Session, data.ShouldCreateWorktree()); err != nil {
+	session := &Session{
+		Name:          data.Name,
+		WorkspaceID:   data.WorkspaceID,
+		Branch:        data.Branch,
+		BaseBranch:    data.BaseBranch,
+		BranchCreated: data.BranchCreated,
+	}
+
+	if err := c.service.CreateSession(ctx, session, data.CreateWorktree); err != nil {
 		var wsNotFound *workspace.WorkspaceNotFoundError
 		if errors.Is(err, ErrSessionAlreadyExists) || errors.As(err, &wsNotFound) {
 			render.Render(w, r, common.ErrInvalidRequest(err))
@@ -80,7 +88,7 @@ func (c *SessionController) CreateSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	response := NewSessionResponse(data.Session)
+	response := NewSessionResponse(session)
 	render.Status(r, http.StatusCreated)
 	render.Render(w, r, response)
 }

--- a/internal/session/sessioncontroller.go
+++ b/internal/session/sessioncontroller.go
@@ -70,7 +70,7 @@ func (c *SessionController) CreateSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if err := c.service.CreateSession(ctx, data.Session); err != nil {
+	if err := c.service.CreateSession(ctx, data.Session, data.ShouldCreateWorktree()); err != nil {
 		var wsNotFound *workspace.WorkspaceNotFoundError
 		if errors.Is(err, ErrSessionAlreadyExists) || errors.As(err, &wsNotFound) {
 			render.Render(w, r, common.ErrInvalidRequest(err))
@@ -115,7 +115,9 @@ func (c *SessionController) DeleteSession(w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 	id := chi.URLParam(r, "id")
 
-	if err := c.service.DeleteSession(ctx, id); err != nil {
+	deleteBranch := r.URL.Query().Get("delete_branch") != "false"
+
+	if err := c.service.DeleteSession(ctx, id, deleteBranch); err != nil {
 		if errors.Is(err, ErrSessionNotFound) {
 			render.Render(w, r, common.ErrNotFound())
 			return

--- a/internal/session/sessionrouter_test.go
+++ b/internal/session/sessionrouter_test.go
@@ -150,56 +150,88 @@ func TestSessionRouter_ListSessionsByWorkspace(t *testing.T) {
 func TestSessionRouter_CreateSession(t *testing.T) {
 	router, sessionStore, _ := setupSessionRouter(t)
 
-	// Create request body
-	session := &Session{
-		ID:          "session-1",
-		WorkspaceID: "ws-1",
-		IsAttached:  true,
-		IsActive:    true,
-		LastUsedAt:  time.Now(),
-	}
-	body, err := json.Marshal(session)
-	require.NoError(t, err)
+	body := []byte(`{"name":"session-1","workspace_id":"ws-1"}`)
 
-	// Create request
 	req := httptest.NewRequest("POST", "/", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
-	// Execute
 	router.Routes().ServeHTTP(w, req)
 
-	// Assert
 	require.Equal(t, http.StatusCreated, w.Code)
 
-	// Verify session was created
-	retrieved, err := sessionStore.GetByID("session-1")
+	var resp SessionResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
-	require.Equal(t, "session-1", retrieved.ID)
+	require.Equal(t, "utena-session-1", resp.ID)
+	require.Equal(t, "session-1", resp.Name)
+
+	retrieved, err := sessionStore.GetByID("utena-session-1")
+	require.NoError(t, err)
+	require.Equal(t, "utena-session-1", retrieved.ID)
 	require.Equal(t, "ws-1", retrieved.WorkspaceID)
+}
+
+func TestSessionRouter_CreateSession_WithName(t *testing.T) {
+	router, sessionStore, _ := setupSessionRouter(t)
+
+	body := []byte(`{"name":"main","workspace_id":"ws-1"}`)
+
+	req := httptest.NewRequest("POST", "/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp SessionResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.Equal(t, "utena-main", resp.ID)
+	require.Equal(t, "main", resp.Name)
+
+	retrieved, err := sessionStore.GetByID("utena-main")
+	require.NoError(t, err)
+	require.Equal(t, "main", retrieved.Name)
+}
+
+func TestSessionRouter_CreateSession_ExistingBranch(t *testing.T) {
+	router, sessionStore, _ := setupSessionRouter(t)
+
+	body := []byte(`{"workspace_id":"ws-1","branch":"main","branch_created":false,"create_worktree":false}`)
+
+	req := httptest.NewRequest("POST", "/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp SessionResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.Equal(t, "utena-main", resp.ID)
+	require.Equal(t, "main", resp.Name)
+
+	retrieved, err := sessionStore.GetByID("utena-main")
+	require.NoError(t, err)
+	require.Equal(t, "main", retrieved.Name)
+	require.Equal(t, "main", retrieved.Branch)
 }
 
 func TestSessionRouter_CreateSession_InvalidWorkspace(t *testing.T) {
 	router, _, _ := setupSessionRouter(t)
 
-	// Create request body with invalid workspace
-	session := &Session{
-		ID:          "session-1",
-		WorkspaceID: "nonexistent",
-		LastUsedAt:  time.Now(),
-	}
-	body, err := json.Marshal(session)
-	require.NoError(t, err)
+	body := []byte(`{"name":"session-1","workspace_id":"nonexistent"}`)
 
-	// Create request
 	req := httptest.NewRequest("POST", "/", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
-	// Execute
 	router.Routes().ServeHTTP(w, req)
 
-	// Assert - should return error
 	require.NotEqual(t, http.StatusCreated, w.Code)
 }
 

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -108,7 +108,7 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, cr
 
 		if pullBranch != "" {
 			if err := s.gitService.Pull(ctx, ws.Path, pullBranch); err != nil {
-				slog.Warn("git pull failed, continuing with worktree creation", "error", err)
+				return fmt.Errorf("failed to pull branch %q: %w", pullBranch, err)
 			}
 		}
 

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -72,7 +72,7 @@ func (s *SessionService) GetSession(ctx context.Context, id string) (*Session, e
 	return s.store.GetByID(id)
 }
 
-func (s *SessionService) CreateSession(ctx context.Context, session *Session) error {
+func (s *SessionService) CreateSession(ctx context.Context, session *Session, createWorktree bool) error {
 	var ws *workspace.Workspace
 	if session.WorkspaceID != "" {
 		var err error
@@ -82,16 +82,32 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session) er
 		}
 	}
 
-	if session.BaseBranch != "" && ws != nil && ws.IsGitRepo {
-		if err := s.gitService.Pull(ctx, ws.Path, session.BaseBranch); err != nil {
-			slog.Warn("git pull failed, continuing with worktree creation", "error", err)
+	if ws != nil && ws.IsGitRepo && createWorktree {
+		pullBranch := session.BaseBranch
+		if !session.BranchCreated && session.Branch != "" {
+			pullBranch = session.Branch
 		}
 
-		worktreePath, err := s.gitService.CreateWorktree(ctx, ws.Path, session.ID, session.BaseBranch)
-		if err != nil {
-			return fmt.Errorf("failed to create worktree: %w", err)
+		if pullBranch != "" {
+			if err := s.gitService.Pull(ctx, ws.Path, pullBranch); err != nil {
+				slog.Warn("git pull failed, continuing with worktree creation", "error", err)
+			}
 		}
-		session.WorktreePath = worktreePath
+
+		if session.BranchCreated {
+			worktreePath, err := s.gitService.CreateWorktree(ctx, ws.Path, session.ID, session.BaseBranch)
+			if err != nil {
+				return fmt.Errorf("failed to create worktree: %w", err)
+			}
+			session.WorktreePath = worktreePath
+			session.Branch = session.ID
+		} else if session.Branch != "" {
+			worktreePath, err := s.gitService.CheckoutWorktree(ctx, ws.Path, session.Branch)
+			if err != nil {
+				return fmt.Errorf("failed to checkout worktree: %w", err)
+			}
+			session.WorktreePath = worktreePath
+		}
 	}
 
 	if session.LastUsedAt.IsZero() {
@@ -192,7 +208,7 @@ func (s *SessionService) ReviveSession(ctx context.Context, name string) (*Reviv
 	return &ReviveResult{Session: session, WorkspacePath: workspacePath}, nil
 }
 
-func (s *SessionService) DeleteSession(ctx context.Context, id string) error {
+func (s *SessionService) DeleteSession(ctx context.Context, id string, deleteBranch bool) error {
 	session, err := s.store.GetByID(id)
 	if err != nil {
 		return err
@@ -204,18 +220,22 @@ func (s *SessionService) DeleteSession(ctx context.Context, id string) error {
 
 	cleanup := &Cleanup{}
 
-	if session.WorktreePath != "" && session.WorkspaceID != "" {
+	if session.WorkspaceID != "" {
 		ws, err := s.workspaceService.GetWorkspace(ctx, session.WorkspaceID)
 		if err == nil {
-			if rmErr := s.gitService.RemoveWorktree(ctx, ws.Path, session.WorktreePath); rmErr != nil {
-				slog.Warn("failed to remove worktree", "error", rmErr)
-			} else {
-				cleanup.WorktreeRemoved = true
+			if session.WorktreePath != "" {
+				if rmErr := s.gitService.RemoveWorktree(ctx, ws.Path, session.WorktreePath); rmErr != nil {
+					slog.Warn("failed to remove worktree", "error", rmErr)
+				} else {
+					cleanup.WorktreeRemoved = true
+				}
 			}
-			if brErr := s.gitService.DeleteBranch(ctx, ws.Path, id); brErr != nil {
-				slog.Warn("failed to delete branch", "error", brErr)
-			} else {
-				cleanup.BranchDeleted = true
+			if deleteBranch && session.Branch != "" {
+				if brErr := s.gitService.DeleteBranch(ctx, ws.Path, session.Branch); brErr != nil {
+					slog.Warn("failed to delete branch", "error", brErr)
+				} else {
+					cleanup.BranchDeleted = true
+				}
 			}
 		} else {
 			slog.Warn("workspace not found during cleanup, skipping worktree/branch removal", "workspace_id", session.WorkspaceID)

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -82,6 +82,24 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, cr
 		}
 	}
 
+	switch {
+	case session.Name != "":
+		if ws != nil {
+			session.ID = BuildSessionID(ws.Name, session.Name)
+		} else {
+			session.ID = session.Name
+		}
+	case session.Branch != "":
+		session.Name = sanitizeBranchName(session.Branch)
+		if ws != nil {
+			session.ID = BuildSessionID(ws.Name, session.Name)
+		} else {
+			session.ID = session.Name
+		}
+	default:
+		return fmt.Errorf("session name or branch is required")
+	}
+
 	if ws != nil && ws.IsGitRepo && createWorktree {
 		pullBranch := session.BaseBranch
 		if !session.BranchCreated && session.Branch != "" {

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -57,8 +57,8 @@ func TestSessionService_ListSessions(t *testing.T) {
 
 	// Add test sessions
 	now := time.Now()
-	session1 := &Session{ID: "session-1", WorkspaceID: "ws-1", LastUsedAt: now.Add(-1 * time.Hour)}
-	session2 := &Session{ID: "session-2", WorkspaceID: "ws-2", LastUsedAt: now}
+	session1 := &Session{ID: "session-1", Name: "session-1", WorkspaceID: "ws-1", LastUsedAt: now.Add(-1 * time.Hour)}
+	session2 := &Session{ID: "session-2", Name: "session-2", WorkspaceID: "ws-2", LastUsedAt: now}
 	sessionStore.Add(session1)
 	sessionStore.Add(session2)
 
@@ -76,9 +76,9 @@ func TestSessionService_ListSessionsByWorkspace(t *testing.T) {
 
 	// Add test sessions
 	now := time.Now()
-	session1 := &Session{ID: "session-1", WorkspaceID: "ws-1", LastUsedAt: now.Add(-1 * time.Hour)}
-	session2 := &Session{ID: "session-2", WorkspaceID: "ws-2", LastUsedAt: now}
-	session3 := &Session{ID: "session-3", WorkspaceID: "ws-1", LastUsedAt: now}
+	session1 := &Session{ID: "session-1", Name: "session-1", WorkspaceID: "ws-1", LastUsedAt: now.Add(-1 * time.Hour)}
+	session2 := &Session{ID: "session-2", Name: "session-2", WorkspaceID: "ws-2", LastUsedAt: now}
+	session3 := &Session{ID: "session-3", Name: "session-3", WorkspaceID: "ws-1", LastUsedAt: now}
 	sessionStore.Add(session1)
 	sessionStore.Add(session2)
 	sessionStore.Add(session3)
@@ -111,6 +111,7 @@ func TestSessionService_GetSession(t *testing.T) {
 
 	session := &Session{
 		ID:          "session-1",
+		Name:        "session-1",
 		WorkspaceID: "ws-1",
 		IsAttached:  true,
 		IsActive:    true,
@@ -140,6 +141,7 @@ func TestSessionService_CreateSession(t *testing.T) {
 
 	session := &Session{
 		ID:          "session-1",
+		Name:        "session-1",
 		WorkspaceID: "ws-1",
 		IsAttached:  true,
 		IsActive:    true,
@@ -149,10 +151,11 @@ func TestSessionService_CreateSession(t *testing.T) {
 	err := service.CreateSession(ctx, session, false)
 	require.NoError(t, err)
 
-	// Verify session was created
-	retrieved, err := sessionStore.GetByID("session-1")
+	// Name is set and workspace exists, so ID is computed as {workspace}-{name}
+	require.Equal(t, "utena-session-1", session.ID)
+	retrieved, err := sessionStore.GetByID("utena-session-1")
 	require.NoError(t, err)
-	require.Equal(t, session.ID, retrieved.ID)
+	require.Equal(t, "session-1", retrieved.Name)
 
 	// Verify LastUsedAt was set
 	require.False(t, retrieved.LastUsedAt.IsZero())
@@ -163,6 +166,7 @@ func TestSessionService_CreateSession_InvalidWorkspace(t *testing.T) {
 
 	session := &Session{
 		ID:          "session-1",
+		Name:        "session-1",
 		WorkspaceID: "nonexistent",
 		LastUsedAt:  time.Now(),
 	}
@@ -178,6 +182,7 @@ func TestSessionService_UpdateSession(t *testing.T) {
 
 	session := &Session{
 		ID:          "session-1",
+		Name:        "session-1",
 		WorkspaceID: "ws-1",
 		IsAttached:  false,
 		IsActive:    true,
@@ -202,6 +207,7 @@ func TestSessionService_UpdateSession_InvalidWorkspace(t *testing.T) {
 
 	session := &Session{
 		ID:          "session-1",
+		Name:        "session-1",
 		WorkspaceID: "ws-1",
 		LastUsedAt:  time.Now(),
 	}
@@ -220,6 +226,7 @@ func TestSessionService_DeleteSession(t *testing.T) {
 
 	session := &Session{
 		ID:          "session-1",
+		Name:        "session-1",
 		WorkspaceID: "ws-1",
 		LastUsedAt:  time.Now(),
 	}
@@ -275,7 +282,7 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 	service := NewSessionService(sessionStore, workspaceService, gitService, bus)
 
 	session := &Session{
-		ID:            "my-feature",
+		Name:          "my-feature",
 		WorkspaceID:   "ws-git",
 		BaseBranch:    "main",
 		BranchCreated: true,
@@ -285,14 +292,15 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 	err := service.CreateSession(ctx, session, true)
 	require.NoError(t, err)
 
-	expectedPath := filepath.Join(repoPath, ".worktrees", "my-feature")
+	require.Equal(t, "git-repo-my-feature", session.ID)
+	expectedPath := filepath.Join(repoPath, ".worktrees", "git-repo-my-feature")
 	require.Equal(t, expectedPath, session.WorktreePath)
 
 	info, err := os.Stat(expectedPath)
 	require.NoError(t, err)
 	require.True(t, info.IsDir())
 
-	retrieved, err := sessionStore.GetByID("my-feature")
+	retrieved, err := sessionStore.GetByID("git-repo-my-feature")
 	require.NoError(t, err)
 	require.Equal(t, expectedPath, retrieved.WorktreePath)
 	require.Equal(t, "main", retrieved.BaseBranch)
@@ -311,7 +319,7 @@ func TestSessionService_CreateSession_WithWorktree_InvalidBranch(t *testing.T) {
 	service := NewSessionService(sessionStore, workspaceService, gitService, bus)
 
 	session := &Session{
-		ID:            "my-feature",
+		Name:          "my-feature",
 		WorkspaceID:   "ws-git",
 		BaseBranch:    "nonexistent",
 		BranchCreated: true,
@@ -322,15 +330,54 @@ func TestSessionService_CreateSession_WithWorktree_InvalidBranch(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to create worktree")
 
-	_, err = sessionStore.GetByID("my-feature")
+	_, err = sessionStore.GetByID("git-repo-my-feature")
 	require.Error(t, err)
+}
+
+func TestSessionService_CreateSession_WithName_ComputesID(t *testing.T) {
+	service, sessionStore, _ := setupSessionService(t)
+
+	session := &Session{
+		Name:        "main",
+		WorkspaceID: "ws-1",
+	}
+
+	ctx := context.Background()
+	err := service.CreateSession(ctx, session, false)
+	require.NoError(t, err)
+
+	require.Equal(t, "utena-main", session.ID)
+	require.Equal(t, "main", session.Name)
+
+	retrieved, err := sessionStore.GetByID("utena-main")
+	require.NoError(t, err)
+	require.Equal(t, "main", retrieved.Name)
+	require.Equal(t, "utena-main", retrieved.ID)
+}
+
+func TestSessionService_CreateSession_WithName_NoWorkspace(t *testing.T) {
+	service, sessionStore, _ := setupSessionService(t)
+
+	session := &Session{
+		Name: "standalone",
+	}
+
+	ctx := context.Background()
+	err := service.CreateSession(ctx, session, false)
+	require.NoError(t, err)
+
+	require.Equal(t, "standalone", session.ID)
+
+	retrieved, err := sessionStore.GetByID("standalone")
+	require.NoError(t, err)
+	require.Equal(t, "standalone", retrieved.Name)
 }
 
 func TestSessionService_CreateSession_NoBranch_SkipsWorktree(t *testing.T) {
 	service, sessionStore, _ := setupSessionService(t)
 
 	session := &Session{
-		ID:          "my-session",
+		Name:        "my-session",
 		WorkspaceID: "ws-1",
 	}
 
@@ -339,7 +386,7 @@ func TestSessionService_CreateSession_NoBranch_SkipsWorktree(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, session.WorktreePath)
 
-	retrieved, err := sessionStore.GetByID("my-session")
+	retrieved, err := sessionStore.GetByID("utena-my-session")
 	require.NoError(t, err)
 	require.Empty(t, retrieved.WorktreePath)
 }
@@ -355,7 +402,7 @@ func TestSessionService_CreateSession_NonGitWorkspace_SkipsWorktree(t *testing.T
 	service := NewSessionService(sessionStore, workspaceService, gitService, bus)
 
 	session := &Session{
-		ID:          "my-session",
+		Name:        "my-session",
 		WorkspaceID: "ws-nogit",
 		BaseBranch:  "main",
 	}
@@ -363,6 +410,7 @@ func TestSessionService_CreateSession_NonGitWorkspace_SkipsWorktree(t *testing.T
 	ctx := context.Background()
 	err := service.CreateSession(ctx, session, false)
 	require.NoError(t, err)
+	require.Equal(t, "plain-my-session", session.ID)
 	require.Empty(t, session.WorktreePath)
 }
 
@@ -371,6 +419,7 @@ func TestSessionService_CreateSession_TouchesWorkspace(t *testing.T) {
 
 	session := &Session{
 		ID:          "session-1",
+		Name:        "session-1",
 		WorkspaceID: "ws-1",
 	}
 
@@ -388,6 +437,7 @@ func TestSessionService_ActivateSession_TouchesWorkspace(t *testing.T) {
 
 	session := &Session{
 		ID:          "session-1",
+		Name:        "session-1",
 		WorkspaceID: "ws-1",
 		LastUsedAt:  time.Now().Add(-1 * time.Hour),
 	}

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -146,7 +146,7 @@ func TestSessionService_CreateSession(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	err := service.CreateSession(ctx, session)
+	err := service.CreateSession(ctx, session, false)
 	require.NoError(t, err)
 
 	// Verify session was created
@@ -168,7 +168,7 @@ func TestSessionService_CreateSession_InvalidWorkspace(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	err := service.CreateSession(ctx, session)
+	err := service.CreateSession(ctx, session, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not found")
 }
@@ -226,7 +226,7 @@ func TestSessionService_DeleteSession(t *testing.T) {
 	sessionStore.Add(session)
 
 	ctx := context.Background()
-	err := service.DeleteSession(ctx, "session-1")
+	err := service.DeleteSession(ctx, "session-1", true)
 	require.NoError(t, err)
 
 	retrieved, err := sessionStore.GetByID("session-1")
@@ -239,7 +239,7 @@ func TestSessionService_DeleteSession_NotFound(t *testing.T) {
 	service, _, _ := setupSessionService(t)
 
 	ctx := context.Background()
-	err := service.DeleteSession(ctx, "nonexistent")
+	err := service.DeleteSession(ctx, "nonexistent", true)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not found")
 }
@@ -275,13 +275,14 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 	service := NewSessionService(sessionStore, workspaceService, gitService, bus)
 
 	session := &Session{
-		ID:          "my-feature",
-		WorkspaceID: "ws-git",
-		BaseBranch:  "main",
+		ID:            "my-feature",
+		WorkspaceID:   "ws-git",
+		BaseBranch:    "main",
+		BranchCreated: true,
 	}
 
 	ctx := context.Background()
-	err := service.CreateSession(ctx, session)
+	err := service.CreateSession(ctx, session, true)
 	require.NoError(t, err)
 
 	expectedPath := filepath.Join(repoPath, ".worktrees", "my-feature")
@@ -310,13 +311,14 @@ func TestSessionService_CreateSession_WithWorktree_InvalidBranch(t *testing.T) {
 	service := NewSessionService(sessionStore, workspaceService, gitService, bus)
 
 	session := &Session{
-		ID:          "my-feature",
-		WorkspaceID: "ws-git",
-		BaseBranch:  "nonexistent",
+		ID:            "my-feature",
+		WorkspaceID:   "ws-git",
+		BaseBranch:    "nonexistent",
+		BranchCreated: true,
 	}
 
 	ctx := context.Background()
-	err := service.CreateSession(ctx, session)
+	err := service.CreateSession(ctx, session, true)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to create worktree")
 
@@ -333,7 +335,7 @@ func TestSessionService_CreateSession_NoBranch_SkipsWorktree(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	err := service.CreateSession(ctx, session)
+	err := service.CreateSession(ctx, session, false)
 	require.NoError(t, err)
 	require.Empty(t, session.WorktreePath)
 
@@ -359,7 +361,7 @@ func TestSessionService_CreateSession_NonGitWorkspace_SkipsWorktree(t *testing.T
 	}
 
 	ctx := context.Background()
-	err := service.CreateSession(ctx, session)
+	err := service.CreateSession(ctx, session, false)
 	require.NoError(t, err)
 	require.Empty(t, session.WorktreePath)
 }
@@ -373,7 +375,7 @@ func TestSessionService_CreateSession_TouchesWorkspace(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	err := service.CreateSession(ctx, session)
+	err := service.CreateSession(ctx, session, false)
 	require.NoError(t, err)
 
 	ws, err := workspaceStore.GetByID("ws-1")

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -253,12 +253,26 @@ func TestSessionService_DeleteSession_NotFound(t *testing.T) {
 
 func initTestRepo(t *testing.T) string {
 	t.Helper()
+	bareDir := t.TempDir()
 	dir := t.TempDir()
+
+	bareCmds := [][]string{
+		{"git", "init", "--bare"},
+	}
+	for _, args := range bareCmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = bareDir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "command %v failed: %s", args, string(out))
+	}
+
 	cmds := [][]string{
 		{"git", "init"},
 		{"git", "config", "user.email", "test@test.com"},
 		{"git", "config", "user.name", "Test"},
+		{"git", "remote", "add", "origin", bareDir},
 		{"git", "commit", "--allow-empty", "-m", "init"},
+		{"git", "push", "-u", "origin", "HEAD"},
 	}
 	for _, args := range cmds {
 		cmd := exec.Command(args[0], args[1:]...)
@@ -328,7 +342,7 @@ func TestSessionService_CreateSession_WithWorktree_InvalidBranch(t *testing.T) {
 	ctx := context.Background()
 	err := service.CreateSession(ctx, session, true)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to create worktree")
+	require.Contains(t, err.Error(), "failed to pull branch")
 
 	_, err = sessionStore.GetByID("git-repo-my-feature")
 	require.Error(t, err)

--- a/internal/session/sessionstore.go
+++ b/internal/session/sessionstore.go
@@ -164,6 +164,12 @@ func (s *SessionStore) OnAppStart(ctx context.Context) error {
 	defer s.mu.Unlock()
 	s.sessions = loaded
 
+	for _, session := range s.sessions {
+		if session.Name == "" {
+			session.Name = session.ID
+		}
+	}
+
 	return nil
 }
 

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -56,24 +56,22 @@ func RenderSessionList(sessions []Session) []render.Renderer {
 }
 
 type CreateSessionRequest struct {
-	*Session
-	CreateWorktree *bool `json:"create_worktree,omitempty"`
+	Name           string `json:"name,omitempty"`
+	WorkspaceID    string `json:"workspace_id"`
+	Branch         string `json:"branch,omitempty"`
+	BaseBranch     string `json:"base_branch,omitempty"`
+	BranchCreated  bool   `json:"branch_created"`
+	CreateWorktree bool   `json:"create_worktree"`
 }
 
 func (c *CreateSessionRequest) Bind(r *http.Request) error {
-
-	if c.Session == nil {
-		return errors.New("session cannot be nil")
+	if c.WorkspaceID == "" {
+		return errors.New("workspace_id is required")
 	}
-
-	return ValidateSession(c.Session)
-}
-
-func (c *CreateSessionRequest) ShouldCreateWorktree() bool {
-	if c.CreateWorktree == nil {
-		return true
+	if c.Name != "" {
+		return ValidateSessionName(c.Name)
 	}
-	return *c.CreateWorktree
+	return nil
 }
 
 type UpdateSessionRequest struct {

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -57,6 +57,7 @@ func RenderSessionList(sessions []Session) []render.Renderer {
 
 type CreateSessionRequest struct {
 	*Session
+	CreateWorktree *bool `json:"create_worktree,omitempty"`
 }
 
 func (c *CreateSessionRequest) Bind(r *http.Request) error {
@@ -66,6 +67,13 @@ func (c *CreateSessionRequest) Bind(r *http.Request) error {
 	}
 
 	return ValidateSession(c.Session)
+}
+
+func (c *CreateSessionRequest) ShouldCreateWorktree() bool {
+	if c.CreateWorktree == nil {
+		return true
+	}
+	return *c.CreateWorktree
 }
 
 type UpdateSessionRequest struct {

--- a/internal/session/validation.go
+++ b/internal/session/validation.go
@@ -28,11 +28,6 @@ func ValidateSession(session *Session) error {
 	if session == nil {
 		return errors.New("session cannot be nil")
 	}
-
-	if err := ValidateSessionName(session.ID); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/internal/session/validation_test.go
+++ b/internal/session/validation_test.go
@@ -30,26 +30,8 @@ func TestValidateSession(t *testing.T) {
 			errorMsg:    "cannot be nil",
 		},
 		{
-			name: "empty ID",
+			name: "empty fields allowed",
 			session: &Session{
-				WorkspaceID: "ws-1",
-				LastUsedAt:  time.Now(),
-			},
-			expectError: true,
-			errorMsg:    "session name cannot be empty",
-		},
-		{
-			name: "empty WorkspaceID",
-			session: &Session{
-				ID:         "session-1",
-				LastUsedAt: time.Now(),
-			},
-			expectError: false,
-		},
-		{
-			name: "zero LastUsedAt is allowed",
-			session: &Session{
-				ID:          "session-1",
 				WorkspaceID: "ws-1",
 			},
 			expectError: false,

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -115,7 +115,8 @@ func (c *client) fetchWorkspaces() tea.Cmd {
 }
 
 type branchListResponse struct {
-	Branches []string `json:"branches"`
+	Branches      []string `json:"branches"`
+	CurrentBranch string   `json:"current_branch"`
 }
 
 func (c *client) fetchBranches(workspaceID string) tea.Cmd {
@@ -196,7 +197,7 @@ func (c *client) reviveSession(name string) tea.Cmd {
 
 func (c *client) createSession(name, workspaceID, baseBranch string) tea.Cmd {
 	return func() tea.Msg {
-		body := map[string]string{
+		body := map[string]interface{}{
 			"id":           name,
 			"workspace_id": workspaceID,
 		}

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -198,8 +198,10 @@ func (c *client) reviveSession(name string) tea.Cmd {
 func (c *client) createSession(name, workspaceID, baseBranch string) tea.Cmd {
 	return func() tea.Msg {
 		body := map[string]interface{}{
-			"id":           name,
 			"workspace_id": workspaceID,
+		}
+		if name != "" {
+			body["name"] = name
 		}
 		if baseBranch != "" {
 			body["base_branch"] = baseBranch
@@ -221,11 +223,12 @@ func (c *client) createSession(name, workspaceID, baseBranch string) tea.Cmd {
 		}
 
 		var resp struct {
+			ID           string `json:"id"`
 			WorktreePath string `json:"worktree_path"`
 		}
 		json.NewDecoder(res.Body).Decode(&resp)
 
-		return sessionCreatedMsg{worktreePath: resp.WorktreePath}
+		return sessionCreatedMsg{id: resp.ID, worktreePath: resp.WorktreePath}
 	}
 }
 

--- a/internal/tui/provider/sessionsprovider.go
+++ b/internal/tui/provider/sessionsprovider.go
@@ -85,6 +85,7 @@ type sessionActivatedMsg struct {
 }
 
 type sessionCreatedMsg struct {
+	id           string
 	worktreePath string
 }
 
@@ -206,17 +207,18 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 			if !ok {
 				return ErrMsg{Err: fmt.Errorf("unexpected result from createSession")}
 			}
+			sessionID := created.id
 			wp := workspacePath
 			if created.worktreePath != "" {
 				wp = created.worktreePath
 			}
 
-			activateResult := p.client.activateSession(name)()
+			activateResult := p.client.activateSession(sessionID)()
 			if err, ok := activateResult.(ErrMsg); ok {
 				return err
 			}
 			return sessionActivatedMsg{
-				name:          name,
+				name:          sessionID,
 				pipeCommand:   "create_session",
 				workspacePath: wp,
 			}

--- a/internal/tui/sessionlist/sessionitem.go
+++ b/internal/tui/sessionlist/sessionitem.go
@@ -13,8 +13,15 @@ type sessionItem struct {
 	claudeStatus string
 }
 
+func (i sessionItem) displayName() string {
+	if i.session.Name != "" {
+		return i.session.Name
+	}
+	return i.session.ID
+}
+
 func (i sessionItem) Title() string {
-	title := i.session.ID
+	title := i.displayName()
 	if i.session.IsDead {
 		title += " (dead)"
 	} else if i.session.IsAttached {
@@ -37,7 +44,7 @@ func (i sessionItem) Description() string {
 	return name
 }
 
-func (i sessionItem) FilterValue() string { return i.session.ID }
+func (i sessionItem) FilterValue() string { return i.displayName() }
 
 func aggregateClaudeStatus(sessions []claude.ClaudeSession) string {
 	if len(sessions) == 0 {

--- a/internal/workspace/types.go
+++ b/internal/workspace/types.go
@@ -55,5 +55,6 @@ func (a *AddWorkspaceRequest) Bind(r *http.Request) error {
 }
 
 type BranchListResponse struct {
-	Branches []string `json:"branches"`
+	Branches      []string `json:"branches"`
+	CurrentBranch string   `json:"current_branch"`
 }

--- a/internal/workspace/workspacecontroller.go
+++ b/internal/workspace/workspacecontroller.go
@@ -94,5 +94,10 @@ func (c *WorkspaceController) ListBranches(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	render.JSON(w, r, BranchListResponse{Branches: branches})
+	currentBranch, err := c.gitService.CurrentBranch(ctx, ws.Path)
+	if err != nil {
+		currentBranch = ""
+	}
+
+	render.JSON(w, r, BranchListResponse{Branches: branches, CurrentBranch: currentBranch})
 }

--- a/internal/zellij/zellijservice.go
+++ b/internal/zellij/zellijservice.go
@@ -83,6 +83,7 @@ func (z *ZellijService) ProcessSessionUpdate(ctx context.Context, req *UpdateSes
 		attached := sessionUpdate.ConnectedClients > 0
 		newSession := &session.Session{
 			ID:         sessionID,
+			Name:       sessionID,
 			IsAttached: attached,
 			IsActive:   true,
 			IsDead:     false,

--- a/internal/zellij/zellijservice.go
+++ b/internal/zellij/zellijservice.go
@@ -91,7 +91,7 @@ func (z *ZellijService) ProcessSessionUpdate(ctx context.Context, req *UpdateSes
 			newSession.LastUsedAt = time.Now()
 		}
 
-		if err := z.sessionService.CreateSession(ctx, newSession); err != nil {
+		if err := z.sessionService.CreateSession(ctx, newSession, false); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

- Add `Name` field to sessions for user-visible display (e.g., `main`) while `ID` is workspace-prefixed for global uniqueness (e.g., `utena-main`)
- Replace embedded `*Session` in `CreateSessionRequest` with a clean struct containing only client-relevant fields: `name`, `workspace_id`, `branch`, `base_branch`, `branch_created`, `create_worktree`
- Server computes `Name` and `ID` from the request — deriving name from branch for existing branches, or using the provided name for new ones
- Add `BuildSessionID(workspaceName, name)` helper and `sanitizeBranchName` for ID computation
- Update TUI session list to display `Name` with `ID` fallback, and use server-returned `ID` for activation/pipe commands
- Add git pull before worktree creation, worktree checkout for existing branches, and branch cleanup on session deletion

## Test plan

- [x] All existing tests updated and passing
- [ ] Create session with new branch → verify workspace-prefixed ID (e.g., `utena-feature-x`)
- [ ] Create session from existing branch → verify name derived from branch
- [ ] Verify Zellij session names match computed IDs
- [ ] Verify session list displays short names, not full IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)