### PR TITLE
feat(claude): add ready-for-review status

### DIFF
--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -41,7 +41,7 @@ func newApp(fs afero.Fs, cfg Config) *App {
 		Workspace: workspaceModule,
 		Session:   sessionModule,
 		Zellij:    zellij.NewZellijModule(sessionModule, bus),
-		Claude:    claude.NewClaudeModule(fs, cfg.ConfigDir),
+		Claude:    claude.NewClaudeModule(bus, fs, cfg.ConfigDir),
 		Todo:      todo.NewTodoModule(workspaceModule, fs, cfg.ConfigDir),
 	}
 }

--- a/internal/claude/claudemodule.go
+++ b/internal/claude/claudemodule.go
@@ -3,6 +3,7 @@ package claude
 import (
 	"context"
 
+	"github.com/eleonorayaya/utena/internal/eventbus"
 	"github.com/go-chi/chi/v5"
 	"github.com/spf13/afero"
 )
@@ -14,9 +15,9 @@ type ClaudeModule struct {
 	Router     *ClaudeRouter
 }
 
-func NewClaudeModule(fs afero.Fs, configDir string) *ClaudeModule {
+func NewClaudeModule(bus eventbus.EventBus, fs afero.Fs, configDir string) *ClaudeModule {
 	store := NewClaudeStore(fs, configDir)
-	service := NewClaudeService(store)
+	service := NewClaudeService(store, bus)
 	controller := NewClaudeController(service)
 	router := NewClaudeRouter(controller)
 

--- a/internal/claude/claudeservice.go
+++ b/internal/claude/claudeservice.go
@@ -2,21 +2,37 @@ package claude
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
+
+	"github.com/eleonorayaya/utena/internal/eventbus"
 )
 
 type ClaudeService struct {
-	store *ClaudeStore
+	store    *ClaudeStore
+	eventBus eventbus.EventBus
 }
 
-func NewClaudeService(store *ClaudeStore) *ClaudeService {
+func NewClaudeService(store *ClaudeStore, bus eventbus.EventBus) *ClaudeService {
 	return &ClaudeService{
-		store: store,
+		store:    store,
+		eventBus: bus,
 	}
 }
 
 func (s *ClaudeService) OnAppStart(ctx context.Context) error {
+	s.eventBus.Subscribe(eventbus.SessionActivated, s.handleSessionActivated)
+	return nil
+}
+
+func (s *ClaudeService) handleSessionActivated(ctx context.Context, event eventbus.Event) error {
+	data, ok := event.Data.(eventbus.SessionActivatedEvent)
+	if !ok {
+		return fmt.Errorf("unexpected event data type: %T", event.Data)
+	}
+
+	s.store.UpdateStatusBySessionID(data.SessionName, StatusReadyForReview, StatusCompleted)
 	return nil
 }
 
@@ -30,7 +46,7 @@ func (s *ClaudeService) HandleHookEvent(ctx context.Context, req *HookEventReque
 		return s.upsertWithStatus(req, StatusWorking)
 
 	case "Stop":
-		return s.upsertWithStatus(req, StatusCompleted)
+		return s.upsertWithStatus(req, StatusReadyForReview)
 
 	case "Notification":
 		if req.NotificationType == "permission_prompt" {
@@ -39,7 +55,7 @@ func (s *ClaudeService) HandleHookEvent(ctx context.Context, req *HookEventReque
 		return nil
 
 	case "TaskCompleted":
-		return s.upsertWithStatus(req, StatusCompleted)
+		return s.upsertWithStatus(req, StatusReadyForReview)
 
 	case "SessionEnd":
 		err := s.store.Delete(req.ClaudeSessionID)

--- a/internal/claude/claudesession.go
+++ b/internal/claude/claudesession.go
@@ -12,6 +12,7 @@ type ClaudeSessionStatus string
 const (
 	StatusWorking        ClaudeSessionStatus = "working"
 	StatusNeedsAttention ClaudeSessionStatus = "needs_attention"
+	StatusReadyForReview ClaudeSessionStatus = "ready_for_review"
 	StatusCompleted      ClaudeSessionStatus = "completed"
 )
 

--- a/internal/claude/claudestore.go
+++ b/internal/claude/claudestore.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/spf13/afero"
 )
@@ -89,6 +90,24 @@ func (s *ClaudeStore) Upsert(session *ClaudeSession) error {
 	s.sessions[session.ID] = &copy
 	s.save()
 	return nil
+}
+
+func (s *ClaudeStore) UpdateStatusBySessionID(sessionID string, from, to ClaudeSessionStatus) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	changed := false
+	for _, session := range s.sessions {
+		if session.SessionID == sessionID && session.Status == from {
+			session.Status = to
+			session.LastUpdatedAt = time.Now()
+			changed = true
+		}
+	}
+
+	if changed {
+		s.save()
+	}
 }
 
 func (s *ClaudeStore) Delete(id string) error {

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -162,6 +162,11 @@ func (s *SessionService) ActivateSession(ctx context.Context, name string) (*Ses
 		s.workspaceService.Touch(ctx, session.WorkspaceID)
 	}
 
+	s.eventBus.Publish(ctx, eventbus.Event{
+		Type: eventbus.SessionActivated,
+		Data: eventbus.SessionActivatedEvent{SessionName: name},
+	})
+
 	return session, nil
 }
 

--- a/internal/tui/sessionlist/sessionitem.go
+++ b/internal/tui/sessionlist/sessionitem.go
@@ -45,11 +45,14 @@ func aggregateClaudeStatus(sessions []claude.ClaudeSession) string {
 	}
 
 	hasNeedsAttention := false
+	hasReadyForReview := false
 	hasWorking := false
 	for _, cs := range sessions {
 		switch cs.Status {
 		case claude.StatusNeedsAttention:
 			hasNeedsAttention = true
+		case claude.StatusReadyForReview:
+			hasReadyForReview = true
 		case claude.StatusWorking:
 			hasWorking = true
 		}
@@ -60,6 +63,9 @@ func aggregateClaudeStatus(sessions []claude.ClaudeSession) string {
 	}
 	if hasWorking {
 		return "[working]"
+	}
+	if hasReadyForReview {
+		return "[ready for review]"
 	}
 	return "[done]"
 }


### PR DESCRIPTION
## Summary
- Adds `ready_for_review` status to `ClaudeSessionStatus`, creating the lifecycle: `working → ready_for_review → completed`
- When Claude finishes work (`Stop`/`TaskCompleted` hook events), sessions are marked `ready_for_review` instead of `completed`
- When the user activates a session, a `SessionActivated` event transitions all `ready_for_review` claude sessions to `completed`
- TUI displays `[ready for review]` in the session list (priority between `[working]` and `[done]`)

## Test plan
- [x] `task daemon:build` and `task tui:build` compile cleanly
- [x] `task test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)