### PR TITLE
Add configurable branch prefix for worktree branches

### DIFF
--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -35,7 +35,7 @@ func newApp(fs afero.Fs, cfg Config) *App {
 	bus := eventbus.NewEventBus()
 
 	workspaceModule := workspace.NewWorkspaceModule(fs, cfg.ConfigDir)
-	sessionModule := session.NewSessionModule(workspaceModule, bus, fs, cfg.ConfigDir)
+	sessionModule := session.NewSessionModule(workspaceModule, bus, fs, cfg.ConfigDir, cfg.BranchPrefix)
 
 	return &App{
 		Workspace: workspaceModule,

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Config struct {
-	Port       int
-	ConfigDir  string
-	PrettyLogs bool
+	Port         int
+	ConfigDir    string
+	PrettyLogs   bool
+	BranchPrefix string
 }
 
 func LoadConfig(args []string) (Config, error) {
@@ -26,6 +27,7 @@ func LoadConfig(args []string) (Config, error) {
 	fs.IntVar(&cfg.Port, "port", 3333, "port to listen on")
 	fs.StringVar(&cfg.ConfigDir, "config-dir", defaultConfigDir, "path to config directory")
 	fs.BoolVar(&cfg.PrettyLogs, "pretty-logs", false, "enable pretty log output")
+	fs.StringVar(&cfg.BranchPrefix, "branch-prefix", "eqt/", "prefix for git branches created with worktrees")
 
 	if err := fs.Parse(args); err != nil {
 		return Config{}, err
@@ -39,6 +41,9 @@ func LoadConfig(args []string) (Config, error) {
 	}
 	if os.Getenv("UTENA_LOG_PRETTY") == "true" {
 		cfg.PrettyLogs = true
+	}
+	if v := os.Getenv("UTENA_BRANCH_PREFIX"); v != "" {
+		cfg.BranchPrefix = v
 	}
 
 	return cfg, nil

--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -52,9 +52,9 @@ func (s *GitService) Pull(ctx context.Context, repoPath string, branch string) e
 	return nil
 }
 
-func (s *GitService) CreateWorktree(ctx context.Context, repoPath string, name string, baseBranch string) (string, error) {
+func (s *GitService) CreateWorktree(ctx context.Context, repoPath string, name string, branchName string, baseBranch string) (string, error) {
 	worktreePath := filepath.Join(repoPath, ".worktrees", name)
-	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "worktree", "add", "-b", name, worktreePath, baseBranch)
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "worktree", "add", "-b", branchName, worktreePath, baseBranch)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("git worktree add failed: %s: %w", string(output), err)
 	}

--- a/internal/git/gitservice_test.go
+++ b/internal/git/gitservice_test.go
@@ -97,7 +97,7 @@ func TestGitService_CreateWorktree(t *testing.T) {
 	repo := initTestRepo(t)
 
 	svc := NewGitService()
-	worktreePath, err := svc.CreateWorktree(context.Background(), repo, "my-feature", "main")
+	worktreePath, err := svc.CreateWorktree(context.Background(), repo, "my-feature", "eqt/my-feature", "main")
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(repo, ".worktrees", "my-feature"), worktreePath)
 
@@ -107,17 +107,17 @@ func TestGitService_CreateWorktree(t *testing.T) {
 
 	branchOut, err := exec.Command("git", "-C", worktreePath, "branch", "--show-current").Output()
 	require.NoError(t, err)
-	require.Equal(t, "my-feature", trimOutput(branchOut))
+	require.Equal(t, "eqt/my-feature", trimOutput(branchOut))
 }
 
 func TestGitService_CreateWorktree_DuplicateName(t *testing.T) {
 	repo := initTestRepo(t)
 
 	svc := NewGitService()
-	_, err := svc.CreateWorktree(context.Background(), repo, "my-feature", "main")
+	_, err := svc.CreateWorktree(context.Background(), repo, "my-feature", "eqt/my-feature", "main")
 	require.NoError(t, err)
 
-	_, err = svc.CreateWorktree(context.Background(), repo, "my-feature", "main")
+	_, err = svc.CreateWorktree(context.Background(), repo, "my-feature", "eqt/my-feature", "main")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "git worktree add failed")
 }
@@ -126,7 +126,7 @@ func TestGitService_CreateWorktree_InvalidBaseBranch(t *testing.T) {
 	repo := initTestRepo(t)
 
 	svc := NewGitService()
-	_, err := svc.CreateWorktree(context.Background(), repo, "my-feature", "nonexistent")
+	_, err := svc.CreateWorktree(context.Background(), repo, "my-feature", "eqt/my-feature", "nonexistent")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "git worktree add failed")
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -20,6 +20,7 @@ type Session struct {
 	Branch        string    `json:"branch,omitempty"`
 	BaseBranch    string    `json:"base_branch,omitempty"`
 	BranchCreated bool      `json:"branch_created,omitempty"`
+	BranchName    string    `json:"branch_name,omitempty"`
 	WorktreePath  string    `json:"worktree_path,omitempty"`
 	IsAttached    bool      `json:"is_attached"`
 	IsActive      bool      `json:"is_active"`

--- a/internal/session/sessionmodule.go
+++ b/internal/session/sessionmodule.go
@@ -16,9 +16,9 @@ type SessionModule struct {
 	Router     *SessionRouter
 }
 
-func NewSessionModule(workspaceModule *workspace.WorkspaceModule, bus eventbus.EventBus, fs afero.Fs, configDir string) *SessionModule {
+func NewSessionModule(workspaceModule *workspace.WorkspaceModule, bus eventbus.EventBus, fs afero.Fs, configDir string, branchPrefix string) *SessionModule {
 	store := NewSessionStore(fs, configDir)
-	service := NewSessionService(store, workspaceModule.Service, workspaceModule.GitService, bus)
+	service := NewSessionService(store, workspaceModule.Service, workspaceModule.GitService, bus, branchPrefix)
 	controller := NewSessionController(service)
 	router := NewSessionRouter(controller)
 

--- a/internal/session/sessionrouter_test.go
+++ b/internal/session/sessionrouter_test.go
@@ -27,7 +27,7 @@ func setupSessionRouter(t *testing.T) (*SessionRouter, *SessionStore, *workspace
 
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, bus)
+	service := NewSessionService(sessionStore, workspaceService, gitService, bus, "eqt/")
 	controller := NewSessionController(service)
 	router := NewSessionRouter(controller)
 

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -18,14 +18,16 @@ type SessionService struct {
 	workspaceService *workspace.WorkspaceService
 	gitService       *git.GitService
 	eventBus         eventbus.EventBus
+	branchPrefix     string
 }
 
-func NewSessionService(store *SessionStore, workspaceService *workspace.WorkspaceService, gitService *git.GitService, bus eventbus.EventBus) *SessionService {
+func NewSessionService(store *SessionStore, workspaceService *workspace.WorkspaceService, gitService *git.GitService, bus eventbus.EventBus, branchPrefix string) *SessionService {
 	return &SessionService{
 		store:            store,
 		workspaceService: workspaceService,
 		gitService:       gitService,
 		eventBus:         bus,
+		branchPrefix:     branchPrefix,
 	}
 }
 
@@ -113,12 +115,14 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, cr
 		}
 
 		if session.BranchCreated {
-			worktreePath, err := s.gitService.CreateWorktree(ctx, ws.Path, session.ID, session.BaseBranch)
+			branchName := s.branchPrefix + session.Name
+			worktreePath, err := s.gitService.CreateWorktree(ctx, ws.Path, session.ID, branchName, session.BaseBranch)
 			if err != nil {
 				return fmt.Errorf("failed to create worktree: %w", err)
 			}
 			session.WorktreePath = worktreePath
-			session.Branch = session.ID
+			session.BranchName = branchName
+			session.Branch = branchName
 		} else if session.Branch != "" {
 			worktreePath, err := s.gitService.CheckoutWorktree(ctx, ws.Path, session.Branch)
 			if err != nil {
@@ -253,11 +257,17 @@ func (s *SessionService) DeleteSession(ctx context.Context, id string, deleteBra
 					cleanup.WorktreeRemoved = true
 				}
 			}
-			if deleteBranch && session.Branch != "" {
-				if brErr := s.gitService.DeleteBranch(ctx, ws.Path, session.Branch); brErr != nil {
-					slog.Warn("failed to delete branch", "error", brErr)
-				} else {
-					cleanup.BranchDeleted = true
+			if deleteBranch {
+				branchToDelete := session.BranchName
+				if branchToDelete == "" {
+					branchToDelete = session.Branch
+				}
+				if branchToDelete != "" {
+					if brErr := s.gitService.DeleteBranch(ctx, ws.Path, branchToDelete); brErr != nil {
+						slog.Warn("failed to delete branch", "error", brErr)
+					} else {
+						cleanup.BranchDeleted = true
+					}
 				}
 			}
 		} else {

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -27,7 +27,7 @@ func setupSessionService(t *testing.T) (*SessionService, *SessionStore, *workspa
 
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, bus)
+	service := NewSessionService(sessionStore, workspaceService, gitService, bus, "eqt/")
 	return service, sessionStore, workspaceStore
 }
 
@@ -293,7 +293,7 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, bus)
+	service := NewSessionService(sessionStore, workspaceService, gitService, bus, "eqt/")
 
 	session := &Session{
 		Name:          "my-feature",
@@ -309,6 +309,7 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 	require.Equal(t, "git-repo-my-feature", session.ID)
 	expectedPath := filepath.Join(repoPath, ".worktrees", "git-repo-my-feature")
 	require.Equal(t, expectedPath, session.WorktreePath)
+	require.Equal(t, "eqt/my-feature", session.BranchName)
 
 	info, err := os.Stat(expectedPath)
 	require.NoError(t, err)
@@ -317,6 +318,7 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 	retrieved, err := sessionStore.GetByID("git-repo-my-feature")
 	require.NoError(t, err)
 	require.Equal(t, expectedPath, retrieved.WorktreePath)
+	require.Equal(t, "eqt/my-feature", retrieved.BranchName)
 	require.Equal(t, "main", retrieved.BaseBranch)
 }
 
@@ -330,7 +332,7 @@ func TestSessionService_CreateSession_WithWorktree_InvalidBranch(t *testing.T) {
 
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, bus)
+	service := NewSessionService(sessionStore, workspaceService, gitService, bus, "eqt/")
 
 	session := &Session{
 		Name:          "my-feature",
@@ -413,7 +415,7 @@ func TestSessionService_CreateSession_NonGitWorkspace_SkipsWorktree(t *testing.T
 
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, bus)
+	service := NewSessionService(sessionStore, workspaceService, gitService, bus, "eqt/")
 
 	session := &Session{
 		Name:        "my-session",

--- a/internal/zellij/zellijservice_test.go
+++ b/internal/zellij/zellijservice_test.go
@@ -26,7 +26,7 @@ func setupZellijService(t *testing.T) (*ZellijService, *session.SessionService, 
 
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	sessionService := session.NewSessionService(sessionStore, workspaceService, gitService, bus)
+	sessionService := session.NewSessionService(sessionStore, workspaceService, gitService, bus, "eqt/")
 	err := sessionService.OnAppStart(ctx)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- Worktree branches are now created with a configurable prefix (default `eqt/`) instead of using the raw session name as the branch name
- Prefix is configurable via `--branch-prefix` flag or `UTENA_BRANCH_PREFIX` env var
- Branch name is stored in the session model for correct cleanup on deletion

## Test plan
- [x] All existing tests pass
- [x] Daemon and TUI build successfully
- [ ] Create a session with a worktree and verify the branch is named `eqt/<session-name>`
- [ ] Delete the session and verify the prefixed branch is cleaned up
- [ ] Test with custom prefix via `--branch-prefix` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)