### PR TITLE
feat(tui): add branch mode choice for session creation

### DIFF
--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -195,7 +195,7 @@ func (c *client) reviveSession(name string) tea.Cmd {
 	}
 }
 
-func (c *client) createSession(name, workspaceID, baseBranch string) tea.Cmd {
+func (c *client) createSession(name, workspaceID, branch string, branchCreated bool) tea.Cmd {
 	return func() tea.Msg {
 		body := map[string]interface{}{
 			"workspace_id": workspaceID,
@@ -203,8 +203,14 @@ func (c *client) createSession(name, workspaceID, baseBranch string) tea.Cmd {
 		if name != "" {
 			body["name"] = name
 		}
-		if baseBranch != "" {
-			body["base_branch"] = baseBranch
+		if branch != "" {
+			body["create_worktree"] = true
+			body["branch_created"] = branchCreated
+			if branchCreated {
+				body["base_branch"] = branch
+			} else {
+				body["branch"] = branch
+			}
 		}
 		jsonBody, err := json.Marshal(body)
 		if err != nil {

--- a/internal/tui/provider/sessionsprovider.go
+++ b/internal/tui/provider/sessionsprovider.go
@@ -25,13 +25,14 @@ func ActivateSession(name string) tea.Cmd {
 	return func() tea.Msg { return activateSessionMsg{name: name} }
 }
 
-func CreateSession(name, workspaceID, branch, workspacePath string) tea.Cmd {
+func CreateSession(name, workspaceID, branch, workspacePath string, branchCreated bool) tea.Cmd {
 	return func() tea.Msg {
 		return createSessionIntentMsg{
 			name:          name,
 			workspaceID:   workspaceID,
 			branch:        branch,
 			workspacePath: workspacePath,
+			branchCreated: branchCreated,
 		}
 	}
 }
@@ -56,6 +57,7 @@ type createSessionIntentMsg struct {
 	workspaceID   string
 	branch        string
 	workspacePath string
+	branchCreated bool
 }
 
 type reviveSessionIntentMsg struct {
@@ -198,8 +200,9 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 		workspaceID := msg.workspaceID
 		branch := msg.branch
 		workspacePath := msg.workspacePath
+		branchCreated := msg.branchCreated
 		return p, func() tea.Msg {
-			createResult := p.client.createSession(name, workspaceID, branch)()
+			createResult := p.client.createSession(name, workspaceID, branch, branchCreated)()
 			if err, ok := createResult.(ErrMsg); ok {
 				return err
 			}

--- a/internal/tui/sessionform/sessionform.go
+++ b/internal/tui/sessionform/sessionform.go
@@ -31,6 +31,7 @@ const (
 	filePickerStep
 	dirTypeChoiceStep
 	branchPickerStep
+	branchModeStep
 	nameInputStep
 )
 
@@ -43,6 +44,7 @@ type Model struct {
 	selectedWorkspace workspace.Workspace
 	selectedBranch    string
 	selectedDirPath   string
+	branchCreated     bool
 	nameErr           string
 	width, height     int
 }
@@ -82,7 +84,7 @@ func (m Model) Keys() help.KeyMap {
 		return mergedKeyMap{keymaps: []help.KeyMap{formKeys, filepicker.Keys}}
 	case branchPickerStep:
 		return mergedKeyMap{keymaps: []help.KeyMap{formKeys, branchpicker.Keys}}
-	case dirTypeChoiceStep:
+	case dirTypeChoiceStep, branchModeStep:
 		return formKeys
 	default:
 		return formKeys
@@ -111,6 +113,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m.updateDirTypeChoice(msg)
 	case branchPickerStep:
 		return m.updateBranchPicker(msg)
+	case branchModeStep:
+		return m.updateBranchMode(msg)
 	case nameInputStep:
 		return m.updateNameInput(msg)
 	}
@@ -199,9 +203,8 @@ func (m Model) updateBranchPicker(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case branchpicker.SelectedMsg:
 		m.selectedBranch = msg.Branch
-		m.activeStep = nameInputStep
-		m.initNameInput()
-		return m, m.nameInput.Focus()
+		m.activeStep = branchModeStep
+		return m, nil
 
 	case tea.KeyMsg:
 		if key.Matches(msg, formKeys.Back) {
@@ -213,6 +216,25 @@ func (m Model) updateBranchPicker(msg tea.Msg) (Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m.branchPicker, cmd = m.branchPicker.Update(msg)
 	return m, cmd
+}
+
+func (m Model) updateBranchMode(msg tea.Msg) (Model, tea.Cmd) {
+	if msg, ok := msg.(tea.KeyMsg); ok {
+		switch msg.String() {
+		case "n":
+			m.branchCreated = true
+			m.activeStep = nameInputStep
+			m.initNameInput()
+			return m, m.nameInput.Focus()
+		case "e":
+			m.branchCreated = false
+			return m, provider.CreateSession("", m.selectedWorkspace.ID, m.selectedBranch, m.selectedWorkspace.Path, false)
+		case "esc":
+			m.activeStep = branchPickerStep
+			return m, nil
+		}
+	}
+	return m, nil
 }
 
 func (m Model) updateNameInput(msg tea.Msg) (Model, tea.Cmd) {
@@ -228,10 +250,10 @@ func (m Model) updateNameInput(msg tea.Msg) (Model, tea.Cmd) {
 				m.nameErr = err.Error()
 				return m, nil
 			}
-			return m, provider.CreateSession(name, m.selectedWorkspace.ID, m.selectedBranch, m.selectedWorkspace.Path)
+			return m, provider.CreateSession(name, m.selectedWorkspace.ID, m.selectedBranch, m.selectedWorkspace.Path, m.branchCreated)
 		case key.Matches(msg, formKeys.Back):
 			if m.selectedWorkspace.IsGitRepo {
-				m.activeStep = branchPickerStep
+				m.activeStep = branchModeStep
 				m.nameErr = ""
 				return m, nil
 			}
@@ -266,6 +288,12 @@ func (m Model) View() string {
 			"  esc: back"
 	case branchPickerStep:
 		return m.branchPicker.View()
+	case branchModeStep:
+		return promptStyle.Render("Branch: ") + pathStyle.Render(m.selectedBranch) +
+			"\n\n" +
+			"  n  New branch from " + pathStyle.Render(m.selectedBranch) + "\n" +
+			"  e  Use existing branch " + pathStyle.Render(m.selectedBranch) + "\n\n" +
+			"  esc: back"
 	case nameInputStep:
 		var b strings.Builder
 		fmt.Fprintf(&b, "Workspace: %s\n\n", m.selectedWorkspace.Name)


### PR DESCRIPTION
## Summary
- Adds a branch mode step to the session creation form for git workspaces
- After selecting a branch, users choose between `n` (new branch from selected) or `e` (use existing branch as-is)
- "New branch" proceeds to name input; "existing branch" creates the session immediately with server-derived name
- HTTP client sends correct `base_branch` vs `branch` field depending on the mode

## Test plan
- [x] `task test` — all tests pass
- [x] `task tui:build && task daemon:build` — both compile
- [ ] Manual: create a session from a git workspace, verify branch mode choice appears after selecting a branch
- [ ] Manual: verify "new branch" path prompts for name and creates a new branch worktree
- [ ] Manual: verify "existing branch" path creates session immediately using the selected branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)