### PR TITLE
fix(tui): use explicit colors for list items in tmux

### DIFF
--- a/internal/tui/branchpicker/branchpicker.go
+++ b/internal/tui/branchpicker/branchpicker.go
@@ -5,6 +5,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+	ulist "github.com/eleonorayaya/utena/internal/tui/list"
 	"github.com/eleonorayaya/utena/internal/tui/provider"
 )
 
@@ -13,11 +14,7 @@ type Model struct {
 }
 
 func New() Model {
-	l := list.New(nil, list.NewDefaultDelegate(), 0, 0)
-	l.Title = "Select base branch"
-	l.KeyMap.Quit.SetEnabled(false)
-	l.SetShowHelp(false)
-	return Model{list: l}
+	return Model{list: ulist.New("Select base branch")}
 }
 
 func (m *Model) SetSize(width, height int) {

--- a/internal/tui/list/list.go
+++ b/internal/tui/list/list.go
@@ -7,8 +7,8 @@ import (
 
 func New(title string) bubblelist.Model {
 	d := bubblelist.NewDefaultDelegate()
-	d.Styles.NormalTitle = d.Styles.NormalTitle.Foreground(lipgloss.Color("255"))
-	d.Styles.NormalDesc = d.Styles.NormalDesc.Foreground(lipgloss.Color("250"))
+	d.Styles.NormalTitle = d.Styles.NormalTitle.Foreground(lipgloss.Color("235"))
+	d.Styles.NormalDesc = d.Styles.NormalDesc.Foreground(lipgloss.Color("242"))
 	l := bubblelist.New(nil, d, 0, 0)
 	l.Title = title
 	l.KeyMap.Quit.SetEnabled(false)

--- a/internal/tui/list/list.go
+++ b/internal/tui/list/list.go
@@ -7,8 +7,8 @@ import (
 
 func New(title string) bubblelist.Model {
 	d := bubblelist.NewDefaultDelegate()
-	d.Styles.NormalTitle = d.Styles.NormalTitle.Foreground(lipgloss.Color("252"))
-	d.Styles.NormalDesc = d.Styles.NormalDesc.Foreground(lipgloss.Color("246"))
+	d.Styles.NormalTitle = d.Styles.NormalTitle.Foreground(lipgloss.Color("255"))
+	d.Styles.NormalDesc = d.Styles.NormalDesc.Foreground(lipgloss.Color("250"))
 	l := bubblelist.New(nil, d, 0, 0)
 	l.Title = title
 	l.KeyMap.Quit.SetEnabled(false)

--- a/internal/tui/list/list.go
+++ b/internal/tui/list/list.go
@@ -1,0 +1,17 @@
+package list
+
+import (
+	bubblelist "github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func New(title string) bubblelist.Model {
+	d := bubblelist.NewDefaultDelegate()
+	d.Styles.NormalTitle = d.Styles.NormalTitle.Foreground(lipgloss.Color("252"))
+	d.Styles.NormalDesc = d.Styles.NormalDesc.Foreground(lipgloss.Color("246"))
+	l := bubblelist.New(nil, d, 0, 0)
+	l.Title = title
+	l.KeyMap.Quit.SetEnabled(false)
+	l.SetShowHelp(false)
+	return l
+}

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/eleonorayaya/utena/internal/claude"
 	"github.com/eleonorayaya/utena/internal/session"
+	ulist "github.com/eleonorayaya/utena/internal/tui/list"
 	"github.com/eleonorayaya/utena/internal/tui/provider"
 	"github.com/eleonorayaya/utena/internal/tui/router"
 )
@@ -20,9 +21,8 @@ type Model struct {
 }
 
 func New() Model {
-	l := list.New(nil, list.NewDefaultDelegate(), 0, 0)
-	l.Title = "Sessions"
-	l.SetShowHelp(false)
+	l := ulist.New("Sessions")
+	l.KeyMap.Quit.SetEnabled(true)
 	return Model{list: l}
 }
 

--- a/internal/tui/todolist/todolist.go
+++ b/internal/tui/todolist/todolist.go
@@ -6,6 +6,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/eleonorayaya/utena/internal/todo"
+	ulist "github.com/eleonorayaya/utena/internal/tui/list"
 	"github.com/eleonorayaya/utena/internal/tui/provider"
 	"github.com/eleonorayaya/utena/internal/tui/router"
 )
@@ -19,11 +20,7 @@ type Model struct {
 }
 
 func New() Model {
-	l := list.New(nil, list.NewDefaultDelegate(), 0, 0)
-	l.Title = "Todos"
-	l.KeyMap.Quit.SetEnabled(false)
-	l.SetShowHelp(false)
-	return Model{list: l}
+	return Model{list: ulist.New("Todos")}
 }
 
 func (m Model) Init() (Model, tea.Cmd) {

--- a/internal/tui/workspacepicker/workspacepicker.go
+++ b/internal/tui/workspacepicker/workspacepicker.go
@@ -5,6 +5,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+	ulist "github.com/eleonorayaya/utena/internal/tui/list"
 	"github.com/eleonorayaya/utena/internal/tui/provider"
 	"github.com/eleonorayaya/utena/internal/workspace"
 )
@@ -16,12 +17,8 @@ type Model struct {
 }
 
 func New(title string, sortActiveFirst bool) Model {
-	l := list.New(nil, list.NewDefaultDelegate(), 0, 0)
-	l.Title = title
-	l.KeyMap.Quit.SetEnabled(false)
-	l.SetShowHelp(false)
 	return Model{
-		list:            l,
+		list:            ulist.New(title),
 		sortActiveFirst: sortActiveFirst,
 	}
 }


### PR DESCRIPTION
## Summary
- Non-selected list items had low contrast / were hard to read when running inside tmux `display-popup`, because the default bubbles list delegate uses adaptive colors that rely on `termenv` background detection — which fails in tmux popups
- Set explicit foreground colors (252 for title, 246 for description) instead of adaptive colors
- Extracted shared list constructor into `internal/tui/list` package to centralize delegate styling and common list defaults (title, disable quit, disable help)

## Test plan
- [ ] Open utena TUI inside tmux popup (`prefix + p`) and verify non-selected list items are readable
- [ ] Verify selected items still have distinct highlight styling
- [ ] Check all list views: sessions, todos, branch picker, workspace picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)