### PR TITLE
feat(tui): add tmux status pane

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -30,6 +30,7 @@ func main() {
 
 	rootCmd.AddCommand(shellInitCmd())
 	rootCmd.AddCommand(todosCmd())
+	rootCmd.AddCommand(statusCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -73,6 +74,36 @@ func todosCmd() *cobra.Command {
 			}
 
 			p := tea.NewProgram(tui.NewApp(resolvedLogPath, port, router.TodoListView))
+			if _, err := p.Run(); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func statusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "status",
+		Short:        "Open status bar view",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			port, _ := cmd.Root().Flags().GetString("port")
+
+			var resolvedLogPath string
+			logfilePath := os.Getenv("BUBBLETEA_LOG")
+			if logfilePath != "" {
+				if _, err := tea.LogToFile(logfilePath, "utena"); err != nil {
+					log.Fatal(err)
+				}
+				resolvedLogPath, _ = filepath.Abs(logfilePath)
+			}
+
+			p := tea.NewProgram(
+				tui.NewApp(resolvedLogPath, port, router.StatusView),
+				tea.WithReportFocus(),
+			)
 			if _, err := p.Run(); err != nil {
 				return err
 			}

--- a/internal/common/timeago.go
+++ b/internal/common/timeago.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"fmt"
+	"time"
+)
+
+func TimeAgo(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		m := int(d.Minutes())
+		if m == 1 {
+			return "1 min ago"
+		}
+		return fmt.Sprintf("%d mins ago", m)
+	case d < 24*time.Hour:
+		h := int(d.Hours())
+		if h == 1 {
+			return "1 hour ago"
+		}
+		return fmt.Sprintf("%d hours ago", h)
+	default:
+		days := int(d.Hours() / 24)
+		if days == 1 {
+			return "yesterday"
+		}
+		if days < 30 {
+			return fmt.Sprintf("%d days ago", days)
+		}
+		return t.Format("Jan 2")
+	}
+}

--- a/internal/tmux/tmuxcontroller.go
+++ b/internal/tmux/tmuxcontroller.go
@@ -53,3 +53,24 @@ func (c *TmuxController) HandleHook(w http.ResponseWriter, r *http.Request) {
 
 	render.JSON(w, r, map[string]string{"status": "ok"})
 }
+
+func (c *TmuxController) HandleSyncWindows(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	req := &SyncWindowsRequest{}
+	if err := render.Bind(r, req); err != nil {
+		render.Render(w, r, common.ErrInvalidRequest(err))
+		return
+	}
+
+	c.service.SyncWindows(ctx, req.SessionName, req.Windows)
+	render.JSON(w, r, map[string]string{"status": "ok"})
+}
+
+func (c *TmuxController) HandleGetWindows(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	sessionName := chi.URLParam(r, "sessionName")
+
+	windows := c.service.GetWindows(ctx, sessionName)
+	render.JSON(w, r, windows)
+}

--- a/internal/tmux/tmuxrouter.go
+++ b/internal/tmux/tmuxrouter.go
@@ -18,6 +18,8 @@ func (tr *TmuxRouter) Routes() chi.Router {
 	r := chi.NewRouter()
 
 	r.Put("/hooks/{event}", tr.controller.HandleHook)
+	r.Put("/windows", tr.controller.HandleSyncWindows)
+	r.Get("/windows/{sessionName}", tr.controller.HandleGetWindows)
 
 	return r
 }

--- a/internal/tmux/tmuxservice.go
+++ b/internal/tmux/tmuxservice.go
@@ -12,14 +12,16 @@ import (
 )
 
 type TmuxService struct {
-	sessionService *session.SessionService
-	eventBus       eventbus.EventBus
+	sessionService   *session.SessionService
+	eventBus         eventbus.EventBus
+	windowsBySession map[string][]Window
 }
 
 func NewTmuxService(sessionService *session.SessionService, bus eventbus.EventBus) *TmuxService {
 	return &TmuxService{
-		sessionService: sessionService,
-		eventBus:       bus,
+		sessionService:   sessionService,
+		eventBus:         bus,
+		windowsBySession: make(map[string][]Window),
 	}
 }
 
@@ -111,6 +113,7 @@ func (t *TmuxService) HandleSessionClosed(ctx context.Context, tmuxName string) 
 	sess.IsDead = true
 	sess.IsActive = false
 	sess.IsAttached = false
+	delete(t.windowsBySession, tmuxName)
 	return t.sessionService.UpdateSession(ctx, sess)
 }
 
@@ -161,4 +164,12 @@ func (t *TmuxService) HandleClientDetached(ctx context.Context, tmuxName string)
 
 	sess.IsAttached = false
 	return t.sessionService.UpdateSession(ctx, sess)
+}
+
+func (t *TmuxService) SyncWindows(ctx context.Context, tmuxName string, windows []Window) {
+	t.windowsBySession[tmuxName] = windows
+}
+
+func (t *TmuxService) GetWindows(ctx context.Context, tmuxName string) []Window {
+	return t.windowsBySession[tmuxName]
 }

--- a/internal/tmux/types.go
+++ b/internal/tmux/types.go
@@ -9,3 +9,18 @@ type HookEvent struct {
 func (h *HookEvent) Bind(r *http.Request) error {
 	return nil
 }
+
+type Window struct {
+	Index  int    `json:"index"`
+	Name   string `json:"name"`
+	Active bool   `json:"active"`
+}
+
+type SyncWindowsRequest struct {
+	SessionName string   `json:"session_name"`
+	Windows     []Window `json:"windows"`
+}
+
+func (s *SyncWindowsRequest) Bind(r *http.Request) error {
+	return nil
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/eleonorayaya/utena/internal/tui/router"
 	"github.com/eleonorayaya/utena/internal/tui/sessionform"
 	"github.com/eleonorayaya/utena/internal/tui/sessionlist"
+	"github.com/eleonorayaya/utena/internal/tui/statusview"
 	"github.com/eleonorayaya/utena/internal/tui/todoform"
 	"github.com/eleonorayaya/utena/internal/tui/todolist"
 )
@@ -30,6 +31,7 @@ func NewApp(logPath, port string, initialView router.View) App {
 		router.TodoListView:    &router.ViewAdapter[todolist.Model]{Model: todolist.New()},
 		router.TodoFormView:    &router.ViewAdapter[todoform.Model]{Model: todoform.New()},
 		router.DebugView:       &router.ViewAdapter[debug.Model]{Model: debug.New(logPath, baseURL)},
+		router.StatusView:      &router.ViewAdapter[statusview.Model]{Model: statusview.New()},
 	}
 
 	return App{

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -14,6 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/eleonorayaya/utena/internal/claude"
 	"github.com/eleonorayaya/utena/internal/session"
+	"github.com/eleonorayaya/utena/internal/tmux"
 	"github.com/eleonorayaya/utena/internal/todo"
 	"github.com/eleonorayaya/utena/internal/workspace"
 )
@@ -307,6 +308,30 @@ func (c *client) fetchTodos() tea.Cmd {
 		}
 
 		return todosLoadedMsg{todos: resp.Todos}
+	}
+}
+
+func (c *client) fetchWindows(sessionName string) tea.Cmd {
+	return func() tea.Msg {
+		res, err := c.httpClient.Get(c.baseURL + "/tmux/windows/" + sessionName)
+		if err != nil {
+			log.Printf("[ERROR] fetch windows: %v", err)
+			return windowsLoadedMsg{}
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			log.Printf("[ERROR] fetch windows: status %d", res.StatusCode)
+			return windowsLoadedMsg{}
+		}
+
+		var windows []tmux.Window
+		if err := json.NewDecoder(res.Body).Decode(&windows); err != nil {
+			log.Printf("[ERROR] decode windows: %v", err)
+			return windowsLoadedMsg{}
+		}
+
+		return windowsLoadedMsg{windows: windows}
 	}
 }
 

--- a/internal/tui/provider/sessionsprovider.go
+++ b/internal/tui/provider/sessionsprovider.go
@@ -6,6 +6,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/eleonorayaya/utena/internal/claude"
 	"github.com/eleonorayaya/utena/internal/session"
+	"github.com/eleonorayaya/utena/internal/tmux"
 )
 
 type SessionsStateUpdatedMsg struct {
@@ -13,8 +14,16 @@ type SessionsStateUpdatedMsg struct {
 	ClaudeSessions map[string][]claude.ClaudeSession
 }
 
+type WindowsStateUpdatedMsg struct {
+	Windows []tmux.Window
+}
+
 func FetchSessions() tea.Cmd {
 	return func() tea.Msg { return fetchSessionsIntentMsg{} }
+}
+
+func FetchWindows(sessionName string) tea.Cmd {
+	return func() tea.Msg { return fetchWindowsIntentMsg{sessionName: sessionName} }
 }
 
 func RequestSessionsState() tea.Cmd {
@@ -66,6 +75,14 @@ type reviveSessionIntentMsg struct {
 
 type deleteSessionIntentMsg struct {
 	id string
+}
+
+type fetchWindowsIntentMsg struct {
+	sessionName string
+}
+
+type windowsLoadedMsg struct {
+	windows []tmux.Window
 }
 
 type setActiveWorkspaceMsg struct {
@@ -149,6 +166,14 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 
 	case fetchSessionsIntentMsg:
 		return p, tea.Batch(p.client.fetchSessions(), p.client.fetchClaudeSessions())
+
+	case fetchWindowsIntentMsg:
+		return p, p.client.fetchWindows(msg.sessionName)
+
+	case windowsLoadedMsg:
+		return p, func() tea.Msg {
+			return WindowsStateUpdatedMsg{Windows: msg.windows}
+		}
 
 	case requestSessionsStateMsg:
 		return p, p.emitState()

--- a/internal/tui/router/view.go
+++ b/internal/tui/router/view.go
@@ -8,4 +8,5 @@ const (
 	TodoListView
 	TodoFormView
 	DebugView
+	StatusView
 )

--- a/internal/tui/sessionlist/sessionitem.go
+++ b/internal/tui/sessionlist/sessionitem.go
@@ -1,10 +1,8 @@
 package sessionlist
 
 import (
-	"fmt"
-	"time"
-
 	"github.com/eleonorayaya/utena/internal/claude"
+	"github.com/eleonorayaya/utena/internal/common"
 	"github.com/eleonorayaya/utena/internal/session"
 )
 
@@ -39,7 +37,7 @@ func (i sessionItem) Description() string {
 		name = "no workspace"
 	}
 	if !i.session.LastUsedAt.IsZero() {
-		return name + " · " + timeAgo(i.session.LastUsedAt)
+		return name + " · " + common.TimeAgo(i.session.LastUsedAt)
 	}
 	return name
 }
@@ -75,33 +73,4 @@ func aggregateClaudeStatus(sessions []claude.ClaudeSession) string {
 		return "[ready for review]"
 	}
 	return "[done]"
-}
-
-func timeAgo(t time.Time) string {
-	d := time.Since(t)
-	switch {
-	case d < time.Minute:
-		return "just now"
-	case d < time.Hour:
-		m := int(d.Minutes())
-		if m == 1 {
-			return "1 min ago"
-		}
-		return fmt.Sprintf("%d mins ago", m)
-	case d < 24*time.Hour:
-		h := int(d.Hours())
-		if h == 1 {
-			return "1 hour ago"
-		}
-		return fmt.Sprintf("%d hours ago", h)
-	default:
-		days := int(d.Hours() / 24)
-		if days == 1 {
-			return "yesterday"
-		}
-		if days < 30 {
-			return fmt.Sprintf("%d days ago", days)
-		}
-		return t.Format("Jan 2")
-	}
 }

--- a/internal/tui/statusview/keys.go
+++ b/internal/tui/statusview/keys.go
@@ -1,0 +1,30 @@
+package statusview
+
+import (
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+)
+
+type keyMap struct {
+	Up       key.Binding
+	Down     key.Binding
+	Select   key.Binding
+	Collapse key.Binding
+}
+
+func (k keyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Up, k.Down, k.Select, k.Collapse}
+}
+
+func (k keyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{k.Up, k.Down, k.Select, k.Collapse}}
+}
+
+var keys = keyMap{
+	Up:       key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("↑/k", "up")),
+	Down:     key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("↓/j", "down")),
+	Select:   key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "switch")),
+	Collapse: key.NewBinding(key.WithKeys("esc", "q"), key.WithHelp("esc", "collapse")),
+}
+
+var _ help.KeyMap = keys

--- a/internal/tui/statusview/model.go
+++ b/internal/tui/statusview/model.go
@@ -1,0 +1,303 @@
+package statusview
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/eleonorayaya/utena/internal/claude"
+	"github.com/eleonorayaya/utena/internal/session"
+	"github.com/eleonorayaya/utena/internal/tmux"
+	"github.com/eleonorayaya/utena/internal/tui/provider"
+)
+
+var (
+	dimStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	activeWinStyle = lipgloss.NewStyle().Bold(true)
+	cursorStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
+	attentionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	workingStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	reviewStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	completedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+)
+
+type tickMsg time.Time
+
+type Model struct {
+	windows            []tmux.Window
+	sessions           []session.Session
+	claudeSessions     map[string][]claude.ClaudeSession
+	currentTmuxSession string
+	paneID             string
+	expanded           bool
+	cursor             int
+	width              int
+}
+
+func New() Model {
+	paneID := os.Getenv("TMUX_PANE")
+	var currentSession string
+	if paneID != "" {
+		out, err := exec.Command("tmux", "display-message", "-p", "-t", paneID, "#{session_name}").Output()
+		if err == nil {
+			currentSession = strings.TrimSpace(string(out))
+		}
+	}
+	return Model{
+		paneID:             paneID,
+		currentTmuxSession: currentSession,
+	}
+}
+
+func (m Model) Init() (Model, tea.Cmd) {
+	cmds := []tea.Cmd{
+		provider.FetchSessions(),
+		tick(),
+	}
+	if m.currentTmuxSession != "" {
+		cmds = append(cmds, provider.FetchWindows(m.currentTmuxSession))
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m Model) Keys() help.KeyMap {
+	return keys
+}
+
+func tick() tea.Cmd {
+	return tea.Tick(2*time.Second, func(t time.Time) tea.Msg {
+		return tickMsg(t)
+	})
+}
+
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		return m, nil
+
+	case tickMsg:
+		cmds := []tea.Cmd{
+			provider.FetchSessions(),
+			tick(),
+		}
+		if m.currentTmuxSession != "" {
+			cmds = append(cmds, provider.FetchWindows(m.currentTmuxSession))
+		}
+		return m, tea.Batch(cmds...)
+
+	case provider.SessionsStateUpdatedMsg:
+		m.sessions = msg.Sessions
+		m.claudeSessions = msg.ClaudeSessions
+		return m, nil
+
+	case provider.WindowsStateUpdatedMsg:
+		m.windows = msg.Windows
+		return m, nil
+
+	case tea.FocusMsg:
+		m.expanded = true
+		return m, nil
+
+	case tea.BlurMsg:
+		m.expanded = false
+		if m.paneID != "" {
+			exec.Command("tmux", "resize-pane", "-y", "1", "-t", m.paneID).Run()
+			exec.Command("tmux", "select-pane", "-d", "-t", m.paneID).Run()
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.expanded {
+			return m.onKeyMsg(msg)
+		}
+	}
+
+	return m, nil
+}
+
+func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
+	activeSessions := m.activeSessions()
+	switch {
+	case key.Matches(msg, keys.Down):
+		if m.cursor < len(activeSessions)-1 {
+			m.cursor++
+		}
+		return m, nil
+	case key.Matches(msg, keys.Up):
+		if m.cursor > 0 {
+			m.cursor--
+		}
+		return m, nil
+	case key.Matches(msg, keys.Select):
+		if m.cursor < len(activeSessions) {
+			s := activeSessions[m.cursor]
+			return m, provider.ActivateSession(s.ID)
+		}
+		return m, nil
+	case key.Matches(msg, keys.Collapse):
+		m.expanded = false
+		if m.paneID != "" {
+			exec.Command("tmux", "resize-pane", "-y", "1", "-t", m.paneID).Run()
+			exec.Command("tmux", "select-pane", "-d", "-t", m.paneID).Run()
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m Model) activeSessions() []session.Session {
+	var result []session.Session
+	for _, s := range m.sessions {
+		if !s.IsDeleted && !s.IsDead {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+func (m Model) View() string {
+	if m.expanded {
+		return m.expandedView()
+	}
+	return m.collapsedView()
+}
+
+func (m Model) collapsedView() string {
+	var windowParts []string
+	for _, w := range m.windows {
+		entry := fmt.Sprintf("%d:%s", w.Index, w.Name)
+		if w.Active {
+			entry += "*"
+			entry = activeWinStyle.Render(entry)
+		}
+		windowParts = append(windowParts, entry)
+	}
+	windowStr := " " + strings.Join(windowParts, " ")
+
+	var sessionParts []string
+	for _, s := range m.activeSessions() {
+		name := s.Name
+		if name == "" {
+			name = s.ID
+		}
+		indicator := statusIndicator(m.claudeSessions[s.ID])
+		if indicator != "" {
+			sessionParts = append(sessionParts, name+"("+indicator+")")
+		} else {
+			sessionParts = append(sessionParts, name)
+		}
+	}
+	sessionStr := strings.Join(sessionParts, " ")
+
+	sep := dimStyle.Render("│")
+	return windowStr + " " + sep + " " + sessionStr
+}
+
+func (m Model) expandedView() string {
+	lines := []string{m.collapsedView()}
+	divider := dimStyle.Render(strings.Repeat("─", m.width))
+	lines = append(lines, divider)
+
+	activeSessions := m.activeSessions()
+	for i, s := range activeSessions {
+		name := s.Name
+		if name == "" {
+			name = s.ID
+		}
+		prefix := "  "
+		if i == m.cursor {
+			prefix = cursorStyle.Render("▸ ")
+		}
+		indicator := statusIndicator(m.claudeSessions[s.ID])
+		entry := prefix + name
+		if indicator != "" {
+			entry += " " + coloredIndicator(m.claudeSessions[s.ID])
+		}
+		if s.IsAttached {
+			entry += dimStyle.Render(" (attached)")
+		}
+		lines = append(lines, entry)
+	}
+
+	helpLine := dimStyle.Render("j/k navigate · enter switch · esc collapse")
+	lines = append(lines, helpLine)
+
+	return strings.Join(lines, "\n")
+}
+
+func statusIndicator(sessions []claude.ClaudeSession) string {
+	if len(sessions) == 0 {
+		return ""
+	}
+	hasNeedsAttention := false
+	hasReadyForReview := false
+	hasWorking := false
+	hasCompleted := false
+	for _, cs := range sessions {
+		switch cs.Status {
+		case claude.StatusNeedsAttention:
+			hasNeedsAttention = true
+		case claude.StatusReadyForReview:
+			hasReadyForReview = true
+		case claude.StatusWorking:
+			hasWorking = true
+		case claude.StatusCompleted:
+			hasCompleted = true
+		}
+	}
+	if hasNeedsAttention {
+		return "!"
+	}
+	if hasWorking {
+		return "~"
+	}
+	if hasReadyForReview {
+		return "✓"
+	}
+	if hasCompleted {
+		return "✓"
+	}
+	return ""
+}
+
+func coloredIndicator(sessions []claude.ClaudeSession) string {
+	if len(sessions) == 0 {
+		return ""
+	}
+	hasNeedsAttention := false
+	hasReadyForReview := false
+	hasWorking := false
+	hasCompleted := false
+	for _, cs := range sessions {
+		switch cs.Status {
+		case claude.StatusNeedsAttention:
+			hasNeedsAttention = true
+		case claude.StatusReadyForReview:
+			hasReadyForReview = true
+		case claude.StatusWorking:
+			hasWorking = true
+		case claude.StatusCompleted:
+			hasCompleted = true
+		}
+	}
+	if hasNeedsAttention {
+		return attentionStyle.Render("!")
+	}
+	if hasWorking {
+		return workingStyle.Render("~")
+	}
+	if hasReadyForReview {
+		return reviewStyle.Render("✓")
+	}
+	if hasCompleted {
+		return completedStyle.Render("✓")
+	}
+	return ""
+}

--- a/plugins/utena-tmux/scripts/create-status-panes.sh
+++ b/plugins/utena-tmux/scripts/create-status-panes.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+tmux list-windows -a -F '#{session_name} #{window_id}' 2>/dev/null | while read -r session_name window_id; do
+    "$SCRIPT_DIR/status-pane.sh" "$session_name" "$window_id"
+done

--- a/plugins/utena-tmux/scripts/hook.sh
+++ b/plugins/utena-tmux/scripts/hook.sh
@@ -2,7 +2,13 @@
 EVENT="$1"
 SESSION_NAME="${2:-}"
 UTENA_PORT="${UTENA_PORT:-3333}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 curl -s -X PUT -H "Content-Type: application/json" \
     -d "{\"session_name\": \"${SESSION_NAME}\"}" \
     "http://localhost:${UTENA_PORT}/tmux/hooks/${EVENT}" \
     >/dev/null 2>&1 || true
+
+if [ "$EVENT" = "session-created" ] || [ "$EVENT" = "client-session-changed" ]; then
+    "$SCRIPT_DIR/sync-windows.sh" "$SESSION_NAME"
+fi

--- a/plugins/utena-tmux/scripts/status-pane.sh
+++ b/plugins/utena-tmux/scripts/status-pane.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+SESSION_NAME="${1:-}"
+WINDOW_ID="${2:-}"
+
+if [ -z "$SESSION_NAME" ] || [ -z "$WINDOW_ID" ]; then
+    exit 0
+fi
+
+existing=$(tmux list-panes -t "$WINDOW_ID" -F '#{pane_id} #{@utena-status}' 2>/dev/null | grep ' 1$' | head -1 | awk '{print $1}')
+if [ -n "$existing" ]; then
+    exit 0
+fi
+
+PANE_ID=$(tmux split-window -v -f -l 1 -d -t "$WINDOW_ID" -P -F '#{pane_id}' 'utena status')
+tmux set-option -p -t "$PANE_ID" @utena-status 1
+tmux select-pane -d -t "$PANE_ID"

--- a/plugins/utena-tmux/scripts/sync-windows.sh
+++ b/plugins/utena-tmux/scripts/sync-windows.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+SESSION_NAME="${1:-}"
+UTENA_PORT="${UTENA_PORT:-3333}"
+
+if [ -z "$SESSION_NAME" ]; then
+    exit 0
+fi
+
+windows_json="["
+first=true
+while IFS='|' read -r index name active; do
+    if [ "$first" = true ]; then
+        first=false
+    else
+        windows_json+=","
+    fi
+    if [ "$active" = "1" ]; then
+        active_val="true"
+    else
+        active_val="false"
+    fi
+    windows_json+="{\"index\":${index},\"name\":\"${name}\",\"active\":${active_val}}"
+done < <(tmux list-windows -t "$SESSION_NAME" -F '#{window_index}|#{window_name}|#{window_active}' 2>/dev/null)
+
+windows_json+="]"
+
+curl -s -X PUT -H "Content-Type: application/json" \
+    -d "{\"session_name\":\"${SESSION_NAME}\",\"windows\":${windows_json}}" \
+    "http://localhost:${UTENA_PORT}/tmux/windows" \
+    >/dev/null 2>&1 || true

--- a/plugins/utena-tmux/scripts/toggle-status.sh
+++ b/plugins/utena-tmux/scripts/toggle-status.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+STATUS_PANE=$(tmux list-panes -F '#{pane_id} #{pane_height} #{@utena-status}' 2>/dev/null | grep ' 1$' | head -1)
+
+if [ -z "$STATUS_PANE" ]; then
+    exit 0
+fi
+
+PANE_ID=$(echo "$STATUS_PANE" | awk '{print $1}')
+PANE_HEIGHT=$(echo "$STATUS_PANE" | awk '{print $2}')
+
+if [ "$PANE_HEIGHT" -le 1 ]; then
+    tmux resize-pane -t "$PANE_ID" -y 8
+    tmux select-pane -e -t "$PANE_ID"
+    tmux select-pane -t "$PANE_ID"
+else
+    tmux resize-pane -t "$PANE_ID" -y 1
+    tmux select-pane -d -t "$PANE_ID"
+    tmux select-pane -t '{up-of}'
+fi

--- a/plugins/utena-tmux/utena.tmux
+++ b/plugins/utena-tmux/utena.tmux
@@ -1,11 +1,24 @@
 #!/usr/bin/env bash
 
 plugin_dir=${TMUX_PLUGIN_MANAGER_PATH:-$HOME/.config/tmux/plugins}
-plugin_path="$plugin_dir}utena-tmux"
+plugin_path="$plugin_dir/utena-tmux"
+script_dir="$plugin_path/scripts"
 
-tmux set-hook -g session-created "run-shell '${plugin_path}/scripts/hook.sh session-created \"#{hook_session_name}\"'"
-tmux set-hook -g session-closed "run-shell '${plugin_path}/scripts/hook.sh session-closed \"#{hook_session_name}\"'"
-tmux set-hook -g client-session-changed "run-shell '${plugin_path}/scripts/hook.sh client-session-changed \"#{session_name}\"'"
-tmux set-hook -g client-attached "run-shell '${plugin_path}/scripts/hook.sh client-attached \"#{session_name}\"'"
-tmux set-hook -g client-detached "run-shell '${plugin_path}/scripts/hook.sh client-detached \"#{session_name}\"'"
+tmux set -g status off
+tmux set -g focus-events on
+
+tmux set-hook -g session-created "run-shell '${script_dir}/hook.sh session-created \"#{hook_session_name}\"'"
+tmux set-hook -g session-closed "run-shell '${script_dir}/hook.sh session-closed \"#{hook_session_name}\"'"
+tmux set-hook -g client-session-changed "run-shell '${script_dir}/hook.sh client-session-changed \"#{session_name}\"'"
+tmux set-hook -g client-attached "run-shell '${script_dir}/hook.sh client-attached \"#{session_name}\"'"
+tmux set-hook -g client-detached "run-shell '${script_dir}/hook.sh client-detached \"#{session_name}\"'"
+
+tmux set-hook -g after-new-window "run-shell '${script_dir}/sync-windows.sh \"#{session_name}\"' ; run-shell '${script_dir}/status-pane.sh \"#{session_name}\" \"#{window_id}\"'"
+tmux set-hook -g window-renamed "run-shell '${script_dir}/sync-windows.sh \"#{session_name}\"'"
+tmux set-hook -g after-kill-window "run-shell '${script_dir}/sync-windows.sh \"#{session_name}\"'"
+tmux set-hook -g after-select-window "run-shell '${script_dir}/sync-windows.sh \"#{session_name}\"'"
+
 tmux bind-key p display-popup -E -w 80% -h 80% "utena"
+tmux bind-key s run-shell "${script_dir}/toggle-status.sh"
+
+run-shell "${script_dir}/create-status-panes.sh"


### PR DESCRIPTION
## Summary

- Replace native tmux status bar with a Bubbletea-powered status pane showing tmux windows and session status indicators
- Add collapsed mode (1 line, passive) and expanded mode (interactive session switcher via `prefix+s`)
- Add daemon window tracking API (`PUT/GET /tmux/windows`) and plugin hooks for window sync

## Details

**Daemon**: New `Window` type and in-memory window store in the tmux module. `PUT /tmux/windows` syncs window state from plugin hooks, `GET /tmux/windows/{session}` serves it to the TUI.

**Plugin**: Window event hooks (`after-new-window`, `window-renamed`, `after-kill-window`, `after-select-window`) call `sync-windows.sh`. Status pane scripts create tagged bottom panes running `utena status`. `prefix+s` toggles expanded/collapsed. Fixes path bug in `utena.tmux`.

**TUI**: New `statusview` package with collapsed view (`1:main 2:api* 3:logs │ auth(!) dash(✓) back(~)`) and expanded view (session list with j/k navigation, enter to switch, esc to collapse). Auto-collapses on blur, 2s polling for updates. `utena status` subcommand with focus reporting enabled.

Also extracts shared `TimeAgo` utility to `internal/common/`.

## Test plan

- [ ] `task fmt && task daemon:build && task tui:build` — no regressions
- [ ] Start daemon, verify `curl -X PUT localhost:3333/tmux/windows` and `curl localhost:3333/tmux/windows/{session}` work
- [ ] Install plugin, verify native status bar is off and status pane appears
- [ ] Create/rename tmux windows → status pane updates within 2s
- [ ] `prefix+s` expands pane, j/k navigates, enter switches session
- [ ] esc or focus loss auto-collapses

🤖 Generated with [Claude Code](https://claude.com/claude-code)