### PR TITLE
fix(tmux): create status pane for first window of new sessions

### DIFF
--- a/plugins/utena-tmux/scripts/hook.sh
+++ b/plugins/utena-tmux/scripts/hook.sh
@@ -12,3 +12,9 @@ curl -s -X PUT -H "Content-Type: application/json" \
 if [ "$EVENT" = "session-created" ] || [ "$EVENT" = "client-session-changed" ]; then
     "$SCRIPT_DIR/sync-windows.sh" "$SESSION_NAME"
 fi
+
+if [ "$EVENT" = "session-created" ]; then
+    tmux list-windows -t "$SESSION_NAME" -F '#{window_id}' 2>/dev/null | while read -r window_id; do
+        "$SCRIPT_DIR/status-pane.sh" "$SESSION_NAME" "$window_id"
+    done
+fi


### PR DESCRIPTION
## Summary
- The `after-new-window` hook doesn't fire for the initial window created by `tmux new-session`, so newly created sessions were missing the status bar on their first window
- Added status pane creation to the `session-created` hook handler, which enumerates the new session's windows and calls `status-pane.sh` for each
- `status-pane.sh` already has an idempotency check (`@utena-status` pane option), so no risk of duplicates

## Test plan
- [ ] Create a new session via the TUI and verify the first window has the status bar
- [ ] Create additional windows in that session and verify they also get status bars
- [ ] Verify existing sessions are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)