### PR TITLE
fix(tmux): add missing tmux prefix to run-shell command

### DIFF
--- a/plugins/utena-tmux/utena.tmux
+++ b/plugins/utena-tmux/utena.tmux
@@ -21,4 +21,4 @@ tmux set-hook -g after-select-window "run-shell '${script_dir}/sync-windows.sh \
 tmux bind-key p display-popup -E -w 80% -h 80% "utena"
 tmux bind-key s run-shell "${script_dir}/toggle-status.sh"
 
-run-shell "${script_dir}/create-status-panes.sh"
+tmux run-shell "${script_dir}/create-status-panes.sh"


### PR DESCRIPTION
Bare `run-shell` is a tmux command, not a bash command. When TPM executes utena.tmux as a bash script, this caused exit code 127 (command not found).