### PR TITLE
feat: reverse session/tmux dependency and integrate gotmux

### DIFF
--- a/Taskfile.tui.yml
+++ b/Taskfile.tui.yml
@@ -3,6 +3,9 @@ version: '3'
 env:
   BUBBLETEA_LOG: tui.log
 
+vars:
+  TUI_BIN: '{{.HOME}}/.local/bin/utena'
+
 tasks:
   build:
     sources:
@@ -17,7 +20,8 @@ tasks:
     deps:
       - build
     cmds:
-      - cp ./out/tui /usr/local/bin/utena
+      - mkdir -p {{dir .TUI_BIN}}
+      - cp ./out/tui {{shellQuote .TUI_BIN}}
   run:
     deps:
       - build

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -15,7 +15,8 @@ import (
 )
 
 var (
-	defaultPort = "3333"
+	defaultPort   = "3333"
+	defaultLogDir = filepath.Join(os.Getenv("HOME"), "Library", "Logs", "utena")
 )
 
 func main() {
@@ -37,17 +38,22 @@ func main() {
 	}
 }
 
+func setupLogging() string {
+	logfilePath := os.Getenv("BUBBLETEA_LOG")
+	if logfilePath == "" {
+		os.MkdirAll(defaultLogDir, 0755)
+		logfilePath = filepath.Join(defaultLogDir, "tui.log")
+	}
+	if _, err := tea.LogToFile(logfilePath, "utena"); err != nil {
+		log.Fatal(err)
+	}
+	resolvedLogPath, _ := filepath.Abs(logfilePath)
+	return resolvedLogPath
+}
+
 func runTUI(cmd *cobra.Command, args []string) error {
 	port, _ := cmd.Flags().GetString("port")
-
-	var resolvedLogPath string
-	logfilePath := os.Getenv("BUBBLETEA_LOG")
-	if logfilePath != "" {
-		if _, err := tea.LogToFile(logfilePath, "utena"); err != nil {
-			log.Fatal(err)
-		}
-		resolvedLogPath, _ = filepath.Abs(logfilePath)
-	}
+	resolvedLogPath := setupLogging()
 
 	p := tea.NewProgram(tui.NewApp(resolvedLogPath, port, router.SessionListView))
 	if _, err := p.Run(); err != nil {
@@ -63,15 +69,7 @@ func todosCmd() *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			port, _ := cmd.Root().Flags().GetString("port")
-
-			var resolvedLogPath string
-			logfilePath := os.Getenv("BUBBLETEA_LOG")
-			if logfilePath != "" {
-				if _, err := tea.LogToFile(logfilePath, "utena"); err != nil {
-					log.Fatal(err)
-				}
-				resolvedLogPath, _ = filepath.Abs(logfilePath)
-			}
+			resolvedLogPath := setupLogging()
 
 			p := tea.NewProgram(tui.NewApp(resolvedLogPath, port, router.TodoListView))
 			if _, err := p.Run(); err != nil {
@@ -90,15 +88,7 @@ func statusCmd() *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			port, _ := cmd.Root().Flags().GetString("port")
-
-			var resolvedLogPath string
-			logfilePath := os.Getenv("BUBBLETEA_LOG")
-			if logfilePath != "" {
-				if _, err := tea.LogToFile(logfilePath, "utena"); err != nil {
-					log.Fatal(err)
-				}
-				resolvedLogPath, _ = filepath.Abs(logfilePath)
-			}
+			resolvedLogPath := setupLogging()
 
 			p := tea.NewProgram(
 				tui.NewApp(resolvedLogPath, port, router.StatusView),

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/eleonorayaya/utena
 go 1.25.5
 
 require (
+	github.com/GianlucaP106/gotmux v0.5.0
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/GianlucaP106/gotmux v0.5.0 h1:kpZsrBPtJFjAvVRfeLwm8cE+7yr4NiMPEaYsTKYGwP8=
+github.com/GianlucaP106/gotmux v0.5.0/go.mod h1:qOsZ+exnCbgv3KJ84VaBo4Q7mXs/W23CW4fyoXAgKe4=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -35,12 +35,13 @@ func newApp(fs afero.Fs, cfg Config) *App {
 	bus := eventbus.NewEventBus()
 
 	workspaceModule := workspace.NewWorkspaceModule(fs, cfg.ConfigDir)
-	sessionModule := session.NewSessionModule(workspaceModule, bus, fs, cfg.ConfigDir, cfg.BranchPrefix)
+	tmuxModule := tmux.NewTmuxModule(bus)
+	sessionModule := session.NewSessionModule(tmuxModule.Service, workspaceModule, bus, fs, cfg.ConfigDir, cfg.BranchPrefix)
 
 	return &App{
 		Workspace: workspaceModule,
 		Session:   sessionModule,
-		Tmux:      tmux.NewTmuxModule(sessionModule, bus),
+		Tmux:      tmuxModule,
 		Claude:    claude.NewClaudeModule(bus, fs, cfg.ConfigDir),
 		Todo:      todo.NewTodoModule(workspaceModule, fs, cfg.ConfigDir),
 	}
@@ -84,8 +85,8 @@ type moduleEntry struct {
 func (a *App) modules() []moduleEntry {
 	return []moduleEntry{
 		{"workspace", "/workspaces", a.Workspace},
-		{"session", "/sessions", a.Session},
 		{"tmux", "/tmux", a.Tmux},
+		{"session", "/sessions", a.Session},
 		{"claude", "/claude", a.Claude},
 		{"todo", "/todos", a.Todo},
 	}

--- a/internal/eventbus/events.go
+++ b/internal/eventbus/events.go
@@ -1,21 +1,19 @@
 package eventbus
 
 const (
-	SessionCreateRequested = "session.create_requested"
-	SessionActivated       = "session.activated"
-	SessionRevived         = "session.revived"
+	TmuxSessionCreated       = "tmux.session_created"
+	TmuxSessionClosed        = "tmux.session_closed"
+	TmuxClientSessionChanged = "tmux.client_session_changed"
+	TmuxClientAttached       = "tmux.client_attached"
+	TmuxClientDetached       = "tmux.client_detached"
+
+	SessionActivated = "session.activated"
 )
 
-type SessionCreateRequestedEvent struct {
-	SessionName   string
-	WorkspacePath string
+type TmuxHookEvent struct {
+	TmuxSessionName string
 }
 
 type SessionActivatedEvent struct {
 	SessionName string
-}
-
-type SessionRevivedEvent struct {
-	SessionName   string
-	WorkspacePath string
 }

--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -52,8 +52,9 @@ func (s *GitService) Pull(ctx context.Context, repoPath string, branch string) e
 	return nil
 }
 
-func (s *GitService) CreateWorktree(ctx context.Context, repoPath string, name string, branchName string, baseBranch string) (string, error) {
-	worktreePath := filepath.Join(repoPath, ".worktrees", name)
+func (s *GitService) CreateWorktree(ctx context.Context, repoPath string, branchName string, baseBranch string) (string, error) {
+	dirName := strings.ReplaceAll(branchName, "/", "-")
+	worktreePath := filepath.Join(repoPath, ".worktrees", dirName)
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "worktree", "add", "-b", branchName, worktreePath, baseBranch)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("git worktree add failed: %s: %w", string(output), err)

--- a/internal/git/gitservice_test.go
+++ b/internal/git/gitservice_test.go
@@ -97,9 +97,9 @@ func TestGitService_CreateWorktree(t *testing.T) {
 	repo := initTestRepo(t)
 
 	svc := NewGitService()
-	worktreePath, err := svc.CreateWorktree(context.Background(), repo, "my-feature", "eqt/my-feature", "main")
+	worktreePath, err := svc.CreateWorktree(context.Background(), repo, "eqt/my-feature", "main")
 	require.NoError(t, err)
-	require.Equal(t, filepath.Join(repo, ".worktrees", "my-feature"), worktreePath)
+	require.Equal(t, filepath.Join(repo, ".worktrees", "eqt-my-feature"), worktreePath)
 
 	info, err := os.Stat(worktreePath)
 	require.NoError(t, err)
@@ -114,10 +114,10 @@ func TestGitService_CreateWorktree_DuplicateName(t *testing.T) {
 	repo := initTestRepo(t)
 
 	svc := NewGitService()
-	_, err := svc.CreateWorktree(context.Background(), repo, "my-feature", "eqt/my-feature", "main")
+	_, err := svc.CreateWorktree(context.Background(), repo, "eqt/my-feature", "main")
 	require.NoError(t, err)
 
-	_, err = svc.CreateWorktree(context.Background(), repo, "my-feature", "eqt/my-feature", "main")
+	_, err = svc.CreateWorktree(context.Background(), repo, "eqt/my-feature", "main")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "git worktree add failed")
 }
@@ -126,7 +126,7 @@ func TestGitService_CreateWorktree_InvalidBaseBranch(t *testing.T) {
 	repo := initTestRepo(t)
 
 	svc := NewGitService()
-	_, err := svc.CreateWorktree(context.Background(), repo, "my-feature", "eqt/my-feature", "nonexistent")
+	_, err := svc.CreateWorktree(context.Background(), repo, "eqt/my-feature", "nonexistent")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "git worktree add failed")
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -37,15 +37,15 @@ type Cleanup struct {
 	BranchDeleted     bool `json:"branch_deleted"`
 }
 
+func SanitizeID(name string) string {
+	r := strings.NewReplacer(
+		" ", "-",
+		".", "_",
+		"/", "-",
+	)
+	return strings.ToLower(r.Replace(name))
+}
+
 func BuildSessionID(workspaceName, name string) string {
-	sanitized := strings.ToLower(strings.ReplaceAll(workspaceName, " ", "-"))
-	return sanitized + "-" + name
-}
-
-func sanitizeBranchName(branch string) string {
-	return strings.ReplaceAll(branch, "/", "-")
-}
-
-func SanitizeForTmux(name string) string {
-	return strings.ReplaceAll(name, ".", "_")
+	return SanitizeID(workspaceName + "-" + name)
 }

--- a/internal/session/sessionmodule.go
+++ b/internal/session/sessionmodule.go
@@ -16,9 +16,9 @@ type SessionModule struct {
 	Router     *SessionRouter
 }
 
-func NewSessionModule(workspaceModule *workspace.WorkspaceModule, bus eventbus.EventBus, fs afero.Fs, configDir string, branchPrefix string) *SessionModule {
+func NewSessionModule(tmuxManager TmuxManager, workspaceModule *workspace.WorkspaceModule, bus eventbus.EventBus, fs afero.Fs, configDir string, branchPrefix string) *SessionModule {
 	store := NewSessionStore(fs, configDir)
-	service := NewSessionService(store, workspaceModule.Service, workspaceModule.GitService, bus, branchPrefix)
+	service := NewSessionService(store, workspaceModule.Service, workspaceModule.GitService, tmuxManager, bus, branchPrefix)
 	controller := NewSessionController(service)
 	router := NewSessionRouter(controller)
 

--- a/internal/session/sessionrouter_test.go
+++ b/internal/session/sessionrouter_test.go
@@ -27,7 +27,7 @@ func setupSessionRouter(t *testing.T) (*SessionRouter, *SessionStore, *workspace
 
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, bus, "eqt/")
+	service := NewSessionService(sessionStore, workspaceService, gitService, &mockTmuxManager{}, bus, "eqt/")
 	controller := NewSessionController(service)
 	router := NewSessionRouter(controller)
 
@@ -377,20 +377,20 @@ func TestSessionRouter_ReviveSession_InvalidWorkspace(t *testing.T) {
 	require.True(t, retrieved.IsDead)
 }
 
-func TestSessionRouter_ActivateSession_RejectsDeadSession(t *testing.T) {
+func TestSessionRouter_ActivateSession_AutoRevivesDeadSession(t *testing.T) {
 	router, sessionStore, _ := setupSessionRouter(t)
 
-	sessionStore.Add(&Session{ID: "dead-session", WorkspaceID: "ws-1", IsDead: true, LastUsedAt: time.Now()})
+	sessionStore.Add(&Session{ID: "dead-session", TmuxSessionName: "dead-session", WorkspaceID: "ws-1", IsDead: true, LastUsedAt: time.Now()})
 
 	req := httptest.NewRequest("PUT", "/dead-session/activate", nil)
 	w := httptest.NewRecorder()
 
 	router.Routes().ServeHTTP(w, req)
 
-	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Equal(t, http.StatusOK, w.Code)
 
 	retrieved, err := sessionStore.GetByID("dead-session")
 	require.NoError(t, err)
-	require.True(t, retrieved.IsDead)
-	require.False(t, retrieved.IsAttached)
+	require.False(t, retrieved.IsDead)
+	require.True(t, retrieved.IsAttached)
 }

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -11,32 +11,44 @@ import (
 	"github.com/eleonorayaya/utena/internal/workspace"
 )
 
-const EventSessionDeleted = "session.deleted"
+type TmuxManager interface {
+	CreateSession(name, startDir string) error
+	KillSession(name string) error
+	HasSession(name string) bool
+	ListSessionNames() ([]string, error)
+}
 
 type SessionService struct {
 	store            *SessionStore
 	workspaceService *workspace.WorkspaceService
 	gitService       *git.GitService
+	tmuxManager      TmuxManager
 	eventBus         eventbus.EventBus
 	branchPrefix     string
 }
 
-func NewSessionService(store *SessionStore, workspaceService *workspace.WorkspaceService, gitService *git.GitService, bus eventbus.EventBus, branchPrefix string) *SessionService {
+func NewSessionService(store *SessionStore, workspaceService *workspace.WorkspaceService, gitService *git.GitService, tmuxManager TmuxManager, bus eventbus.EventBus, branchPrefix string) *SessionService {
 	return &SessionService{
 		store:            store,
 		workspaceService: workspaceService,
 		gitService:       gitService,
+		tmuxManager:      tmuxManager,
 		eventBus:         bus,
 		branchPrefix:     branchPrefix,
 	}
 }
 
 func (s *SessionService) OnAppStart(ctx context.Context) error {
+	s.eventBus.Subscribe(eventbus.TmuxSessionCreated, s.handleTmuxSessionCreated)
+	s.eventBus.Subscribe(eventbus.TmuxSessionClosed, s.handleTmuxSessionClosed)
+	s.eventBus.Subscribe(eventbus.TmuxClientSessionChanged, s.handleTmuxClientSessionChanged)
+	s.eventBus.Subscribe(eventbus.TmuxClientAttached, s.handleTmuxClientAttached)
+	s.eventBus.Subscribe(eventbus.TmuxClientDetached, s.handleTmuxClientDetached)
+	s.reconcileTmuxState(ctx)
 	return nil
 }
 
 func (s *SessionService) OnAppEnd(ctx context.Context) error {
-
 	return nil
 }
 
@@ -61,7 +73,6 @@ func (s *SessionService) resolveWorkspaceName(session *Session) {
 }
 
 func (s *SessionService) ListSessionsByWorkspace(ctx context.Context, workspaceID string) ([]Session, error) {
-
 	_, err := s.workspaceService.GetWorkspace(ctx, workspaceID)
 	if err != nil {
 		return nil, err
@@ -93,20 +104,22 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, cr
 		if ws != nil {
 			session.ID = BuildSessionID(ws.Name, session.Name)
 		} else {
-			session.ID = session.Name
+			session.ID = SanitizeID(session.Name)
 		}
 	case session.Branch != "":
-		session.Name = sanitizeBranchName(session.Branch)
+		if session.Name == "" {
+			session.Name = session.Branch
+		}
 		if ws != nil {
 			session.ID = BuildSessionID(ws.Name, session.Name)
 		} else {
-			session.ID = session.Name
+			session.ID = SanitizeID(session.Name)
 		}
 	default:
 		return fmt.Errorf("session name or branch is required")
 	}
 
-	session.TmuxSessionName = SanitizeForTmux(session.ID)
+	session.TmuxSessionName = session.ID
 
 	if ws != nil && ws.IsGitRepo && createWorktree {
 		pullBranch := session.BaseBranch
@@ -122,7 +135,7 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, cr
 
 		if session.BranchCreated {
 			branchName := s.branchPrefix + session.Name
-			worktreePath, err := s.gitService.CreateWorktree(ctx, ws.Path, session.Name, branchName, session.BaseBranch)
+			worktreePath, err := s.gitService.CreateWorktree(ctx, ws.Path, branchName, session.BaseBranch)
 			if err != nil {
 				return fmt.Errorf("failed to create worktree: %w", err)
 			}
@@ -159,13 +172,10 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, cr
 			startDir = ws.Path
 		}
 	}
-	s.eventBus.Publish(ctx, eventbus.Event{
-		Type: eventbus.SessionCreateRequested,
-		Data: eventbus.SessionCreateRequestedEvent{
-			SessionName:   session.ID,
-			WorkspacePath: startDir,
-		},
-	})
+
+	if err := s.tmuxManager.CreateSession(session.TmuxSessionName, startDir); err != nil {
+		slog.Warn("failed to create tmux session", "session", session.TmuxSessionName, "error", err)
+	}
 
 	return nil
 }
@@ -194,8 +204,16 @@ func (s *SessionService) ActivateSession(ctx context.Context, name string) (*Ses
 
 	slog.Info("activate session", "session", name, "is_attached", session.IsAttached)
 
-	if session.IsDead {
-		return nil, ErrSessionDead
+	if !s.tmuxManager.HasSession(session.TmuxSessionName) {
+		startDir := s.resolveStartDir(ctx, session)
+		if err := s.tmuxManager.CreateSession(session.TmuxSessionName, startDir); err != nil {
+			return nil, fmt.Errorf("failed to revive tmux session: %w", err)
+		}
+		session.IsDead = false
+		session.IsActive = true
+	} else if session.IsDead {
+		session.IsDead = false
+		session.IsActive = true
 	}
 
 	if session.IsAttached {
@@ -259,13 +277,10 @@ func (s *SessionService) ReviveSession(ctx context.Context, name string) (*Reviv
 	if session.WorktreePath != "" {
 		startDir = session.WorktreePath
 	}
-	s.eventBus.Publish(ctx, eventbus.Event{
-		Type: eventbus.SessionRevived,
-		Data: eventbus.SessionRevivedEvent{
-			SessionName:   session.ID,
-			WorkspacePath: startDir,
-		},
-	})
+
+	if err := s.tmuxManager.CreateSession(session.TmuxSessionName, startDir); err != nil {
+		slog.Warn("failed to create tmux session for revive", "session", session.TmuxSessionName, "error", err)
+	}
 
 	return &ReviveResult{Session: session, WorkspacePath: workspacePath}, nil
 }
@@ -310,15 +325,147 @@ func (s *SessionService) DeleteSession(ctx context.Context, id string, deleteBra
 		}
 	}
 
+	if err := s.tmuxManager.KillSession(session.TmuxSessionName); err != nil {
+		slog.Info("tmux session already gone or failed to kill", "session", session.TmuxSessionName, "error", err)
+	} else {
+		cleanup.TmuxSessionKilled = true
+	}
+
 	session.IsDeleted = true
 	session.Cleanup = cleanup
 
-	if err := s.store.Update(session); err != nil {
-		return err
+	return s.store.Update(session)
+}
+
+func (s *SessionService) resolveStartDir(ctx context.Context, session *Session) string {
+	if session.WorktreePath != "" {
+		return session.WorktreePath
+	}
+	if session.WorkspaceID != "" {
+		ws, err := s.workspaceService.GetWorkspace(ctx, session.WorkspaceID)
+		if err == nil {
+			return ws.Path
+		}
+	}
+	return ""
+}
+
+func (s *SessionService) handleTmuxSessionCreated(ctx context.Context, event eventbus.Event) error {
+	data, ok := event.Data.(eventbus.TmuxHookEvent)
+	if !ok {
+		return fmt.Errorf("unexpected event data type: %T", event.Data)
 	}
 
-	return s.eventBus.Publish(ctx, eventbus.Event{
-		Type: EventSessionDeleted,
-		Data: session,
-	})
+	sess, err := s.store.GetByTmuxName(data.TmuxSessionName)
+	if err != nil {
+		slog.Debug("session not found for session-created hook", "tmux_name", data.TmuxSessionName, "error", err)
+		return nil
+	}
+
+	sess.IsActive = true
+	sess.IsDead = false
+	return s.store.Update(sess)
+}
+
+func (s *SessionService) handleTmuxSessionClosed(ctx context.Context, event eventbus.Event) error {
+	data, ok := event.Data.(eventbus.TmuxHookEvent)
+	if !ok {
+		return fmt.Errorf("unexpected event data type: %T", event.Data)
+	}
+
+	sess, err := s.store.GetByTmuxName(data.TmuxSessionName)
+	if err != nil {
+		slog.Debug("session not found for session-closed hook", "tmux_name", data.TmuxSessionName, "error", err)
+		return nil
+	}
+
+	sess.IsDead = true
+	sess.IsActive = false
+	sess.IsAttached = false
+	return s.store.Update(sess)
+}
+
+func (s *SessionService) handleTmuxClientSessionChanged(ctx context.Context, event eventbus.Event) error {
+	data, ok := event.Data.(eventbus.TmuxHookEvent)
+	if !ok {
+		return fmt.Errorf("unexpected event data type: %T", event.Data)
+	}
+
+	sessions := s.store.List()
+	for _, sess := range sessions {
+		if sess.IsAttached {
+			sess.IsAttached = false
+			if err := s.store.Update(&sess); err != nil {
+				return err
+			}
+		}
+	}
+
+	sess, err := s.store.GetByTmuxName(data.TmuxSessionName)
+	if err != nil {
+		slog.Debug("session not found for client-session-changed hook", "tmux_name", data.TmuxSessionName, "error", err)
+		return nil
+	}
+
+	sess.IsAttached = true
+	sess.LastUsedAt = time.Now()
+	return s.store.Update(sess)
+}
+
+func (s *SessionService) handleTmuxClientAttached(ctx context.Context, event eventbus.Event) error {
+	data, ok := event.Data.(eventbus.TmuxHookEvent)
+	if !ok {
+		return fmt.Errorf("unexpected event data type: %T", event.Data)
+	}
+
+	sess, err := s.store.GetByTmuxName(data.TmuxSessionName)
+	if err != nil {
+		slog.Debug("session not found for client-attached hook", "tmux_name", data.TmuxSessionName, "error", err)
+		return nil
+	}
+
+	sess.IsAttached = true
+	sess.LastUsedAt = time.Now()
+	return s.store.Update(sess)
+}
+
+func (s *SessionService) handleTmuxClientDetached(ctx context.Context, event eventbus.Event) error {
+	data, ok := event.Data.(eventbus.TmuxHookEvent)
+	if !ok {
+		return fmt.Errorf("unexpected event data type: %T", event.Data)
+	}
+
+	sess, err := s.store.GetByTmuxName(data.TmuxSessionName)
+	if err != nil {
+		slog.Debug("session not found for client-detached hook", "tmux_name", data.TmuxSessionName, "error", err)
+		return nil
+	}
+
+	sess.IsAttached = false
+	return s.store.Update(sess)
+}
+
+func (s *SessionService) reconcileTmuxState(ctx context.Context) {
+	tmuxNames, err := s.tmuxManager.ListSessionNames()
+	if err != nil {
+		slog.Warn("failed to list tmux sessions for reconciliation", "error", err)
+		return
+	}
+
+	activeSet := make(map[string]bool, len(tmuxNames))
+	for _, name := range tmuxNames {
+		activeSet[name] = true
+	}
+
+	for _, sess := range s.store.List() {
+		if sess.IsActive && !sess.IsDead && !sess.IsDeleted {
+			if !activeSet[sess.TmuxSessionName] {
+				slog.Info("reconciliation: marking session as dead (tmux session gone)", "session", sess.ID, "tmux_name", sess.TmuxSessionName)
+				sess.IsDead = true
+				sess.IsActive = false
+				sess.IsAttached = false
+				s.store.Update(&sess)
+			}
+		}
+	}
 }

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -15,6 +15,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type mockTmuxManager struct{}
+
+func (m *mockTmuxManager) CreateSession(name, startDir string) error { return nil }
+func (m *mockTmuxManager) KillSession(name string) error             { return nil }
+func (m *mockTmuxManager) HasSession(name string) bool               { return false }
+func (m *mockTmuxManager) ListSessionNames() ([]string, error)       { return nil, nil }
+
 func setupSessionService(t *testing.T) (*SessionService, *SessionStore, *workspace.WorkspaceStore) {
 	t.Helper()
 
@@ -27,7 +34,7 @@ func setupSessionService(t *testing.T) (*SessionService, *SessionStore, *workspa
 
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, bus, "eqt/")
+	service := NewSessionService(sessionStore, workspaceService, gitService, &mockTmuxManager{}, bus, "eqt/")
 	return service, sessionStore, workspaceStore
 }
 
@@ -293,7 +300,7 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, bus, "eqt/")
+	service := NewSessionService(sessionStore, workspaceService, gitService, &mockTmuxManager{}, bus, "eqt/")
 
 	session := &Session{
 		Name:          "my-feature",
@@ -307,7 +314,7 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "git-repo-my-feature", session.ID)
-	expectedPath := filepath.Join(repoPath, ".worktrees", "my-feature")
+	expectedPath := filepath.Join(repoPath, ".worktrees", "eqt-my-feature")
 	require.Equal(t, expectedPath, session.WorktreePath)
 	require.Equal(t, "eqt/my-feature", session.BranchName)
 
@@ -332,7 +339,7 @@ func TestSessionService_CreateSession_WithWorktree_InvalidBranch(t *testing.T) {
 
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, bus, "eqt/")
+	service := NewSessionService(sessionStore, workspaceService, gitService, &mockTmuxManager{}, bus, "eqt/")
 
 	session := &Session{
 		Name:          "my-feature",
@@ -415,7 +422,7 @@ func TestSessionService_CreateSession_NonGitWorkspace_SkipsWorktree(t *testing.T
 
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, bus, "eqt/")
+	service := NewSessionService(sessionStore, workspaceService, gitService, &mockTmuxManager{}, bus, "eqt/")
 
 	session := &Session{
 		Name:        "my-session",
@@ -452,10 +459,11 @@ func TestSessionService_ActivateSession_TouchesWorkspace(t *testing.T) {
 	service, sessionStore, workspaceStore := setupSessionService(t)
 
 	session := &Session{
-		ID:          "session-1",
-		Name:        "session-1",
-		WorkspaceID: "ws-1",
-		LastUsedAt:  time.Now().Add(-1 * time.Hour),
+		ID:              "session-1",
+		Name:            "session-1",
+		TmuxSessionName: "session-1",
+		WorkspaceID:     "ws-1",
+		LastUsedAt:      time.Now().Add(-1 * time.Hour),
 	}
 	sessionStore.Add(session)
 
@@ -466,4 +474,25 @@ func TestSessionService_ActivateSession_TouchesWorkspace(t *testing.T) {
 	ws, err := workspaceStore.GetByID("ws-1")
 	require.NoError(t, err)
 	require.False(t, ws.LastUsedAt.IsZero())
+}
+
+func TestSessionService_ActivateSession_AutoRevivesDeadSession(t *testing.T) {
+	service, sessionStore, _ := setupSessionService(t)
+
+	session := &Session{
+		ID:              "dead-session",
+		Name:            "dead-session",
+		TmuxSessionName: "dead-session",
+		WorkspaceID:     "ws-1",
+		IsDead:          true,
+		LastUsedAt:      time.Now(),
+	}
+	sessionStore.Add(session)
+
+	ctx := context.Background()
+	result, err := service.ActivateSession(ctx, "dead-session")
+	require.NoError(t, err)
+	require.False(t, result.IsDead)
+	require.True(t, result.IsActive)
+	require.True(t, result.IsAttached)
 }

--- a/internal/session/sessionstore.go
+++ b/internal/session/sessionstore.go
@@ -183,7 +183,7 @@ func (s *SessionStore) OnAppStart(ctx context.Context) error {
 			session.Name = session.ID
 		}
 		if session.TmuxSessionName == "" {
-			session.TmuxSessionName = SanitizeForTmux(session.ID)
+			session.TmuxSessionName = session.ID
 		}
 	}
 

--- a/internal/tmux/tmuxmodule.go
+++ b/internal/tmux/tmuxmodule.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/eleonorayaya/utena/internal/eventbus"
-	"github.com/eleonorayaya/utena/internal/session"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -14,8 +13,8 @@ type TmuxModule struct {
 	Router     *TmuxRouter
 }
 
-func NewTmuxModule(sessionModule *session.SessionModule, bus eventbus.EventBus) *TmuxModule {
-	service := NewTmuxService(sessionModule.Service, bus)
+func NewTmuxModule(bus eventbus.EventBus) *TmuxModule {
+	service := NewTmuxService(bus)
 	controller := NewTmuxController(service)
 	router := NewTmuxRouter(controller)
 	return &TmuxModule{Service: service, Controller: controller, Router: router}

--- a/internal/tmux/tmuxservice.go
+++ b/internal/tmux/tmuxservice.go
@@ -2,88 +2,32 @@ package tmux
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"os/exec"
-	"time"
 
+	"github.com/GianlucaP106/gotmux/gotmux"
 	"github.com/eleonorayaya/utena/internal/eventbus"
-	"github.com/eleonorayaya/utena/internal/session"
 )
 
 type TmuxService struct {
-	sessionService   *session.SessionService
+	tmux             *gotmux.Tmux
 	eventBus         eventbus.EventBus
 	windowsBySession map[string][]Window
 }
 
-func NewTmuxService(sessionService *session.SessionService, bus eventbus.EventBus) *TmuxService {
+func NewTmuxService(bus eventbus.EventBus) *TmuxService {
+	tmux, err := gotmux.DefaultTmux()
+	if err != nil {
+		slog.Warn("failed to initialize gotmux", "error", err)
+	}
+
 	return &TmuxService{
-		sessionService:   sessionService,
+		tmux:             tmux,
 		eventBus:         bus,
 		windowsBySession: make(map[string][]Window),
 	}
 }
 
 func (t *TmuxService) OnAppStart(ctx context.Context) error {
-	t.eventBus.Subscribe(eventbus.SessionCreateRequested, t.handleSessionCreateRequested)
-	t.eventBus.Subscribe(session.EventSessionDeleted, t.handleSessionDeleted)
-	t.eventBus.Subscribe(eventbus.SessionRevived, t.handleSessionRevived)
-	return nil
-}
-
-func (t *TmuxService) handleSessionCreateRequested(ctx context.Context, event eventbus.Event) error {
-	data, ok := event.Data.(eventbus.SessionCreateRequestedEvent)
-	if !ok {
-		return fmt.Errorf("unexpected event data type: %T", event.Data)
-	}
-
-	sess, err := t.sessionService.GetSession(ctx, data.SessionName)
-	if err != nil {
-		slog.Warn("session not found for create event", "session", data.SessionName, "error", err)
-		return nil
-	}
-
-	cmd := exec.CommandContext(ctx, "tmux", "new-session", "-d", "-s", sess.TmuxSessionName, "-c", data.WorkspacePath)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		slog.Warn("failed to create tmux session", "session", sess.TmuxSessionName, "error", err, "output", string(output))
-	}
-
-	return nil
-}
-
-func (t *TmuxService) handleSessionDeleted(ctx context.Context, event eventbus.Event) error {
-	sess, ok := event.Data.(*session.Session)
-	if !ok {
-		return fmt.Errorf("unexpected event data type: %T", event.Data)
-	}
-
-	cmd := exec.CommandContext(ctx, "tmux", "kill-session", "-t", sess.TmuxSessionName)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		slog.Warn("failed to kill tmux session", "session", sess.TmuxSessionName, "error", err, "output", string(output))
-	}
-
-	sess.Cleanup.TmuxSessionKilled = true
-	return t.sessionService.UpdateSession(ctx, sess)
-}
-
-func (t *TmuxService) handleSessionRevived(ctx context.Context, event eventbus.Event) error {
-	data, ok := event.Data.(eventbus.SessionRevivedEvent)
-	if !ok {
-		return fmt.Errorf("unexpected event data type: %T", event.Data)
-	}
-
-	sess, err := t.sessionService.GetSession(ctx, data.SessionName)
-	if err != nil {
-		slog.Warn("session not found for revive event", "session", data.SessionName, "error", err)
-		return nil
-	}
-
-	cmd := exec.CommandContext(ctx, "tmux", "new-session", "-d", "-s", sess.TmuxSessionName, "-c", data.WorkspacePath)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		slog.Warn("failed to create tmux session", "session", sess.TmuxSessionName, "error", err, "output", string(output))
-	}
-
 	return nil
 }
 
@@ -91,79 +35,87 @@ func (t *TmuxService) OnAppEnd(ctx context.Context) error {
 	return nil
 }
 
-func (t *TmuxService) HandleSessionCreated(ctx context.Context, tmuxName string) error {
-	sess, err := t.sessionService.GetSessionByTmuxName(ctx, tmuxName)
-	if err != nil {
-		slog.Debug("session not found for session-created hook", "tmux_name", tmuxName, "error", err)
-		return nil
+func (t *TmuxService) CreateSession(name, startDir string) error {
+	opts := &gotmux.SessionOptions{
+		Name:           name,
+		StartDirectory: startDir,
 	}
-
-	sess.IsActive = true
-	sess.IsDead = false
-	return t.sessionService.UpdateSession(ctx, sess)
+	_, err := t.tmux.NewSession(opts)
+	return err
 }
 
-func (t *TmuxService) HandleSessionClosed(ctx context.Context, tmuxName string) error {
-	sess, err := t.sessionService.GetSessionByTmuxName(ctx, tmuxName)
-	if err != nil {
-		slog.Debug("session not found for session-closed hook", "tmux_name", tmuxName, "error", err)
-		return nil
-	}
-
-	sess.IsDead = true
-	sess.IsActive = false
-	sess.IsAttached = false
-	delete(t.windowsBySession, tmuxName)
-	return t.sessionService.UpdateSession(ctx, sess)
-}
-
-func (t *TmuxService) HandleClientSessionChanged(ctx context.Context, tmuxName string) error {
-	sessions, err := t.sessionService.ListSessions(ctx)
+func (t *TmuxService) KillSession(name string) error {
+	sess, err := t.tmux.GetSessionByName(name)
 	if err != nil {
 		return err
 	}
+	return sess.Kill()
+}
 
-	for _, s := range sessions {
-		if s.IsAttached {
-			s.IsAttached = false
-			if err := t.sessionService.UpdateSession(ctx, &s); err != nil {
-				return err
-			}
-		}
-	}
+func (t *TmuxService) HasSession(name string) bool {
+	return t.tmux.HasSession(name)
+}
 
-	sess, err := t.sessionService.GetSessionByTmuxName(ctx, tmuxName)
+func (t *TmuxService) ListSessionNames() ([]string, error) {
+	sessions, err := t.tmux.ListSessions()
 	if err != nil {
-		slog.Debug("session not found for client-session-changed hook", "tmux_name", tmuxName, "error", err)
-		return nil
+		return nil, err
 	}
+	names := make([]string, len(sessions))
+	for i, s := range sessions {
+		names[i] = s.Name
+	}
+	return names, nil
+}
 
-	sess.IsAttached = true
-	sess.LastUsedAt = time.Now()
-	return t.sessionService.UpdateSession(ctx, sess)
+func (t *TmuxService) SwitchClient(targetSession string) error {
+	return t.tmux.SwitchClient(&gotmux.SwitchClientOptions{
+		TargetSession: targetSession,
+	})
+}
+
+func (t *TmuxService) GetCurrentSessionName(paneID string) (string, error) {
+	output, err := t.tmux.Command("display-message", "-p", "-t", paneID, "#{session_name}")
+	if err != nil {
+		return "", err
+	}
+	return output, nil
+}
+
+func (t *TmuxService) HandleSessionCreated(ctx context.Context, tmuxName string) error {
+	return t.eventBus.Publish(ctx, eventbus.Event{
+		Type: eventbus.TmuxSessionCreated,
+		Data: eventbus.TmuxHookEvent{TmuxSessionName: tmuxName},
+	})
+}
+
+func (t *TmuxService) HandleSessionClosed(ctx context.Context, tmuxName string) error {
+	delete(t.windowsBySession, tmuxName)
+	return t.eventBus.Publish(ctx, eventbus.Event{
+		Type: eventbus.TmuxSessionClosed,
+		Data: eventbus.TmuxHookEvent{TmuxSessionName: tmuxName},
+	})
+}
+
+func (t *TmuxService) HandleClientSessionChanged(ctx context.Context, tmuxName string) error {
+	return t.eventBus.Publish(ctx, eventbus.Event{
+		Type: eventbus.TmuxClientSessionChanged,
+		Data: eventbus.TmuxHookEvent{TmuxSessionName: tmuxName},
+	})
 }
 
 func (t *TmuxService) HandleClientAttached(ctx context.Context, tmuxName string) error {
-	sess, err := t.sessionService.GetSessionByTmuxName(ctx, tmuxName)
-	if err != nil {
-		slog.Debug("session not found for client-attached hook", "tmux_name", tmuxName, "error", err)
-		return nil
-	}
-
-	sess.IsAttached = true
-	sess.LastUsedAt = time.Now()
-	return t.sessionService.UpdateSession(ctx, sess)
+	return t.eventBus.Publish(ctx, eventbus.Event{
+		Type: eventbus.TmuxClientAttached,
+		Data: eventbus.TmuxHookEvent{TmuxSessionName: tmuxName},
+	})
 }
 
 func (t *TmuxService) HandleClientDetached(ctx context.Context, tmuxName string) error {
-	sess, err := t.sessionService.GetSessionByTmuxName(ctx, tmuxName)
-	if err != nil {
-		slog.Debug("session not found for client-detached hook", "tmux_name", tmuxName, "error", err)
-		return nil
-	}
-
-	sess.IsAttached = false
-	return t.sessionService.UpdateSession(ctx, sess)
+	return t.eventBus.Publish(ctx, eventbus.Event{
+		Type: eventbus.TmuxClientDetached,
+		Data: eventbus.TmuxHookEvent{TmuxSessionName: tmuxName},
+	})
 }
 
 func (t *TmuxService) SyncWindows(ctx context.Context, tmuxName string, windows []Window) {

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"os/exec"
 	"time"
 
+	"github.com/GianlucaP106/gotmux/gotmux"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/eleonorayaya/utena/internal/claude"
 	"github.com/eleonorayaya/utena/internal/session"
@@ -388,9 +388,13 @@ func (c *client) deleteTodo(id string) tea.Cmd {
 
 func (c *client) switchTmuxSession(name string) tea.Cmd {
 	return func() tea.Msg {
-		cmd := exec.Command("tmux", "switch-client", "-t", name)
-		if output, err := cmd.CombinedOutput(); err != nil {
-			log.Printf("[ERROR] tmux switch-client failed: %v output: %s", err, string(output))
+		t, err := gotmux.DefaultTmux()
+		if err != nil {
+			log.Printf("[ERROR] gotmux init failed: %v", err)
+			return tea.Quit()
+		}
+		if err := t.SwitchClient(&gotmux.SwitchClientOptions{TargetSession: name}); err != nil {
+			log.Printf("[ERROR] tmux switch-client failed: %v", err)
 		}
 		return tea.Quit()
 	}

--- a/internal/tui/statusview/model.go
+++ b/internal/tui/statusview/model.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GianlucaP106/gotmux/gotmux"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
@@ -44,9 +45,12 @@ func New() Model {
 	paneID := os.Getenv("TMUX_PANE")
 	var currentSession string
 	if paneID != "" {
-		out, err := exec.Command("tmux", "display-message", "-p", "-t", paneID, "#{session_name}").Output()
+		t, err := gotmux.DefaultTmux()
 		if err == nil {
-			currentSession = strings.TrimSpace(string(out))
+			output, err := t.Command("display-message", "-p", "-t", paneID, "#{session_name}")
+			if err == nil {
+				currentSession = strings.TrimSpace(output)
+			}
 		}
 	}
 	return Model{


### PR DESCRIPTION
## Summary

- Reverse dependency direction: session now depends on tmux (not vice versa) via `TmuxManager` interface
- Replace all `exec.Command` tmux calls with [gotmux](https://github.com/GianlucaP106/gotmux) library across daemon and TUI
- Add startup reconciliation to detect and mark orphaned sessions as dead
- `ActivateSession` auto-revives dead/missing tmux sessions transparently
- `DeleteSession` gracefully tolerates already-gone tmux sessions
- Unify ID sanitization into single `SanitizeID` function (fixes chi router 405 on dotfile session IDs)
- Add default TUI logging to `~/Library/Logs/utena/tui.log`
- Change TUI install path to `~/.local/bin/utena`

## Test plan

- [x] All existing tests pass (`task test`)
- [x] Both binaries compile (`task daemon:build`, `task tui:build`)
- [ ] Verify daemon startup reconciliation marks orphaned sessions dead
- [ ] Verify activating a dead session auto-revives its tmux session
- [ ] Verify deleting a session with no tmux session succeeds
- [ ] Verify TUI status pane works in tmux windows
- [ ] Verify session creation/switching via TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)