### PR TITLE
fix(tui): hide help bar when status view is collapsed

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -18,7 +18,7 @@ import (
 type App struct {
 	provider provider.Provider
 	router   router.Router
-	help     help.Model
+	help     helpModel
 	width    int
 	height   int
 }
@@ -37,7 +37,7 @@ func NewApp(logPath, port string, initialView router.View) App {
 	return App{
 		provider: provider.NewRootProvider(baseURL),
 		router:   router.New(views, initialView),
-		help:     help.New(),
+		help:     newHelpModel(initialView != router.StatusView),
 	}
 }
 
@@ -56,6 +56,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	a.help = a.help.Update(msg)
+
 	var cmds []tea.Cmd
 	var cmd tea.Cmd
 	a.provider, cmd = a.provider.Update(msg)
@@ -70,7 +72,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (a App) OnWindowSizeMsg(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 	a.width = msg.Width
 	a.height = msg.Height
-	adjusted := tea.WindowSizeMsg{Width: msg.Width, Height: msg.Height - 2}
+	adjusted := tea.WindowSizeMsg{Width: msg.Width, Height: msg.Height - a.help.HeightCost()}
 	var cmd tea.Cmd
 	a.router, cmd = a.router.Update(adjusted)
 	return a, cmd

--- a/internal/tui/helpmodel.go
+++ b/internal/tui/helpmodel.go
@@ -1,0 +1,41 @@
+package tui
+
+import (
+	"github.com/charmbracelet/bubbles/help"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/eleonorayaya/utena/internal/tui/router"
+)
+
+type helpModel struct {
+	inner   help.Model
+	visible bool
+}
+
+func newHelpModel(visible bool) helpModel {
+	return helpModel{
+		inner:   help.New(),
+		visible: visible,
+	}
+}
+
+func (h helpModel) Update(msg tea.Msg) helpModel {
+	switch msg := msg.(type) {
+	case router.SetHelpVisibleMsg:
+		h.visible = msg.Visible
+	}
+	return h
+}
+
+func (h helpModel) View(keymap help.KeyMap) string {
+	if !h.visible {
+		return ""
+	}
+	return h.inner.View(keymap)
+}
+
+func (h helpModel) HeightCost() int {
+	if !h.visible {
+		return 0
+	}
+	return 2
+}

--- a/internal/tui/router/messages.go
+++ b/internal/tui/router/messages.go
@@ -13,3 +13,9 @@ func NavigateTo(target View) tea.Cmd {
 func Back() tea.Cmd {
 	return func() tea.Msg { return BackMsg{} }
 }
+
+type SetHelpVisibleMsg struct{ Visible bool }
+
+func SetHelpVisible(visible bool) tea.Cmd {
+	return func() tea.Msg { return SetHelpVisibleMsg{Visible: visible} }
+}

--- a/internal/tui/statusview/model.go
+++ b/internal/tui/statusview/model.go
@@ -3,7 +3,6 @@ package statusview
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -98,6 +97,12 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		if m.currentTmuxSession != "" {
 			cmds = append(cmds, provider.FetchWindows(m.currentTmuxSession))
 		}
+		if m.paneID != "" {
+			cmd := m.syncFocusState()
+			if cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
 		return m, tea.Batch(cmds...)
 
 	case provider.SessionsStateUpdatedMsg:
@@ -108,18 +113,6 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case provider.WindowsStateUpdatedMsg:
 		m.windows = msg.Windows
 		return m, nil
-
-	case tea.FocusMsg:
-		m.expanded = true
-		return m, router.SetHelpVisible(true)
-
-	case tea.BlurMsg:
-		m.expanded = false
-		if m.paneID != "" {
-			exec.Command("tmux", "resize-pane", "-y", "1", "-t", m.paneID).Run()
-			exec.Command("tmux", "select-pane", "-d", "-t", m.paneID).Run()
-		}
-		return m, router.SetHelpVisible(false)
 
 	case tea.KeyMsg:
 		if m.expanded {
@@ -151,13 +144,44 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 		return m, nil
 	case key.Matches(msg, keys.Collapse):
 		m.expanded = false
-		if m.paneID != "" {
-			exec.Command("tmux", "resize-pane", "-y", "1", "-t", m.paneID).Run()
-			exec.Command("tmux", "select-pane", "-d", "-t", m.paneID).Run()
-		}
+		m.collapsePane()
 		return m, router.SetHelpVisible(false)
 	}
 	return m, nil
+}
+
+func (m *Model) syncFocusState() tea.Cmd {
+	t, err := gotmux.DefaultTmux()
+	if err != nil {
+		return nil
+	}
+	output, err := t.Command("display-message", "-p", "-t", m.paneID, "#{pane_active}")
+	if err != nil {
+		return nil
+	}
+	active := strings.TrimSpace(output) == "1"
+	if active && !m.expanded {
+		m.expanded = true
+		return router.SetHelpVisible(true)
+	}
+	if !active && m.expanded {
+		m.expanded = false
+		m.collapsePane()
+		return router.SetHelpVisible(false)
+	}
+	return nil
+}
+
+func (m Model) collapsePane() {
+	if m.paneID == "" {
+		return
+	}
+	t, err := gotmux.DefaultTmux()
+	if err != nil {
+		return
+	}
+	t.Command("resize-pane", "-y", "1", "-t", m.paneID)
+	t.Command("select-pane", "-d", "-t", m.paneID)
 }
 
 func (m Model) activeSessions() []session.Session {

--- a/internal/tui/statusview/model.go
+++ b/internal/tui/statusview/model.go
@@ -16,6 +16,7 @@ import (
 	"github.com/eleonorayaya/utena/internal/session"
 	"github.com/eleonorayaya/utena/internal/tmux"
 	"github.com/eleonorayaya/utena/internal/tui/provider"
+	"github.com/eleonorayaya/utena/internal/tui/router"
 )
 
 var (
@@ -67,6 +68,9 @@ func (m Model) Init() (Model, tea.Cmd) {
 	if m.currentTmuxSession != "" {
 		cmds = append(cmds, provider.FetchWindows(m.currentTmuxSession))
 	}
+	if !m.expanded {
+		cmds = append(cmds, router.SetHelpVisible(false))
+	}
 	return m, tea.Batch(cmds...)
 }
 
@@ -107,7 +111,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 	case tea.FocusMsg:
 		m.expanded = true
-		return m, nil
+		return m, router.SetHelpVisible(true)
 
 	case tea.BlurMsg:
 		m.expanded = false
@@ -115,7 +119,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			exec.Command("tmux", "resize-pane", "-y", "1", "-t", m.paneID).Run()
 			exec.Command("tmux", "select-pane", "-d", "-t", m.paneID).Run()
 		}
-		return m, nil
+		return m, router.SetHelpVisible(false)
 
 	case tea.KeyMsg:
 		if m.expanded {
@@ -151,7 +155,7 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 			exec.Command("tmux", "resize-pane", "-y", "1", "-t", m.paneID).Run()
 			exec.Command("tmux", "select-pane", "-d", "-t", m.paneID).Run()
 		}
-		return m, nil
+		return m, router.SetHelpVisible(false)
 	}
 	return m, nil
 }
@@ -229,9 +233,6 @@ func (m Model) expandedView() string {
 		}
 		lines = append(lines, entry)
 	}
-
-	helpLine := dimStyle.Render("j/k navigate · enter switch · esc collapse")
-	lines = append(lines, helpLine)
 
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
The app-level help.Model always rendered below view content, overflowing the 1-line tmux status pane. Wrap it in a toggleable helpModel that hides when the status view collapses and shows when it expands.