### PR TITLE
fix(tmux): auto-close status pane when last in window

### DIFF
--- a/plugins/utena-tmux/scripts/cleanup-status-pane.sh
+++ b/plugins/utena-tmux/scripts/cleanup-status-pane.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+WINDOW_ID="${1:-}"
+
+if [ -z "$WINDOW_ID" ]; then
+    exit 0
+fi
+
+PANES=$(tmux list-panes -t "$WINDOW_ID" -F '#{pane_id} #{@utena-status}' 2>/dev/null)
+if [ -z "$PANES" ]; then
+    exit 0
+fi
+
+PANE_COUNT=$(echo "$PANES" | wc -l | tr -d ' ')
+if [ "$PANE_COUNT" -eq 1 ]; then
+    STATUS_PANE=$(echo "$PANES" | grep ' 1$' | awk '{print $1}')
+    if [ -n "$STATUS_PANE" ]; then
+        tmux kill-pane -t "$STATUS_PANE"
+    fi
+fi

--- a/plugins/utena-tmux/utena.tmux
+++ b/plugins/utena-tmux/utena.tmux
@@ -13,6 +13,7 @@ tmux set-hook -g client-session-changed "run-shell '${script_dir}/hook.sh client
 tmux set-hook -g client-attached "run-shell '${script_dir}/hook.sh client-attached \"#{session_name}\"'"
 tmux set-hook -g client-detached "run-shell '${script_dir}/hook.sh client-detached \"#{session_name}\"'"
 
+tmux set-hook -g pane-exited "run-shell '${script_dir}/cleanup-status-pane.sh \"#{window_id}\"'"
 tmux set-hook -g after-new-window "run-shell '${script_dir}/sync-windows.sh \"#{session_name}\"' ; run-shell '${script_dir}/status-pane.sh \"#{session_name}\" \"#{window_id}\"'"
 tmux set-hook -g window-renamed "run-shell '${script_dir}/sync-windows.sh \"#{session_name}\"'"
 tmux set-hook -g after-kill-window "run-shell '${script_dir}/sync-windows.sh \"#{session_name}\"'"


### PR DESCRIPTION
## Summary
- Adds a `pane-exited` tmux hook that checks if the status pane is the only remaining pane in a window
- If so, kills the status pane so the window closes cleanly instead of leaving an orphaned status bar

## Test plan
- [ ] Close all non-status panes in a window — window should close automatically
- [ ] Close one of multiple panes — status pane and window should remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)