### PR TITLE
fix(tmux): prevent duplicate status panes from race condition

### DIFF
--- a/plugins/utena-tmux/scripts/status-pane.sh
+++ b/plugins/utena-tmux/scripts/status-pane.sh
@@ -6,6 +6,12 @@ if [ -z "$SESSION_NAME" ] || [ -z "$WINDOW_ID" ]; then
     exit 0
 fi
 
+LOCK_DIR="/tmp/utena-status-pane-${WINDOW_ID}.lock"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    exit 0
+fi
+trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT
+
 existing=$(tmux list-panes -t "$WINDOW_ID" -F '#{pane_id} #{@utena-status}' 2>/dev/null | grep ' 1$' | head -1 | awk '{print $1}')
 if [ -n "$existing" ]; then
     exit 0

--- a/plugins/utena-tmux/scripts/toggle-status.sh
+++ b/plugins/utena-tmux/scripts/toggle-status.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
-STATUS_PANE=$(tmux list-panes -F '#{pane_id} #{pane_height} #{@utena-status}' 2>/dev/null | grep ' 1$' | head -1)
+STATUS_PANES=$(tmux list-panes -F '#{pane_id} #{pane_height} #{@utena-status}' 2>/dev/null | grep ' 1$')
 
-if [ -z "$STATUS_PANE" ]; then
+if [ -z "$STATUS_PANES" ]; then
     exit 0
 fi
 
-PANE_ID=$(echo "$STATUS_PANE" | awk '{print $1}')
-PANE_HEIGHT=$(echo "$STATUS_PANE" | awk '{print $2}')
+FIRST_PANE=$(echo "$STATUS_PANES" | head -1)
+PANE_ID=$(echo "$FIRST_PANE" | awk '{print $1}')
+PANE_HEIGHT=$(echo "$FIRST_PANE" | awk '{print $2}')
+
+echo "$STATUS_PANES" | tail -n +2 | while read -r line; do
+    extra_id=$(echo "$line" | awk '{print $1}')
+    tmux kill-pane -t "$extra_id" 2>/dev/null
+done
 
 if [ "$PANE_HEIGHT" -le 1 ]; then
     tmux resize-pane -t "$PANE_ID" -y 8


### PR DESCRIPTION
## Summary
- When a new session is created, both `session-created` and `after-new-window` hooks call `status-pane.sh` for the same window concurrently, racing past the existing-pane check and creating duplicate status panes
- Added `mkdir`-based atomic locking to `status-pane.sh` so only one concurrent invocation can proceed per window
- Added dedup cleanup to `toggle-status.sh` to kill extra status panes if any already exist

## Test plan
- [ ] Create a new tmux session and verify only one status pane appears
- [ ] Press `prefix + s` to toggle — should expand/collapse without creating a second pane
- [ ] Reload the plugin (`tmux source ~/.tmux.conf`) and verify no duplicate panes

🤖 Generated with [Claude Code](https://claude.com/claude-code)