### PR TITLE
fix(tui): reduce status bar polling interval to 100ms

### DIFF
--- a/internal/tui/statusview/model.go
+++ b/internal/tui/statusview/model.go
@@ -78,7 +78,7 @@ func (m Model) Keys() help.KeyMap {
 }
 
 func tick() tea.Cmd {
-	return tea.Tick(2*time.Second, func(t time.Time) tea.Msg {
+	return tea.Tick(100*time.Millisecond, func(t time.Time) tea.Msg {
 		return tickMsg(t)
 	})
 }


### PR DESCRIPTION
## Summary
- Reduces the status bar polling interval from 2 seconds to 100ms to minimize update latency

## Test plan
- [ ] Run `task tui:run` and verify the status bar updates reflect changes within ~100ms
- [ ] Monitor CPU usage to ensure the faster polling doesn't cause excessive overhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)