### PR TITLE
feat: robust async session creation with progress tracking

### DIFF
--- a/.claude/plans/atomic-launching-harp.md
+++ b/.claude/plans/atomic-launching-harp.md
@@ -1,0 +1,51 @@
+# Plan: Add "Never Swallow Errors" guidance to go-patterns skill
+
+## Context
+
+User wants to codify the rule that errors must never be silently swallowed. The `error-handling.md` file in the go-patterns skill is the right place — it already covers error definition patterns and controller-level handling but lacks this fundamental principle.
+
+## Change
+
+**File**: `.claude/skills/go-patterns/error-handling.md`
+
+Add a new section `## Never Swallow Errors` immediately after line 1 (before "## Sentinel Errors"), establishing it as the first and most fundamental rule.
+
+Content to add:
+
+```markdown
+## Never Swallow Errors
+
+Every error must be explicitly handled -- never discard with `_` or ignore a return value.
+
+```go
+// Wrong: silently swallowed
+result, _ := doSomething()
+doSomething() // ignoring error return
+
+// Correct: always handle
+result, err := doSomething()
+if err != nil {
+	return fmt.Errorf("doing something: %w", err)
+}
+```
+
+Logging an error and returning nil is also swallowing -- the caller loses the ability to react. Never do this unless the user explicitly asks for it.
+
+```go
+// Wrong: swallowed via log-and-discard
+if err != nil {
+	log.Printf("failed: %v", err)
+	return nil // caller has no idea something failed
+}
+
+// Correct: propagate the error
+if err != nil {
+	return fmt.Errorf("doing something: %w", err)
+}
+```
+```
+
+## Verification
+
+- Read the modified file to confirm the section is properly placed and formatted
+- Confirm the skill index (`go-patterns` main file) already references `error-handling.md` for error handling guidance (it does)

--- a/.claude/plans/lovely-gathering-stearns.md
+++ b/.claude/plans/lovely-gathering-stearns.md
@@ -1,0 +1,291 @@
+# Robust Async Session Creation
+
+## Context
+
+Session creation sometimes fails (likely git pull timeout on large repos), leaving the session in a partial state — worktree created but no tmux session. The current synchronous flow blocks the TUI until all steps complete (or fail), and there's no way to recover from the failed step.
+
+The goal is to make session creation async with step-by-step progress tracking, error capture, and repair support. Also consolidate the data model — remove redundant fields, unify status tracking, and merge the concepts of "dead" and "failed" sessions into a single "broken" status.
+
+## Data Model Changes
+
+### Simplified Session struct
+
+**`internal/session/session.go`**
+
+Remove these fields:
+- `IsActive`, `IsDead`, `IsDeleted` → replaced by `Status`
+- `BranchName` → redundant with `Branch` (the prefix is applied during creation and stored in `Branch`)
+- `WorkspaceName` → resolved on-the-fly via `resolveWorkspaceName()` already, no need to persist
+- `Cleanup` → replaced by `Resources` (unified tracking)
+
+```go
+type SessionStatus string
+
+const (
+    StatusCreating SessionStatus = "creating"
+    StatusReady    SessionStatus = "ready"
+    StatusBroken   SessionStatus = "broken"
+    StatusDeleted  SessionStatus = "deleted"
+)
+
+type ResourceStatus string
+
+const (
+    ResourcePending  ResourceStatus = "pending"
+    ResourceCreating ResourceStatus = "creating"
+    ResourceReady    ResourceStatus = "ready"
+    ResourceFailed   ResourceStatus = "failed"
+    ResourceRemoved  ResourceStatus = "removed"
+)
+
+type ResourceState struct {
+    Status ResourceStatus `json:"status"`
+    Error  string         `json:"error,omitempty"`
+}
+
+type Resources struct {
+    Branch   *ResourceState `json:"branch,omitempty"`
+    Worktree *ResourceState `json:"worktree,omitempty"`
+    Tmux     *ResourceState `json:"tmux,omitempty"`
+}
+
+type Session struct {
+    ID              string        `json:"id"`
+    TmuxSessionName string        `json:"tmux_session_name,omitempty"`
+    Name            string        `json:"name,omitempty"`
+    WorkspaceID     string        `json:"workspace_id"`
+    Branch          string        `json:"branch,omitempty"`
+    BaseBranch      string        `json:"base_branch,omitempty"`
+    BranchCreated   bool          `json:"branch_created,omitempty"`
+    WorktreePath    string        `json:"worktree_path,omitempty"`
+    Status          SessionStatus `json:"status"`
+    Resources       *Resources    `json:"resources,omitempty"`
+    IsAttached      bool          `json:"is_attached"`
+    LastUsedAt      time.Time     `json:"last_used_at"`
+}
+```
+
+### Resource lifecycle
+
+**During creation** (async goroutine):
+- Branch: `pending` → `creating` (git pull) → `ready`
+- Worktree: `pending` → `creating` (git worktree add) → `ready`
+- Tmux: `pending` → `creating` → `ready`
+- Any failure: resource goes to `failed` with error, session Status=Broken
+
+**During deletion** (synchronous, same as today):
+- Worktree: `ready` → `removed`
+- Branch: `ready` → `removed` (if deleteBranch=true)
+- Tmux: `ready` → `removed`
+- Session Status=Deleted
+
+**During repair** (unified operation — single `RepairSession` method, replaces both `RetrySession` and `ReviveSession`):
+- Find resources that aren't `ready`, recreate them
+- Already-`ready` resources are skipped
+- Session goes Creating → Ready (or Broken again if repair fails)
+
+**Tmux killed externally** (reconciliation / hooks):
+- Set Tmux resource status to Removed, session Status=Broken
+
+Resources is always populated and persisted on the session. It serves as the persistent truth about what resources exist for a session, enabling future async refresh/reconciliation of resource state.
+
+### Migration
+
+`sessionstore.go` `OnAppStart` backfills existing sessions with no `Status`:
+- `IsDeleted=true` → `StatusDeleted`
+- `IsDead=true` → `StatusBroken` (with Tmux resource = Removed)
+- default → `StatusReady`
+- Copy `BranchName` → `Branch` if Branch is empty
+- Build Resources from existing fields (WorktreePath, Branch, TmuxSessionName)
+- Drop old fields from JSON on next save
+
+### Error sentinels
+
+Replace `ErrSessionNotDead`, `ErrSessionDead` with:
+- `ErrSessionNotBroken` (for repair on non-broken session)
+- `ErrCannotActivate` (for activating creating/broken session)
+
+## Service Layer Changes
+
+### `internal/session/sessionservice.go`
+
+**`CreateSession` becomes two parts:**
+
+1. **Synchronous** (HTTP request): validate, compute ID, build initial Resources with pending states, store session with Status=Creating, return immediately.
+
+2. **Async** (goroutine via `runSetup`): execute steps sequentially, updating resource status before/after each. On success → Status=Ready. On failure → Status=Broken with failed resource error.
+
+```
+CreateSession(ctx, session, createWorktree):
+  1. Validate workspace, compute ID (same as today)
+  2. Build Resources based on what's needed:
+     - If git repo + createWorktree: Branch={Pending}, Worktree={Pending}, Tmux={Pending}
+     - Otherwise: Tmux={Pending}
+  3. Set Status=Creating, LastUsedAt=now
+  4. store.Add(session)
+  5. Touch workspace
+  6. go runSetup(session.ID, ws, createWorktree)
+  7. Return session immediately
+
+runSetup(sessionID, ws, createWorktree):
+  Only acts on resources that are not Ready (already filtered by RefreshSession
+  during repair, or set to Pending during initial creation).
+
+  1. Load session from store
+  2. If Branch resource exists and not Ready:
+     a. Branch → Creating, store.Update
+     b. git pull
+     c. Branch → Ready, store.Update
+  3. If Worktree resource exists and not Ready:
+     a. Worktree → Creating, store.Update
+     b. git worktree add (sets session.WorktreePath, session.Branch)
+     c. Worktree → Ready, store.Update
+  4. If Tmux resource not Ready:
+     a. Tmux → Creating, store.Update
+     b. tmuxManager.CreateSession
+     c. Tmux → Ready, store.Update
+  5. Status=Ready, store.Update
+
+  On any error:
+     - Set resource to Failed with error message
+     - Set session Status=Broken
+     - store.Update, return
+```
+
+**`RefreshSession(ctx, id)` — standalone method, checks actual state of each resource:**
+```
+RefreshSession(ctx, id):
+  1. Load session from store
+  2. For each resource in session.Resources:
+     - Branch: skip refresh (no cheap way to verify pull status; best-effort)
+     - Worktree: os.Stat(session.WorktreePath) — exists? Ready : Removed
+     - Tmux: tmuxManager.HasSession(name) — exists? Ready : Removed
+  3. Derive session Status from resource states:
+     - All applicable resources Ready → StatusReady
+     - Any resource Failed/Removed/Pending → StatusBroken
+  4. store.Update, return session
+```
+This is independently callable — can be invoked by an API endpoint, reconciliation, or future async refresh without triggering repair.
+
+**`RepairSession` (replaces both `RetrySession` and `ReviveSession`):**
+```
+RepairSession(ctx, id):
+  1. Call RefreshSession(ctx, id) to get up-to-date resource state
+  2. Verify Status=Broken (after refresh). If already Ready, return early.
+  3. Set Status=Creating, clear errors on non-ready resources
+  4. store.Update
+  5. go runSetup(session.ID, ...) — only acts on non-ready resources
+  6. Return session
+```
+
+**`BranchName` consolidation in CreateSession:**
+Currently does `branchName := s.branchPrefix + session.Name` then sets both `BranchName` and `Branch`. Change to just set `Branch` directly.
+
+**Update existing methods for new status model:**
+
+- `ActivateSession`: reject if Status is Creating or Broken. If Broken, return error telling user to repair first.
+- Remove `ReviveSession` — replaced by `RepairSession`.
+- `DeleteSession`: reject if Status=Creating. Update Resources to track what was removed. Set Status=Deleted.
+- `reconcileTmuxState`: call `RefreshSession` for each non-deleted session to reconcile actual state.
+- Event handlers: update Status instead of boolean flags.
+  - `handleTmuxSessionCreated`: call `RefreshSession` to update resource state
+  - `handleTmuxSessionClosed`: call `RefreshSession` to update resource state
+  - Attached/detached handlers: update IsAttached only (unchanged logic)
+
+**`resolveWorkspaceName`**: keep as-is — it already resolves on read. Just remove `WorkspaceName` from the stored struct. Add it as a response-only field in `SessionResponse`.
+
+## API Changes
+
+### `internal/session/sessioncontroller.go` + `sessionrouter.go`
+
+**New endpoint**: `PUT /sessions/{id}/repair` → `RepairSession`
+- Returns 200 with session (status=creating)
+- Returns 400 if session is not in broken state
+
+**Remove endpoint**: `PUT /sessions/{name}/revive` — replaced by repair
+
+**Existing endpoints:**
+- `POST /sessions`: returns 202 Accepted with session in `creating` status
+- `GET /sessions/{id}`: now includes `status` and `resources` fields
+
+### `internal/session/types.go`
+
+Remove `ReviveResult`. `SessionResponse` adds `WorkspaceName` as a response-only field (resolved by controller, not persisted):
+```go
+type SessionResponse struct {
+    *Session
+    WorkspaceName string `json:"workspace_name,omitempty"`
+    WorkspacePath string `json:"workspace_path,omitempty"`
+}
+```
+
+## TUI Changes
+
+### Post-creation flow (`internal/tui/provider/sessionsprovider.go`)
+
+**Current**: create → activate → switch tmux → quit
+**New**: create → navigate to session list → poll until ready → auto-activate → switch → quit
+
+Add `pendingSessionID` field to `sessionsProvider`. When set, each `sessionsLoadedMsg` checks the pending session's status:
+- Ready → emit `activateSessionMsg` → switch tmux → quit
+- Broken → emit `ErrMsg` with the error, clear pendingSessionID
+- Creating → continue polling (already happening via status view 100ms ticks)
+
+### Session list display (`internal/tui/sessionlist/sessionitem.go`)
+
+Update `Title()`:
+- `StatusCreating` → `"(creating...)"`
+- `StatusBroken` → `"(broken)"`
+
+### Session list keys (`internal/tui/sessionlist/sessionlist.go`)
+
+Update `rebuildItems`: skip `StatusDeleted` instead of `IsDeleted`. Show broken sessions based on `showDead` flag (rename to `showBroken`).
+
+Update select key handler:
+- `StatusCreating` → status message "session is still being created"
+- `StatusBroken` → show error from `Resources` as status message (e.g. "broken: timeout pulling branch main"). User must press Enter again to repair — this gives them a chance to fix the underlying issue first.
+- `StatusReady` → activate (unchanged)
+
+Track `pendingRepairID` — when a broken session is selected once, show the error. When selected a second time (same session), trigger `provider.RepairSession(id)` (similar to the double-press-to-delete pattern already used for `pendingDeleteID`).
+
+### Client (`internal/tui/provider/client.go`)
+
+Add `repairSession(id)` method: `PUT /sessions/{id}/repair`.
+Remove `reviveSession(id)` method.
+
+### Provider (`internal/tui/provider/sessionsprovider.go`)
+
+Replace `ReviveSession` command with `RepairSession`.
+Remove `reviveSessionIntentMsg` and `sessionRevivedMsg`, add `repairSessionIntentMsg`.
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `internal/session/session.go` | New types, remove old booleans/BranchName/WorkspaceName/Cleanup, update errors |
+| `internal/session/sessionservice.go` | Async CreateSession, runSetup, RepairSession, remove ReviveSession, update all status refs |
+| `internal/session/sessioncontroller.go` | Repair endpoint, remove revive endpoint, resolve WorkspaceName in responses, 202 status |
+| `internal/session/sessionrouter.go` | Add repair route, remove revive route |
+| `internal/session/sessionstore.go` | Backfill migration in OnAppStart |
+| `internal/session/types.go` | WorkspaceName in SessionResponse, remove ReviveResult |
+| `internal/tui/provider/sessionsprovider.go` | pendingSessionID polling, RepairSession cmd, remove ReviveSession |
+| `internal/tui/provider/client.go` | repairSession method, remove reviveSession |
+| `internal/tui/sessionlist/sessionlist.go` | Update filters and key handlers, showBroken, pendingRepairID |
+| `internal/tui/sessionlist/sessionitem.go` | Update Title() for new statuses |
+
+## Implementation Order
+
+1. **Session model** — new types, remove old fields, migration logic
+2. **Session service** — async creation, runSetup, RepairSession, remove ReviveSession, update all methods
+3. **Session controller + router** — repair endpoint, remove revive, response updates
+4. **TUI provider** — polling, repair command, client method
+5. **TUI session list** — display, key handlers
+
+## Verification
+
+1. `task build` — compiles cleanly
+2. `task test` — tests pass (update tests for new model)
+3. Manual: create session → appears as "creating..." → transitions to ready → auto-switches
+4. Manual: simulate failure (bad branch) → shows "broken" → repair succeeds
+5. Manual: kill tmux session externally → shows "broken" → repair recreates tmux
+6. Manual: restart daemon with old sessions.json → migration works

--- a/.claude/skills/go-patterns/error-handling.md
+++ b/.claude/skills/go-patterns/error-handling.md
@@ -1,5 +1,36 @@
 # Error Handling Patterns
 
+## Never Swallow Errors
+
+Every error must be explicitly handled -- never discard with `_` or ignore a return value.
+
+```go
+// Wrong: silently swallowed
+result, _ := doSomething()
+doSomething() // ignoring error return
+
+// Correct: always handle
+result, err := doSomething()
+if err != nil {
+	return fmt.Errorf("doing something: %w", err)
+}
+```
+
+Logging an error and returning nil is also swallowing -- the caller loses the ability to react. Never do this unless the user explicitly asks for it.
+
+```go
+// Wrong: swallowed via log-and-discard
+if err != nil {
+	log.Printf("failed: %v", err)
+	return nil // caller has no idea something failed
+}
+
+// Correct: propagate the error
+if err != nil {
+	return fmt.Errorf("doing something: %w", err)
+}
+```
+
 Choose between two patterns based on whether the error needs to carry context.
 
 ## Sentinel Errors: errors.Is

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -28,7 +28,50 @@ func NewApp(cfg Config) *App {
 }
 
 func NewTestApp(cfg Config) *App {
-	return newApp(afero.NewMemMapFs(), cfg)
+	return newTestApp(afero.NewMemMapFs(), cfg)
+}
+
+func newTestApp(fs afero.Fs, cfg Config) *App {
+	bus := eventbus.NewEventBus()
+
+	workspaceModule := workspace.NewWorkspaceModule(fs, cfg.ConfigDir)
+	tmuxModule := tmux.NewTmuxModule(bus)
+	mockTmux := &noopTmuxManager{sessions: make(map[string]bool)}
+	sessionModule := session.NewSessionModule(mockTmux, workspaceModule, bus, fs, cfg.ConfigDir, cfg.BranchPrefix)
+
+	return &App{
+		Workspace: workspaceModule,
+		Session:   sessionModule,
+		Tmux:      tmuxModule,
+		Claude:    claude.NewClaudeModule(bus, fs, cfg.ConfigDir),
+		Todo:      todo.NewTodoModule(workspaceModule, fs, cfg.ConfigDir),
+	}
+}
+
+type noopTmuxManager struct {
+	sessions map[string]bool
+}
+
+func (m *noopTmuxManager) CreateSession(name, startDir string) error {
+	m.sessions[name] = true
+	return nil
+}
+
+func (m *noopTmuxManager) KillSession(name string) error {
+	delete(m.sessions, name)
+	return nil
+}
+
+func (m *noopTmuxManager) HasSession(name string) bool {
+	return m.sessions[name]
+}
+
+func (m *noopTmuxManager) ListSessionNames() ([]string, error) {
+	names := make([]string, 0, len(m.sessions))
+	for name := range m.sessions {
+		names = append(names, name)
+	}
+	return names, nil
 }
 
 func newApp(fs afero.Fs, cfg Config) *App {

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -27,17 +27,13 @@ func NewApp(cfg Config) *App {
 	return newApp(afero.NewOsFs(), cfg)
 }
 
-func NewTestApp(cfg Config) *App {
-	return newTestApp(afero.NewMemMapFs(), cfg)
-}
-
-func newTestApp(fs afero.Fs, cfg Config) *App {
+func NewTestApp(cfg Config, tmuxManager session.TmuxManager) *App {
+	fs := afero.NewMemMapFs()
 	bus := eventbus.NewEventBus()
 
 	workspaceModule := workspace.NewWorkspaceModule(fs, cfg.ConfigDir)
 	tmuxModule := tmux.NewTmuxModule(bus)
-	mockTmux := &noopTmuxManager{sessions: make(map[string]bool)}
-	sessionModule := session.NewSessionModule(mockTmux, workspaceModule, bus, fs, cfg.ConfigDir, cfg.BranchPrefix)
+	sessionModule := session.NewSessionModule(tmuxManager, workspaceModule, bus, fs, cfg.ConfigDir, cfg.BranchPrefix)
 
 	return &App{
 		Workspace: workspaceModule,
@@ -46,32 +42,6 @@ func newTestApp(fs afero.Fs, cfg Config) *App {
 		Claude:    claude.NewClaudeModule(bus, fs, cfg.ConfigDir),
 		Todo:      todo.NewTodoModule(workspaceModule, fs, cfg.ConfigDir),
 	}
-}
-
-type noopTmuxManager struct {
-	sessions map[string]bool
-}
-
-func (m *noopTmuxManager) CreateSession(name, startDir string) error {
-	m.sessions[name] = true
-	return nil
-}
-
-func (m *noopTmuxManager) KillSession(name string) error {
-	delete(m.sessions, name)
-	return nil
-}
-
-func (m *noopTmuxManager) HasSession(name string) bool {
-	return m.sessions[name]
-}
-
-func (m *noopTmuxManager) ListSessionNames() ([]string, error) {
-	names := make([]string, 0, len(m.sessions))
-	for name := range m.sessions {
-		names = append(names, name)
-	}
-	return names, nil
 }
 
 func newApp(fs afero.Fs, cfg Config) *App {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/eleonorayaya/utena/internal/session"
 	"github.com/eleonorayaya/utena/internal/workspace"
@@ -31,6 +32,24 @@ func setupTestRouter(t *testing.T) (*App, chi.Router) {
 	return app, server.Handler.(*chi.Mux)
 }
 
+func waitForSessionStatus(t *testing.T, router chi.Router, id string, status session.SessionStatus, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		req := httptest.NewRequest("GET", "/sessions/"+id, nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code == http.StatusOK {
+			var resp session.SessionResponse
+			if json.Unmarshal(w.Body.Bytes(), &resp) == nil && resp.Status == status {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("session %q did not reach status %q within %v", id, status, timeout)
+}
+
 func TestDaemon_ListWorkspaces(t *testing.T) {
 	_, router := setupTestRouter(t)
 
@@ -46,7 +65,6 @@ func TestDaemon_ListWorkspaces(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, response.Workspaces, 2)
 
-	// Verify hard-coded workspaces
 	ids := make(map[string]bool)
 	for _, ws := range response.Workspaces {
 		ids[ws.ID] = true
@@ -83,13 +101,16 @@ func TestDaemon_CreateAndGetSession(t *testing.T) {
 
 	router.ServeHTTP(w, req)
 
-	require.Equal(t, http.StatusCreated, w.Code)
+	require.Equal(t, http.StatusAccepted, w.Code)
 
 	var createResp session.SessionResponse
 	err := json.Unmarshal(w.Body.Bytes(), &createResp)
 	require.NoError(t, err)
 	require.Equal(t, "utena-test-session-1", createResp.ID)
 	require.Equal(t, "test-session-1", createResp.Name)
+	require.Equal(t, session.StatusCreating, createResp.Status)
+
+	waitForSessionStatus(t, router, "utena-test-session-1", session.StatusReady, 2*time.Second)
 
 	req = httptest.NewRequest("GET", "/sessions/utena-test-session-1", nil)
 	w = httptest.NewRecorder()
@@ -119,8 +140,11 @@ func TestDaemon_ListSessions(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		router.ServeHTTP(w, req)
-		require.Equal(t, http.StatusCreated, w.Code)
+		require.Equal(t, http.StatusAccepted, w.Code)
 	}
+
+	waitForSessionStatus(t, router, "utena-session-1", session.StatusReady, 2*time.Second)
+	waitForSessionStatus(t, router, "other-session-2", session.StatusReady, 2*time.Second)
 
 	req := httptest.NewRequest("GET", "/sessions", nil)
 	w := httptest.NewRecorder()
@@ -150,7 +174,9 @@ func TestDaemon_TmuxHookSessionCreated(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
+	require.Equal(t, http.StatusAccepted, w.Code)
+
+	waitForSessionStatus(t, router, "utena-test-session", session.StatusReady, 2*time.Second)
 
 	hookBody := []byte(`{"session_name":"utena-test-session"}`)
 	req = httptest.NewRequest("PUT", "/tmux/hooks/session-created", bytes.NewReader(hookBody))
@@ -175,8 +201,7 @@ func TestDaemon_TmuxHookSessionCreated(t *testing.T) {
 
 	sess := findSessionByID(sessionsResponse.Sessions, "utena-test-session")
 	require.NotNil(t, sess)
-	require.True(t, sess.IsActive)
-	require.False(t, sess.IsDead)
+	require.Equal(t, session.StatusReady, sess.Status)
 }
 
 func findSessionByID(sessions []session.Session, id string) *session.Session {
@@ -196,7 +221,9 @@ func TestDaemon_TmuxHookSessionClosed(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
+	require.Equal(t, http.StatusAccepted, w.Code)
+
+	waitForSessionStatus(t, router, "utena-test-session", session.StatusReady, 2*time.Second)
 
 	hookBody := []byte(`{"session_name":"utena-test-session"}`)
 	req = httptest.NewRequest("PUT", "/tmux/hooks/session-closed", bytes.NewReader(hookBody))
@@ -216,7 +243,6 @@ func TestDaemon_TmuxHookSessionClosed(t *testing.T) {
 
 	sess := findSessionByID(sessionsResponse.Sessions, "utena-test-session")
 	require.NotNil(t, sess)
-	require.True(t, sess.IsDead)
-	require.False(t, sess.IsActive)
+	require.Equal(t, session.StatusBroken, sess.Status)
 	require.False(t, sess.IsAttached)
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,11 +17,61 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupTestRouter(t *testing.T) (*App, chi.Router) {
+type testTmuxManager struct {
+	mu        sync.Mutex
+	sessions  map[string]bool
+	createErr error
+}
+
+func newTestTmuxManager() *testTmuxManager {
+	return &testTmuxManager{sessions: make(map[string]bool)}
+}
+
+func (m *testTmuxManager) CreateSession(name, startDir string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.sessions[name] = true
+	return nil
+}
+
+func (m *testTmuxManager) KillSession(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.sessions, name)
+	return nil
+}
+
+func (m *testTmuxManager) HasSession(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.sessions[name]
+}
+
+func (m *testTmuxManager) ListSessionNames() ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	names := make([]string, 0, len(m.sessions))
+	for name := range m.sessions {
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func (m *testTmuxManager) setCreateErr(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createErr = err
+}
+
+func setupTestRouter(t *testing.T) (*App, chi.Router, *testTmuxManager) {
 	t.Helper()
 
 	cfg := Config{ConfigDir: "/config"}
-	app := NewTestApp(cfg)
+	tmux := newTestTmuxManager()
+	app := NewTestApp(cfg, tmux)
 
 	app.Workspace.Store.Add(&workspace.Workspace{ID: "ws-1", Name: "utena", Path: "/tmp/utena"})
 	app.Workspace.Store.Add(&workspace.Workspace{ID: "ws-2", Name: "other", Path: "/tmp/other"})
@@ -29,7 +81,7 @@ func setupTestRouter(t *testing.T) (*App, chi.Router) {
 
 	server := BuildServer(app, cfg)
 
-	return app, server.Handler.(*chi.Mux)
+	return app, server.Handler.(*chi.Mux), tmux
 }
 
 func waitForSessionStatus(t *testing.T, router chi.Router, id string, status session.SessionStatus, timeout time.Duration) {
@@ -51,7 +103,7 @@ func waitForSessionStatus(t *testing.T, router chi.Router, id string, status ses
 }
 
 func TestDaemon_ListWorkspaces(t *testing.T) {
-	_, router := setupTestRouter(t)
+	_, router, _ := setupTestRouter(t)
 
 	req := httptest.NewRequest("GET", "/workspaces", nil)
 	w := httptest.NewRecorder()
@@ -74,7 +126,7 @@ func TestDaemon_ListWorkspaces(t *testing.T) {
 }
 
 func TestDaemon_GetWorkspaceByID(t *testing.T) {
-	_, router := setupTestRouter(t)
+	_, router, _ := setupTestRouter(t)
 
 	req := httptest.NewRequest("GET", "/workspaces/ws-1", nil)
 	w := httptest.NewRecorder()
@@ -91,7 +143,7 @@ func TestDaemon_GetWorkspaceByID(t *testing.T) {
 }
 
 func TestDaemon_CreateAndGetSession(t *testing.T) {
-	_, router := setupTestRouter(t)
+	_, router, _ := setupTestRouter(t)
 
 	body := []byte(`{"name":"test-session-1","workspace_id":"ws-1"}`)
 
@@ -124,10 +176,39 @@ func TestDaemon_CreateAndGetSession(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "utena-test-session-1", response.ID)
 	require.Equal(t, "ws-1", response.WorkspaceID)
+	require.Equal(t, session.StatusReady, response.Status)
+}
+
+func TestDaemon_CreateSession_TmuxFails(t *testing.T) {
+	_, router, tmux := setupTestRouter(t)
+	tmux.setCreateErr(fmt.Errorf("tmux server not running"))
+
+	body := []byte(`{"name":"fail-session","workspace_id":"ws-1"}`)
+
+	req := httptest.NewRequest("POST", "/sessions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusAccepted, w.Code)
+
+	waitForSessionStatus(t, router, "utena-fail-session", session.StatusBroken, 2*time.Second)
+
+	req = httptest.NewRequest("GET", "/sessions/utena-fail-session", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	var response session.SessionResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.Equal(t, session.StatusBroken, response.Status)
+	require.Equal(t, session.ResourceFailed, response.Resources.Tmux.Status)
+	require.Contains(t, response.Resources.Tmux.Error, "tmux server not running")
 }
 
 func TestDaemon_ListSessions(t *testing.T) {
-	_, router := setupTestRouter(t)
+	_, router, _ := setupTestRouter(t)
 
 	bodies := []string{
 		`{"name":"session-1","workspace_id":"ws-1"}`,
@@ -167,7 +248,7 @@ func TestDaemon_ListSessions(t *testing.T) {
 }
 
 func TestDaemon_TmuxHookSessionCreated(t *testing.T) {
-	_, router := setupTestRouter(t)
+	_, router, _ := setupTestRouter(t)
 
 	body := []byte(`{"name":"test-session","workspace_id":"ws-1"}`)
 	req := httptest.NewRequest("POST", "/sessions", bytes.NewReader(body))
@@ -214,7 +295,7 @@ func findSessionByID(sessions []session.Session, id string) *session.Session {
 }
 
 func TestDaemon_TmuxHookSessionClosed(t *testing.T) {
-	_, router := setupTestRouter(t)
+	_, router, _ := setupTestRouter(t)
 
 	body := []byte(`{"name":"test-session","workspace_id":"ws-1"}`)
 	req := httptest.NewRequest("POST", "/sessions", bytes.NewReader(body))
@@ -245,4 +326,38 @@ func TestDaemon_TmuxHookSessionClosed(t *testing.T) {
 	require.NotNil(t, sess)
 	require.Equal(t, session.StatusBroken, sess.Status)
 	require.False(t, sess.IsAttached)
+}
+
+func TestDaemon_RepairSession_AfterTmuxFailure(t *testing.T) {
+	_, router, tmux := setupTestRouter(t)
+	tmux.setCreateErr(fmt.Errorf("tmux down"))
+
+	body := []byte(`{"name":"repair-me","workspace_id":"ws-1"}`)
+	req := httptest.NewRequest("POST", "/sessions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusAccepted, w.Code)
+
+	waitForSessionStatus(t, router, "utena-repair-me", session.StatusBroken, 2*time.Second)
+
+	tmux.setCreateErr(nil)
+
+	req = httptest.NewRequest("PUT", "/sessions/utena-repair-me/repair", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	waitForSessionStatus(t, router, "utena-repair-me", session.StatusReady, 2*time.Second)
+
+	req = httptest.NewRequest("GET", "/sessions/utena-repair-me", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	var response session.SessionResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.Equal(t, session.StatusReady, response.Status)
+	require.Equal(t, session.ResourceReady, response.Resources.Tmux.Status)
+	require.True(t, tmux.HasSession("utena-repair-me"))
 }

--- a/internal/session/resources.go
+++ b/internal/session/resources.go
@@ -1,0 +1,46 @@
+package session
+
+type ResourceStatus string
+
+const (
+	ResourcePending  ResourceStatus = "pending"
+	ResourceCreating ResourceStatus = "creating"
+	ResourceReady    ResourceStatus = "ready"
+	ResourceFailed   ResourceStatus = "failed"
+	ResourceRemoved  ResourceStatus = "removed"
+)
+
+type ResourceState struct {
+	Status ResourceStatus `json:"status"`
+	Error  string         `json:"error,omitempty"`
+}
+
+type Resources struct {
+	Branch   *ResourceState `json:"branch,omitempty"`
+	Worktree *ResourceState `json:"worktree,omitempty"`
+	Tmux     *ResourceState `json:"tmux,omitempty"`
+}
+
+func (r *Resources) AllReady() bool {
+	if r == nil {
+		return true
+	}
+	for _, rs := range []*ResourceState{r.Branch, r.Worktree, r.Tmux} {
+		if rs != nil && rs.Status != ResourceReady {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *Resources) FirstError() string {
+	if r == nil {
+		return ""
+	}
+	for _, rs := range []*ResourceState{r.Branch, r.Worktree, r.Tmux} {
+		if rs != nil && rs.Error != "" {
+			return rs.Error
+		}
+	}
+	return ""
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -21,27 +21,6 @@ const (
 	StatusDeleted  SessionStatus = "deleted"
 )
 
-type ResourceStatus string
-
-const (
-	ResourcePending  ResourceStatus = "pending"
-	ResourceCreating ResourceStatus = "creating"
-	ResourceReady    ResourceStatus = "ready"
-	ResourceFailed   ResourceStatus = "failed"
-	ResourceRemoved  ResourceStatus = "removed"
-)
-
-type ResourceState struct {
-	Status ResourceStatus `json:"status"`
-	Error  string         `json:"error,omitempty"`
-}
-
-type Resources struct {
-	Branch   *ResourceState `json:"branch,omitempty"`
-	Worktree *ResourceState `json:"worktree,omitempty"`
-	Tmux     *ResourceState `json:"tmux,omitempty"`
-}
-
 type Session struct {
 	ID              string        `json:"id"`
 	TmuxSessionName string        `json:"tmux_session_name,omitempty"`
@@ -56,30 +35,6 @@ type Session struct {
 	IsAttached      bool          `json:"is_attached"`
 	WorkspaceName   string        `json:"workspace_name,omitempty"`
 	LastUsedAt      time.Time     `json:"last_used_at"`
-}
-
-func (r *Resources) AllReady() bool {
-	if r == nil {
-		return true
-	}
-	for _, rs := range []*ResourceState{r.Branch, r.Worktree, r.Tmux} {
-		if rs != nil && rs.Status != ResourceReady {
-			return false
-		}
-	}
-	return true
-}
-
-func (r *Resources) FirstError() string {
-	if r == nil {
-		return ""
-	}
-	for _, rs := range []*ResourceState{r.Branch, r.Worktree, r.Tmux} {
-		if rs != nil && rs.Error != "" {
-			return rs.Error
-		}
-	}
-	return ""
 }
 
 func SanitizeID(name string) string {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -9,32 +9,77 @@ import (
 var ErrSessionAlreadyExists = errors.New("session already exists")
 var ErrSessionNotFound = errors.New("session not found")
 var ErrSessionAttached = errors.New("cannot delete attached session")
-var ErrSessionNotDead = errors.New("session is not dead")
-var ErrSessionDead = errors.New("cannot activate dead session")
+var ErrSessionNotBroken = errors.New("session is not broken")
+var ErrCannotActivate = errors.New("cannot activate session in current state")
 
-type Session struct {
-	ID              string    `json:"id"`
-	TmuxSessionName string    `json:"tmux_session_name,omitempty"`
-	Name            string    `json:"name,omitempty"`
-	WorkspaceID     string    `json:"workspace_id"`
-	WorkspaceName   string    `json:"workspace_name,omitempty"`
-	Branch          string    `json:"branch,omitempty"`
-	BaseBranch      string    `json:"base_branch,omitempty"`
-	BranchCreated   bool      `json:"branch_created,omitempty"`
-	BranchName      string    `json:"branch_name,omitempty"`
-	WorktreePath    string    `json:"worktree_path,omitempty"`
-	IsAttached      bool      `json:"is_attached"`
-	IsActive        bool      `json:"is_active"`
-	IsDead          bool      `json:"is_dead"`
-	IsDeleted       bool      `json:"is_deleted"`
-	Cleanup         *Cleanup  `json:"cleanup,omitempty"`
-	LastUsedAt      time.Time `json:"last_used_at"`
+type SessionStatus string
+
+const (
+	StatusCreating SessionStatus = "creating"
+	StatusReady    SessionStatus = "ready"
+	StatusBroken   SessionStatus = "broken"
+	StatusDeleted  SessionStatus = "deleted"
+)
+
+type ResourceStatus string
+
+const (
+	ResourcePending  ResourceStatus = "pending"
+	ResourceCreating ResourceStatus = "creating"
+	ResourceReady    ResourceStatus = "ready"
+	ResourceFailed   ResourceStatus = "failed"
+	ResourceRemoved  ResourceStatus = "removed"
+)
+
+type ResourceState struct {
+	Status ResourceStatus `json:"status"`
+	Error  string         `json:"error,omitempty"`
 }
 
-type Cleanup struct {
-	TmuxSessionKilled bool `json:"tmux_session_killed"`
-	WorktreeRemoved   bool `json:"worktree_removed"`
-	BranchDeleted     bool `json:"branch_deleted"`
+type Resources struct {
+	Branch   *ResourceState `json:"branch,omitempty"`
+	Worktree *ResourceState `json:"worktree,omitempty"`
+	Tmux     *ResourceState `json:"tmux,omitempty"`
+}
+
+type Session struct {
+	ID              string        `json:"id"`
+	TmuxSessionName string        `json:"tmux_session_name,omitempty"`
+	Name            string        `json:"name,omitempty"`
+	WorkspaceID     string        `json:"workspace_id"`
+	Branch          string        `json:"branch,omitempty"`
+	BaseBranch      string        `json:"base_branch,omitempty"`
+	BranchCreated   bool          `json:"branch_created,omitempty"`
+	WorktreePath    string        `json:"worktree_path,omitempty"`
+	Status          SessionStatus `json:"status"`
+	Resources       *Resources    `json:"resources,omitempty"`
+	IsAttached      bool          `json:"is_attached"`
+	WorkspaceName   string        `json:"workspace_name,omitempty"`
+	LastUsedAt      time.Time     `json:"last_used_at"`
+}
+
+func (r *Resources) AllReady() bool {
+	if r == nil {
+		return true
+	}
+	for _, rs := range []*ResourceState{r.Branch, r.Worktree, r.Tmux} {
+		if rs != nil && rs.Status != ResourceReady {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *Resources) FirstError() string {
+	if r == nil {
+		return ""
+	}
+	for _, rs := range []*ResourceState{r.Branch, r.Worktree, r.Tmux} {
+		if rs != nil && rs.Error != "" {
+			return rs.Error
+		}
+	}
+	return ""
 }
 
 func SanitizeID(name string) string {

--- a/internal/session/sessioncontroller.go
+++ b/internal/session/sessioncontroller.go
@@ -43,8 +43,10 @@ func (c *SessionController) GetSessionByID(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	response := NewSessionResponse(session)
-	render.Render(w, r, response)
+	resp := NewSessionResponse(session)
+	resp.WorkspaceName = c.service.resolveWorkspaceName(session)
+	resp.WorkspacePath = c.service.resolveWorkspacePath(session)
+	render.Render(w, r, resp)
 }
 
 func (c *SessionController) ListSessionsByWorkspace(w http.ResponseWriter, r *http.Request) {
@@ -88,9 +90,10 @@ func (c *SessionController) CreateSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	response := NewSessionResponse(session)
-	render.Status(r, http.StatusCreated)
-	render.Render(w, r, response)
+	resp := NewSessionResponse(session)
+	resp.WorkspaceName = c.service.resolveWorkspaceName(session)
+	render.Status(r, http.StatusAccepted)
+	render.Render(w, r, resp)
 }
 
 func (c *SessionController) UpdateSession(w http.ResponseWriter, r *http.Request) {
@@ -149,7 +152,7 @@ func (c *SessionController) ActivateSession(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		if errors.Is(err, ErrSessionNotFound) {
 			render.Render(w, r, common.ErrNotFound())
-		} else if errors.Is(err, ErrSessionDead) {
+		} else if errors.Is(err, ErrCannotActivate) {
 			render.Render(w, r, common.ErrInvalidRequest(err))
 		} else {
 			render.Render(w, r, common.ErrUnknown(err))
@@ -160,18 +163,15 @@ func (c *SessionController) ActivateSession(w http.ResponseWriter, r *http.Reque
 	render.Render(w, r, NewSessionResponse(session))
 }
 
-func (c *SessionController) ReviveSession(w http.ResponseWriter, r *http.Request) {
+func (c *SessionController) RepairSession(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	name := chi.URLParam(r, "name")
+	id := chi.URLParam(r, "id")
 
-	result, err := c.service.ReviveSession(ctx, name)
+	session, err := c.service.RepairSession(ctx, id)
 	if err != nil {
-		var wsNotFound *workspace.WorkspaceNotFoundError
 		if errors.Is(err, ErrSessionNotFound) {
 			render.Render(w, r, common.ErrNotFound())
-		} else if errors.Is(err, ErrSessionNotDead) {
-			render.Render(w, r, common.ErrInvalidRequest(err))
-		} else if errors.As(err, &wsNotFound) {
+		} else if errors.Is(err, ErrSessionNotBroken) {
 			render.Render(w, r, common.ErrInvalidRequest(err))
 		} else {
 			render.Render(w, r, common.ErrUnknown(err))
@@ -179,5 +179,5 @@ func (c *SessionController) ReviveSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	render.Render(w, r, NewReviveResponse(result))
+	render.Render(w, r, NewSessionResponse(session))
 }

--- a/internal/session/sessioncontroller.go
+++ b/internal/session/sessioncontroller.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -18,6 +19,13 @@ func NewSessionController(service *SessionService) *SessionController {
 	return &SessionController{
 		service: service,
 	}
+}
+
+func (c *SessionController) lookupWorkspace(id string) (*workspace.Workspace, error) {
+	if id == "" {
+		return nil, nil
+	}
+	return c.service.workspaceService.GetWorkspace(context.Background(), id)
 }
 
 func (c *SessionController) ListSessions(w http.ResponseWriter, r *http.Request) {
@@ -43,10 +51,12 @@ func (c *SessionController) GetSessionByID(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	resp := NewSessionResponse(session)
-	resp.WorkspaceName = c.service.resolveWorkspaceName(session)
-	resp.WorkspacePath = c.service.resolveWorkspacePath(session)
-	render.Render(w, r, resp)
+	ws, err := c.lookupWorkspace(session.WorkspaceID)
+	if err != nil {
+		render.Render(w, r, common.ErrUnknown(err))
+		return
+	}
+	render.Render(w, r, NewSessionResponse(session, ws))
 }
 
 func (c *SessionController) ListSessionsByWorkspace(w http.ResponseWriter, r *http.Request) {
@@ -90,10 +100,13 @@ func (c *SessionController) CreateSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	resp := NewSessionResponse(session)
-	resp.WorkspaceName = c.service.resolveWorkspaceName(session)
+	ws, err := c.lookupWorkspace(session.WorkspaceID)
+	if err != nil {
+		render.Render(w, r, common.ErrUnknown(err))
+		return
+	}
 	render.Status(r, http.StatusAccepted)
-	render.Render(w, r, resp)
+	render.Render(w, r, NewSessionResponse(session, ws))
 }
 
 func (c *SessionController) UpdateSession(w http.ResponseWriter, r *http.Request) {
@@ -118,8 +131,12 @@ func (c *SessionController) UpdateSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	response := NewSessionResponse(data.Session)
-	render.Render(w, r, response)
+	ws, err := c.lookupWorkspace(data.Session.WorkspaceID)
+	if err != nil {
+		render.Render(w, r, common.ErrUnknown(err))
+		return
+	}
+	render.Render(w, r, NewSessionResponse(data.Session, ws))
 }
 
 func (c *SessionController) DeleteSession(w http.ResponseWriter, r *http.Request) {
@@ -160,7 +177,7 @@ func (c *SessionController) ActivateSession(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	render.Render(w, r, NewSessionResponse(session))
+	render.Render(w, r, NewSessionResponse(session, nil))
 }
 
 func (c *SessionController) RepairSession(w http.ResponseWriter, r *http.Request) {
@@ -179,5 +196,5 @@ func (c *SessionController) RepairSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	render.Render(w, r, NewSessionResponse(session))
+	render.Render(w, r, NewSessionResponse(session, nil))
 }

--- a/internal/session/sessionrouter.go
+++ b/internal/session/sessionrouter.go
@@ -21,7 +21,7 @@ func (sr *SessionRouter) Routes() chi.Router {
 	r.Post("/", sr.controller.CreateSession)
 	r.Get("/workspace/{workspaceId}", sr.controller.ListSessionsByWorkspace)
 	r.Put("/{name}/activate", sr.controller.ActivateSession)
-	r.Put("/{name}/revive", sr.controller.ReviveSession)
+	r.Put("/{id}/repair", sr.controller.RepairSession)
 	r.Get("/{id}", sr.controller.GetSessionByID)
 	r.Put("/{id}", sr.controller.UpdateSession)
 	r.Delete("/{id}", sr.controller.DeleteSession)

--- a/internal/session/sessionrouter_test.go
+++ b/internal/session/sessionrouter_test.go
@@ -37,21 +37,17 @@ func setupSessionRouter(t *testing.T) (*SessionRouter, *SessionStore, *workspace
 func TestSessionRouter_ListSessions(t *testing.T) {
 	router, sessionStore, _ := setupSessionRouter(t)
 
-	// Add test sessions
 	now := time.Now()
-	session1 := &Session{ID: "session-1", WorkspaceID: "ws-1", LastUsedAt: now}
-	session2 := &Session{ID: "session-2", WorkspaceID: "ws-2", LastUsedAt: now}
+	session1 := &Session{ID: "session-1", WorkspaceID: "ws-1", Status: StatusReady, LastUsedAt: now}
+	session2 := &Session{ID: "session-2", WorkspaceID: "ws-2", Status: StatusReady, LastUsedAt: now}
 	sessionStore.Add(session1)
 	sessionStore.Add(session2)
 
-	// Create request
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 
-	// Execute
 	router.Routes().ServeHTTP(w, req)
 
-	// Assert
 	require.Equal(t, http.StatusOK, w.Code)
 
 	var response SessionListResponse
@@ -59,7 +55,6 @@ func TestSessionRouter_ListSessions(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, response.Sessions, 2)
 
-	// Verify session IDs
 	ids := make(map[string]bool)
 	for _, session := range response.Sessions {
 		ids[session.ID] = true
@@ -71,24 +66,20 @@ func TestSessionRouter_ListSessions(t *testing.T) {
 func TestSessionRouter_GetSessionByID(t *testing.T) {
 	router, sessionStore, _ := setupSessionRouter(t)
 
-	// Add test session
 	session := &Session{
 		ID:          "session-1",
 		WorkspaceID: "ws-1",
 		IsAttached:  true,
-		IsActive:    true,
+		Status:      StatusReady,
 		LastUsedAt:  time.Now(),
 	}
 	sessionStore.Add(session)
 
-	// Create request
 	req := httptest.NewRequest("GET", "/session-1", nil)
 	w := httptest.NewRecorder()
 
-	// Execute
 	router.Routes().ServeHTTP(w, req)
 
-	// Assert
 	require.Equal(t, http.StatusOK, w.Code)
 
 	var response SessionResponse
@@ -97,43 +88,36 @@ func TestSessionRouter_GetSessionByID(t *testing.T) {
 	require.Equal(t, "session-1", response.ID)
 	require.Equal(t, "ws-1", response.WorkspaceID)
 	require.True(t, response.IsAttached)
-	require.True(t, response.IsActive)
+	require.Equal(t, StatusReady, response.Status)
 }
 
 func TestSessionRouter_GetSessionByID_NotFound(t *testing.T) {
 	router, _, _ := setupSessionRouter(t)
 
-	// Create request
 	req := httptest.NewRequest("GET", "/nonexistent", nil)
 	w := httptest.NewRecorder()
 
-	// Execute
 	router.Routes().ServeHTTP(w, req)
 
-	// Assert
 	require.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestSessionRouter_ListSessionsByWorkspace(t *testing.T) {
 	router, sessionStore, _ := setupSessionRouter(t)
 
-	// Add test sessions
 	now := time.Now()
-	session1 := &Session{ID: "session-1", WorkspaceID: "ws-1", LastUsedAt: now}
-	session2 := &Session{ID: "session-2", WorkspaceID: "ws-2", LastUsedAt: now}
-	session3 := &Session{ID: "session-3", WorkspaceID: "ws-1", LastUsedAt: now}
+	session1 := &Session{ID: "session-1", WorkspaceID: "ws-1", Status: StatusReady, LastUsedAt: now}
+	session2 := &Session{ID: "session-2", WorkspaceID: "ws-2", Status: StatusReady, LastUsedAt: now}
+	session3 := &Session{ID: "session-3", WorkspaceID: "ws-1", Status: StatusReady, LastUsedAt: now}
 	sessionStore.Add(session1)
 	sessionStore.Add(session2)
 	sessionStore.Add(session3)
 
-	// Create request
 	req := httptest.NewRequest("GET", "/workspace/ws-1", nil)
 	w := httptest.NewRecorder()
 
-	// Execute
 	router.Routes().ServeHTTP(w, req)
 
-	// Assert
 	require.Equal(t, http.StatusOK, w.Code)
 
 	var response SessionListResponse
@@ -141,7 +125,6 @@ func TestSessionRouter_ListSessionsByWorkspace(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, response.Sessions, 2)
 
-	// Verify only ws-1 sessions returned
 	for _, session := range response.Sessions {
 		require.Equal(t, "ws-1", session.WorkspaceID)
 	}
@@ -158,13 +141,16 @@ func TestSessionRouter_CreateSession(t *testing.T) {
 
 	router.Routes().ServeHTTP(w, req)
 
-	require.Equal(t, http.StatusCreated, w.Code)
+	require.Equal(t, http.StatusAccepted, w.Code)
 
 	var resp SessionResponse
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
 	require.Equal(t, "utena-session-1", resp.ID)
 	require.Equal(t, "session-1", resp.Name)
+	require.Equal(t, StatusCreating, resp.Status)
+
+	waitForStatus(t, sessionStore, "utena-session-1", StatusReady, 2*time.Second)
 
 	retrieved, err := sessionStore.GetByID("utena-session-1")
 	require.NoError(t, err)
@@ -183,13 +169,15 @@ func TestSessionRouter_CreateSession_WithName(t *testing.T) {
 
 	router.Routes().ServeHTTP(w, req)
 
-	require.Equal(t, http.StatusCreated, w.Code)
+	require.Equal(t, http.StatusAccepted, w.Code)
 
 	var resp SessionResponse
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
 	require.Equal(t, "utena-main", resp.ID)
 	require.Equal(t, "main", resp.Name)
+
+	waitForStatus(t, sessionStore, "utena-main", StatusReady, 2*time.Second)
 
 	retrieved, err := sessionStore.GetByID("utena-main")
 	require.NoError(t, err)
@@ -207,13 +195,15 @@ func TestSessionRouter_CreateSession_ExistingBranch(t *testing.T) {
 
 	router.Routes().ServeHTTP(w, req)
 
-	require.Equal(t, http.StatusCreated, w.Code)
+	require.Equal(t, http.StatusAccepted, w.Code)
 
 	var resp SessionResponse
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
 	require.Equal(t, "utena-main", resp.ID)
 	require.Equal(t, "main", resp.Name)
+
+	waitForStatus(t, sessionStore, "utena-main", StatusReady, 2*time.Second)
 
 	retrieved, err := sessionStore.GetByID("utena-main")
 	require.NoError(t, err)
@@ -232,39 +222,33 @@ func TestSessionRouter_CreateSession_InvalidWorkspace(t *testing.T) {
 
 	router.Routes().ServeHTTP(w, req)
 
-	require.NotEqual(t, http.StatusCreated, w.Code)
+	require.NotEqual(t, http.StatusAccepted, w.Code)
 }
 
 func TestSessionRouter_UpdateSession(t *testing.T) {
 	router, sessionStore, _ := setupSessionRouter(t)
 
-	// Add initial session
 	session := &Session{
 		ID:          "session-1",
 		WorkspaceID: "ws-1",
 		IsAttached:  false,
-		IsActive:    true,
+		Status:      StatusReady,
 		LastUsedAt:  time.Now(),
 	}
 	sessionStore.Add(session)
 
-	// Update session
 	session.IsAttached = true
 	body, err := json.Marshal(session)
 	require.NoError(t, err)
 
-	// Create request
 	req := httptest.NewRequest("PUT", "/session-1", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
-	// Execute
 	router.Routes().ServeHTTP(w, req)
 
-	// Assert
 	require.Equal(t, http.StatusOK, w.Code)
 
-	// Verify update
 	retrieved, err := sessionStore.GetByID("session-1")
 	require.NoError(t, err)
 	require.True(t, retrieved.IsAttached)
@@ -273,32 +257,40 @@ func TestSessionRouter_UpdateSession(t *testing.T) {
 func TestSessionRouter_DeleteSession(t *testing.T) {
 	router, sessionStore, _ := setupSessionRouter(t)
 
-	// Add test session
-	session := &Session{ID: "session-1", WorkspaceID: "ws-1", LastUsedAt: time.Now()}
+	session := &Session{
+		ID:          "session-1",
+		WorkspaceID: "ws-1",
+		Status:      StatusReady,
+		Resources:   &Resources{Tmux: &ResourceState{Status: ResourceReady}},
+		LastUsedAt:  time.Now(),
+	}
 	sessionStore.Add(session)
 
-	// Create request
 	req := httptest.NewRequest("DELETE", "/session-1", nil)
 	w := httptest.NewRecorder()
 
-	// Execute
 	router.Routes().ServeHTTP(w, req)
 
-	// Assert
 	require.Equal(t, http.StatusNoContent, w.Code)
 
 	retrieved, err := sessionStore.GetByID("session-1")
 	require.NoError(t, err)
-	require.True(t, retrieved.IsDeleted)
-	require.NotNil(t, retrieved.Cleanup)
+	require.Equal(t, StatusDeleted, retrieved.Status)
+	require.NotNil(t, retrieved.Resources)
 }
 
-func TestSessionRouter_ReviveSession(t *testing.T) {
+func TestSessionRouter_RepairSession(t *testing.T) {
 	router, sessionStore, _ := setupSessionRouter(t)
 
-	sessionStore.Add(&Session{ID: "dead-session", WorkspaceID: "ws-1", IsDead: true, LastUsedAt: time.Now()})
+	sessionStore.Add(&Session{
+		ID:          "broken-session",
+		WorkspaceID: "ws-1",
+		Status:      StatusBroken,
+		Resources:   &Resources{Tmux: &ResourceState{Status: ResourceRemoved}},
+		LastUsedAt:  time.Now(),
+	})
 
-	req := httptest.NewRequest("PUT", "/dead-session/revive", nil)
+	req := httptest.NewRequest("PUT", "/broken-session/repair", nil)
 	w := httptest.NewRecorder()
 
 	router.Routes().ServeHTTP(w, req)
@@ -308,38 +300,14 @@ func TestSessionRouter_ReviveSession(t *testing.T) {
 	var response SessionResponse
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
-	require.Equal(t, "dead-session", response.ID)
-	require.False(t, response.IsDead)
-	require.Equal(t, "/tmp/utena", response.WorkspacePath)
-
-	retrieved, err := sessionStore.GetByID("dead-session")
-	require.NoError(t, err)
-	require.False(t, retrieved.IsDead)
+	require.Equal(t, "broken-session", response.ID)
+	require.Equal(t, StatusCreating, response.Status)
 }
 
-func TestSessionRouter_ReviveSession_NoWorkspace(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
-
-	sessionStore.Add(&Session{ID: "dead-no-ws", IsDead: true, LastUsedAt: time.Now()})
-
-	req := httptest.NewRequest("PUT", "/dead-no-ws/revive", nil)
-	w := httptest.NewRecorder()
-
-	router.Routes().ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusOK, w.Code)
-
-	var response SessionResponse
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	require.NoError(t, err)
-	require.False(t, response.IsDead)
-	require.Empty(t, response.WorkspacePath)
-}
-
-func TestSessionRouter_ReviveSession_NotFound(t *testing.T) {
+func TestSessionRouter_RepairSession_NotFound(t *testing.T) {
 	router, _, _ := setupSessionRouter(t)
 
-	req := httptest.NewRequest("PUT", "/nonexistent/revive", nil)
+	req := httptest.NewRequest("PUT", "/nonexistent/repair", nil)
 	w := httptest.NewRecorder()
 
 	router.Routes().ServeHTTP(w, req)
@@ -347,50 +315,41 @@ func TestSessionRouter_ReviveSession_NotFound(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, w.Code)
 }
 
-func TestSessionRouter_ReviveSession_NotDead(t *testing.T) {
+func TestSessionRouter_RepairSession_NotBroken(t *testing.T) {
 	router, sessionStore, _ := setupSessionRouter(t)
 
-	sessionStore.Add(&Session{ID: "alive-session", WorkspaceID: "ws-1", IsDead: false, LastUsedAt: time.Now()})
+	sessionStore.Add(&Session{
+		ID:          "alive-session",
+		WorkspaceID: "ws-1",
+		Status:      StatusReady,
+		Resources:   &Resources{Tmux: &ResourceState{Status: ResourceReady}},
+		LastUsedAt:  time.Now(),
+	})
 
-	req := httptest.NewRequest("PUT", "/alive-session/revive", nil)
-	w := httptest.NewRecorder()
-
-	router.Routes().ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusBadRequest, w.Code)
-}
-
-func TestSessionRouter_ReviveSession_InvalidWorkspace(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
-
-	sessionStore.Add(&Session{ID: "dead-bad-ws", WorkspaceID: "nonexistent", IsDead: true, LastUsedAt: time.Now()})
-
-	req := httptest.NewRequest("PUT", "/dead-bad-ws/revive", nil)
-	w := httptest.NewRecorder()
-
-	router.Routes().ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusBadRequest, w.Code)
-
-	retrieved, err := sessionStore.GetByID("dead-bad-ws")
-	require.NoError(t, err)
-	require.True(t, retrieved.IsDead)
-}
-
-func TestSessionRouter_ActivateSession_AutoRevivesDeadSession(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
-
-	sessionStore.Add(&Session{ID: "dead-session", TmuxSessionName: "dead-session", WorkspaceID: "ws-1", IsDead: true, LastUsedAt: time.Now()})
-
-	req := httptest.NewRequest("PUT", "/dead-session/activate", nil)
+	req := httptest.NewRequest("PUT", "/alive-session/repair", nil)
 	w := httptest.NewRecorder()
 
 	router.Routes().ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
+}
 
-	retrieved, err := sessionStore.GetByID("dead-session")
-	require.NoError(t, err)
-	require.False(t, retrieved.IsDead)
-	require.True(t, retrieved.IsAttached)
+func TestSessionRouter_ActivateSession_RejectsBrokenSession(t *testing.T) {
+	router, sessionStore, _ := setupSessionRouter(t)
+
+	sessionStore.Add(&Session{
+		ID:              "broken-session",
+		TmuxSessionName: "broken-session",
+		WorkspaceID:     "ws-1",
+		Status:          StatusBroken,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceRemoved}},
+		LastUsedAt:      time.Now(),
+	})
+
+	req := httptest.NewRequest("PUT", "/broken-session/activate", nil)
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/internal/session/sessionrouter_test.go
+++ b/internal/session/sessionrouter_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupSessionRouter(t *testing.T) (*SessionRouter, *SessionStore, *workspace.WorkspaceStore) {
+func setupSessionRouter(t *testing.T) (*SessionRouter, *SessionStore, *workspace.WorkspaceStore, *mockTmuxManager) {
 	t.Helper()
 
 	bus := eventbus.NewEventBus()
@@ -25,17 +25,18 @@ func setupSessionRouter(t *testing.T) (*SessionRouter, *SessionStore, *workspace
 	workspaceStore.Add(&workspace.Workspace{ID: "ws-1", Name: "utena", Path: "/tmp/utena"})
 	workspaceStore.Add(&workspace.Workspace{ID: "ws-2", Name: "other", Path: "/tmp/other"})
 
+	tmux := newMockTmuxManager()
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, &mockTmuxManager{}, bus, "eqt/")
+	service := NewSessionService(sessionStore, workspaceService, gitService, tmux, bus, "eqt/")
 	controller := NewSessionController(service)
 	router := NewSessionRouter(controller)
 
-	return router, sessionStore, workspaceStore
+	return router, sessionStore, workspaceStore, tmux
 }
 
 func TestSessionRouter_ListSessions(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
+	router, sessionStore, _, _ := setupSessionRouter(t)
 
 	now := time.Now()
 	session1 := &Session{ID: "session-1", WorkspaceID: "ws-1", Status: StatusReady, LastUsedAt: now}
@@ -64,13 +65,14 @@ func TestSessionRouter_ListSessions(t *testing.T) {
 }
 
 func TestSessionRouter_GetSessionByID(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
+	router, sessionStore, _, _ := setupSessionRouter(t)
 
 	session := &Session{
 		ID:          "session-1",
 		WorkspaceID: "ws-1",
 		IsAttached:  true,
 		Status:      StatusReady,
+		Resources:   &Resources{Tmux: &ResourceState{Status: ResourceReady}},
 		LastUsedAt:  time.Now(),
 	}
 	sessionStore.Add(session)
@@ -89,10 +91,12 @@ func TestSessionRouter_GetSessionByID(t *testing.T) {
 	require.Equal(t, "ws-1", response.WorkspaceID)
 	require.True(t, response.IsAttached)
 	require.Equal(t, StatusReady, response.Status)
+	require.NotNil(t, response.Resources)
+	require.Equal(t, ResourceReady, response.Resources.Tmux.Status)
 }
 
 func TestSessionRouter_GetSessionByID_NotFound(t *testing.T) {
-	router, _, _ := setupSessionRouter(t)
+	router, _, _, _ := setupSessionRouter(t)
 
 	req := httptest.NewRequest("GET", "/nonexistent", nil)
 	w := httptest.NewRecorder()
@@ -103,7 +107,7 @@ func TestSessionRouter_GetSessionByID_NotFound(t *testing.T) {
 }
 
 func TestSessionRouter_ListSessionsByWorkspace(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
+	router, sessionStore, _, _ := setupSessionRouter(t)
 
 	now := time.Now()
 	session1 := &Session{ID: "session-1", WorkspaceID: "ws-1", Status: StatusReady, LastUsedAt: now}
@@ -131,7 +135,7 @@ func TestSessionRouter_ListSessionsByWorkspace(t *testing.T) {
 }
 
 func TestSessionRouter_CreateSession(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
+	router, sessionStore, _, tmux := setupSessionRouter(t)
 
 	body := []byte(`{"name":"session-1","workspace_id":"ws-1"}`)
 
@@ -156,10 +160,11 @@ func TestSessionRouter_CreateSession(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "utena-session-1", retrieved.ID)
 	require.Equal(t, "ws-1", retrieved.WorkspaceID)
+	require.True(t, tmux.HasSession("utena-session-1"))
 }
 
 func TestSessionRouter_CreateSession_WithName(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
+	router, sessionStore, _, _ := setupSessionRouter(t)
 
 	body := []byte(`{"name":"main","workspace_id":"ws-1"}`)
 
@@ -185,7 +190,7 @@ func TestSessionRouter_CreateSession_WithName(t *testing.T) {
 }
 
 func TestSessionRouter_CreateSession_ExistingBranch(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
+	router, sessionStore, _, _ := setupSessionRouter(t)
 
 	body := []byte(`{"workspace_id":"ws-1","branch":"main","branch_created":false,"create_worktree":false}`)
 
@@ -212,7 +217,7 @@ func TestSessionRouter_CreateSession_ExistingBranch(t *testing.T) {
 }
 
 func TestSessionRouter_CreateSession_InvalidWorkspace(t *testing.T) {
-	router, _, _ := setupSessionRouter(t)
+	router, _, _, _ := setupSessionRouter(t)
 
 	body := []byte(`{"name":"session-1","workspace_id":"nonexistent"}`)
 
@@ -226,7 +231,7 @@ func TestSessionRouter_CreateSession_InvalidWorkspace(t *testing.T) {
 }
 
 func TestSessionRouter_UpdateSession(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
+	router, sessionStore, _, _ := setupSessionRouter(t)
 
 	session := &Session{
 		ID:          "session-1",
@@ -255,14 +260,16 @@ func TestSessionRouter_UpdateSession(t *testing.T) {
 }
 
 func TestSessionRouter_DeleteSession(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
+	router, sessionStore, _, tmux := setupSessionRouter(t)
 
+	tmux.sessions["session-1"] = true
 	session := &Session{
-		ID:          "session-1",
-		WorkspaceID: "ws-1",
-		Status:      StatusReady,
-		Resources:   &Resources{Tmux: &ResourceState{Status: ResourceReady}},
-		LastUsedAt:  time.Now(),
+		ID:              "session-1",
+		TmuxSessionName: "session-1",
+		WorkspaceID:     "ws-1",
+		Status:          StatusReady,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceReady}},
+		LastUsedAt:      time.Now(),
 	}
 	sessionStore.Add(session)
 
@@ -276,18 +283,20 @@ func TestSessionRouter_DeleteSession(t *testing.T) {
 	retrieved, err := sessionStore.GetByID("session-1")
 	require.NoError(t, err)
 	require.Equal(t, StatusDeleted, retrieved.Status)
-	require.NotNil(t, retrieved.Resources)
+	require.Equal(t, ResourceRemoved, retrieved.Resources.Tmux.Status)
+	require.False(t, tmux.HasSession("session-1"))
 }
 
 func TestSessionRouter_RepairSession(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
+	router, sessionStore, _, _ := setupSessionRouter(t)
 
 	sessionStore.Add(&Session{
-		ID:          "broken-session",
-		WorkspaceID: "ws-1",
-		Status:      StatusBroken,
-		Resources:   &Resources{Tmux: &ResourceState{Status: ResourceRemoved}},
-		LastUsedAt:  time.Now(),
+		ID:              "broken-session",
+		TmuxSessionName: "broken-session",
+		WorkspaceID:     "ws-1",
+		Status:          StatusBroken,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceRemoved}},
+		LastUsedAt:      time.Now(),
 	})
 
 	req := httptest.NewRequest("PUT", "/broken-session/repair", nil)
@@ -302,10 +311,12 @@ func TestSessionRouter_RepairSession(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "broken-session", response.ID)
 	require.Equal(t, StatusCreating, response.Status)
+
+	waitForStatus(t, sessionStore, "broken-session", StatusReady, 2*time.Second)
 }
 
 func TestSessionRouter_RepairSession_NotFound(t *testing.T) {
-	router, _, _ := setupSessionRouter(t)
+	router, _, _, _ := setupSessionRouter(t)
 
 	req := httptest.NewRequest("PUT", "/nonexistent/repair", nil)
 	w := httptest.NewRecorder()
@@ -316,14 +327,16 @@ func TestSessionRouter_RepairSession_NotFound(t *testing.T) {
 }
 
 func TestSessionRouter_RepairSession_NotBroken(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
+	router, sessionStore, _, tmux := setupSessionRouter(t)
 
+	tmux.sessions["alive-session"] = true
 	sessionStore.Add(&Session{
-		ID:          "alive-session",
-		WorkspaceID: "ws-1",
-		Status:      StatusReady,
-		Resources:   &Resources{Tmux: &ResourceState{Status: ResourceReady}},
-		LastUsedAt:  time.Now(),
+		ID:              "alive-session",
+		TmuxSessionName: "alive-session",
+		WorkspaceID:     "ws-1",
+		Status:          StatusReady,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceReady}},
+		LastUsedAt:      time.Now(),
 	})
 
 	req := httptest.NewRequest("PUT", "/alive-session/repair", nil)
@@ -335,7 +348,7 @@ func TestSessionRouter_RepairSession_NotBroken(t *testing.T) {
 }
 
 func TestSessionRouter_ActivateSession_RejectsBrokenSession(t *testing.T) {
-	router, sessionStore, _ := setupSessionRouter(t)
+	router, sessionStore, _, _ := setupSessionRouter(t)
 
 	sessionStore.Add(&Session{
 		ID:              "broken-session",
@@ -352,4 +365,67 @@ func TestSessionRouter_ActivateSession_RejectsBrokenSession(t *testing.T) {
 	router.Routes().ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSessionRouter_GetSessionByID_ShowsResourceState(t *testing.T) {
+	router, sessionStore, _, _ := setupSessionRouter(t)
+
+	session := &Session{
+		ID:          "creating-session",
+		WorkspaceID: "ws-1",
+		Status:      StatusCreating,
+		Resources: &Resources{
+			Branch:   &ResourceState{Status: ResourceReady},
+			Worktree: &ResourceState{Status: ResourceCreating},
+			Tmux:     &ResourceState{Status: ResourcePending},
+		},
+		LastUsedAt: time.Now(),
+	}
+	sessionStore.Add(session)
+
+	req := httptest.NewRequest("GET", "/creating-session", nil)
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response SessionResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.Equal(t, StatusCreating, response.Status)
+	require.Equal(t, ResourceReady, response.Resources.Branch.Status)
+	require.Equal(t, ResourceCreating, response.Resources.Worktree.Status)
+	require.Equal(t, ResourcePending, response.Resources.Tmux.Status)
+}
+
+func TestSessionRouter_GetSessionByID_ShowsBrokenResourceError(t *testing.T) {
+	router, sessionStore, _, _ := setupSessionRouter(t)
+
+	session := &Session{
+		ID:          "broken-session",
+		WorkspaceID: "ws-1",
+		Status:      StatusBroken,
+		Resources: &Resources{
+			Branch:   &ResourceState{Status: ResourceReady},
+			Worktree: &ResourceState{Status: ResourceFailed, Error: "failed to create worktree: timeout"},
+			Tmux:     &ResourceState{Status: ResourcePending},
+		},
+		LastUsedAt: time.Now(),
+	}
+	sessionStore.Add(session)
+
+	req := httptest.NewRequest("GET", "/broken-session", nil)
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response SessionResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.Equal(t, StatusBroken, response.Status)
+	require.Equal(t, ResourceFailed, response.Resources.Worktree.Status)
+	require.Equal(t, "failed to create worktree: timeout", response.Resources.Worktree.Error)
 }

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/eleonorayaya/utena/internal/eventbus"
@@ -55,21 +56,32 @@ func (s *SessionService) OnAppEnd(ctx context.Context) error {
 func (s *SessionService) ListSessions(ctx context.Context) ([]Session, error) {
 	sessions := s.store.List()
 	for i := range sessions {
-		s.resolveWorkspaceName(&sessions[i])
+		sessions[i].WorkspaceName = s.resolveWorkspaceName(&sessions[i])
 	}
 	return sessions, nil
 }
 
-func (s *SessionService) resolveWorkspaceName(session *Session) {
+func (s *SessionService) resolveWorkspaceName(session *Session) string {
 	if session.WorkspaceID == "" {
-		return
+		return ""
 	}
 	ws, err := s.workspaceService.GetWorkspace(context.Background(), session.WorkspaceID)
 	if err != nil {
 		slog.Warn("failed to resolve workspace name", "session", session.ID, "workspace_id", session.WorkspaceID, "error", err)
-		return
+		return ""
 	}
-	session.WorkspaceName = ws.Name
+	return ws.Name
+}
+
+func (s *SessionService) resolveWorkspacePath(session *Session) string {
+	if session.WorkspaceID == "" {
+		return ""
+	}
+	ws, err := s.workspaceService.GetWorkspace(context.Background(), session.WorkspaceID)
+	if err != nil {
+		return ""
+	}
+	return ws.Path
 }
 
 func (s *SessionService) ListSessionsByWorkspace(ctx context.Context, workspaceID string) ([]Session, error) {
@@ -121,35 +133,15 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, cr
 
 	session.TmuxSessionName = session.ID
 
-	if ws != nil && ws.IsGitRepo && createWorktree {
-		pullBranch := session.BaseBranch
-		if !session.BranchCreated && session.Branch != "" {
-			pullBranch = session.Branch
-		}
-
-		if pullBranch != "" {
-			if err := s.gitService.Pull(ctx, ws.Path, pullBranch); err != nil {
-				return fmt.Errorf("failed to pull branch %q: %w", pullBranch, err)
-			}
-		}
-
-		if session.BranchCreated {
-			branchName := s.branchPrefix + session.Name
-			worktreePath, err := s.gitService.CreateWorktree(ctx, ws.Path, branchName, session.BaseBranch)
-			if err != nil {
-				return fmt.Errorf("failed to create worktree: %w", err)
-			}
-			session.WorktreePath = worktreePath
-			session.BranchName = branchName
-			session.Branch = branchName
-		} else if session.Branch != "" {
-			worktreePath, err := s.gitService.CheckoutWorktree(ctx, ws.Path, session.Branch)
-			if err != nil {
-				return fmt.Errorf("failed to checkout worktree: %w", err)
-			}
-			session.WorktreePath = worktreePath
-		}
+	res := &Resources{
+		Tmux: &ResourceState{Status: ResourcePending},
 	}
+	if ws != nil && ws.IsGitRepo && createWorktree {
+		res.Branch = &ResourceState{Status: ResourcePending}
+		res.Worktree = &ResourceState{Status: ResourcePending}
+	}
+	session.Resources = res
+	session.Status = StatusCreating
 
 	if session.LastUsedAt.IsZero() {
 		session.LastUsedAt = time.Now()
@@ -163,21 +155,166 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, cr
 		s.workspaceService.Touch(ctx, session.WorkspaceID)
 	}
 
-	startDir := ""
-	if session.WorktreePath != "" {
-		startDir = session.WorktreePath
-	} else if session.WorkspaceID != "" {
-		ws, err := s.workspaceService.GetWorkspace(ctx, session.WorkspaceID)
-		if err == nil {
-			startDir = ws.Path
+	go s.runSetup(session.ID, ws)
+
+	return nil
+}
+
+func (s *SessionService) runSetup(sessionID string, ws *workspace.Workspace) {
+	ctx := context.Background()
+
+	sess, err := s.store.GetByID(sessionID)
+	if err != nil {
+		slog.Error("runSetup: failed to load session", "id", sessionID, "error", err)
+		return
+	}
+
+	if sess.Resources.Branch != nil && sess.Resources.Branch.Status != ResourceReady {
+		sess.Resources.Branch.Status = ResourceCreating
+		s.store.Update(sess)
+
+		pullBranch := sess.BaseBranch
+		if !sess.BranchCreated && sess.Branch != "" {
+			pullBranch = sess.Branch
+		}
+
+		if pullBranch != "" {
+			if err := s.gitService.Pull(ctx, ws.Path, pullBranch); err != nil {
+				sess.Resources.Branch.Status = ResourceFailed
+				sess.Resources.Branch.Error = fmt.Sprintf("failed to pull branch %q: %v", pullBranch, err)
+				sess.Status = StatusBroken
+				s.store.Update(sess)
+				return
+			}
+		}
+
+		sess.Resources.Branch.Status = ResourceReady
+		s.store.Update(sess)
+	}
+
+	if sess.Resources.Worktree != nil && sess.Resources.Worktree.Status != ResourceReady {
+		sess.Resources.Worktree.Status = ResourceCreating
+		s.store.Update(sess)
+
+		if sess.BranchCreated {
+			branchName := s.branchPrefix + sess.Name
+			worktreePath, err := s.gitService.CreateWorktree(ctx, ws.Path, branchName, sess.BaseBranch)
+			if err != nil {
+				sess.Resources.Worktree.Status = ResourceFailed
+				sess.Resources.Worktree.Error = fmt.Sprintf("failed to create worktree: %v", err)
+				sess.Status = StatusBroken
+				s.store.Update(sess)
+				return
+			}
+			sess.WorktreePath = worktreePath
+			sess.Branch = branchName
+		} else if sess.Branch != "" {
+			worktreePath, err := s.gitService.CheckoutWorktree(ctx, ws.Path, sess.Branch)
+			if err != nil {
+				sess.Resources.Worktree.Status = ResourceFailed
+				sess.Resources.Worktree.Error = fmt.Sprintf("failed to checkout worktree: %v", err)
+				sess.Status = StatusBroken
+				s.store.Update(sess)
+				return
+			}
+			sess.WorktreePath = worktreePath
+		}
+
+		sess.Resources.Worktree.Status = ResourceReady
+		s.store.Update(sess)
+	}
+
+	if sess.Resources.Tmux != nil && sess.Resources.Tmux.Status != ResourceReady {
+		sess.Resources.Tmux.Status = ResourceCreating
+		s.store.Update(sess)
+
+		startDir := s.resolveStartDir(ctx, sess)
+		if err := s.tmuxManager.CreateSession(sess.TmuxSessionName, startDir); err != nil {
+			sess.Resources.Tmux.Status = ResourceFailed
+			sess.Resources.Tmux.Error = fmt.Sprintf("failed to create tmux session: %v", err)
+			sess.Status = StatusBroken
+			s.store.Update(sess)
+			return
+		}
+
+		sess.Resources.Tmux.Status = ResourceReady
+		s.store.Update(sess)
+	}
+
+	sess.Status = StatusReady
+	s.store.Update(sess)
+}
+
+func (s *SessionService) RefreshSession(ctx context.Context, id string) (*Session, error) {
+	sess, err := s.store.GetByID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	if sess.Resources == nil {
+		return sess, nil
+	}
+
+	if sess.Resources.Worktree != nil && sess.Resources.Worktree.Status == ResourceReady {
+		if sess.WorktreePath != "" {
+			if _, err := os.Stat(sess.WorktreePath); os.IsNotExist(err) {
+				sess.Resources.Worktree.Status = ResourceRemoved
+			}
 		}
 	}
 
-	if err := s.tmuxManager.CreateSession(session.TmuxSessionName, startDir); err != nil {
-		slog.Warn("failed to create tmux session", "session", session.TmuxSessionName, "error", err)
+	if sess.Resources.Tmux != nil && sess.Resources.Tmux.Status == ResourceReady {
+		if !s.tmuxManager.HasSession(sess.TmuxSessionName) {
+			sess.Resources.Tmux.Status = ResourceRemoved
+		}
 	}
 
-	return nil
+	if sess.Status != StatusCreating && sess.Status != StatusDeleted {
+		if sess.Resources.AllReady() {
+			sess.Status = StatusReady
+		} else {
+			sess.Status = StatusBroken
+		}
+	}
+
+	s.store.Update(sess)
+	return sess, nil
+}
+
+func (s *SessionService) RepairSession(ctx context.Context, id string) (*Session, error) {
+	sess, err := s.RefreshSession(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if sess.Status == StatusReady {
+		return sess, nil
+	}
+
+	if sess.Status != StatusBroken {
+		return nil, ErrSessionNotBroken
+	}
+
+	if sess.Resources != nil {
+		for _, rs := range []*ResourceState{sess.Resources.Branch, sess.Resources.Worktree, sess.Resources.Tmux} {
+			if rs != nil && rs.Status != ResourceReady {
+				rs.Status = ResourcePending
+				rs.Error = ""
+			}
+		}
+	}
+
+	sess.Status = StatusCreating
+	s.store.Update(sess)
+
+	var ws *workspace.Workspace
+	if sess.WorkspaceID != "" {
+		ws, _ = s.workspaceService.GetWorkspace(ctx, sess.WorkspaceID)
+	}
+
+	go s.runSetup(sess.ID, ws)
+
+	return sess, nil
 }
 
 func (s *SessionService) UpdateSession(ctx context.Context, session *Session) error {
@@ -202,18 +339,22 @@ func (s *SessionService) ActivateSession(ctx context.Context, name string) (*Ses
 		return nil, err
 	}
 
-	slog.Info("activate session", "session", name, "is_attached", session.IsAttached)
+	slog.Info("activate session", "session", name, "status", session.Status, "is_attached", session.IsAttached)
+
+	if session.Status == StatusCreating || session.Status == StatusBroken {
+		return nil, ErrCannotActivate
+	}
 
 	if !s.tmuxManager.HasSession(session.TmuxSessionName) {
 		startDir := s.resolveStartDir(ctx, session)
 		if err := s.tmuxManager.CreateSession(session.TmuxSessionName, startDir); err != nil {
 			return nil, fmt.Errorf("failed to revive tmux session: %w", err)
 		}
-		session.IsDead = false
-		session.IsActive = true
-	} else if session.IsDead {
-		session.IsDead = false
-		session.IsActive = true
+		session.Status = StatusReady
+		if session.Resources != nil && session.Resources.Tmux != nil {
+			session.Resources.Tmux.Status = ResourceReady
+			session.Resources.Tmux.Error = ""
+		}
 	}
 
 	if session.IsAttached {
@@ -230,7 +371,6 @@ func (s *SessionService) ActivateSession(ctx context.Context, name string) (*Ses
 	}
 
 	session.LastUsedAt = time.Now()
-	session.IsActive = true
 	session.IsAttached = true
 
 	if err := s.store.Update(session); err != nil {
@@ -249,42 +389,6 @@ func (s *SessionService) ActivateSession(ctx context.Context, name string) (*Ses
 	return session, nil
 }
 
-func (s *SessionService) ReviveSession(ctx context.Context, name string) (*ReviveResult, error) {
-	session, err := s.store.GetByID(name)
-	if err != nil {
-		return nil, err
-	}
-
-	if !session.IsDead {
-		return nil, ErrSessionNotDead
-	}
-
-	var workspacePath string
-	if session.WorkspaceID != "" {
-		ws, err := s.workspaceService.GetWorkspace(ctx, session.WorkspaceID)
-		if err != nil {
-			return nil, err
-		}
-		workspacePath = ws.Path
-	}
-
-	session.IsDead = false
-	if err := s.store.Update(session); err != nil {
-		return nil, err
-	}
-
-	startDir := workspacePath
-	if session.WorktreePath != "" {
-		startDir = session.WorktreePath
-	}
-
-	if err := s.tmuxManager.CreateSession(session.TmuxSessionName, startDir); err != nil {
-		slog.Warn("failed to create tmux session for revive", "session", session.TmuxSessionName, "error", err)
-	}
-
-	return &ReviveResult{Session: session, WorkspacePath: workspacePath}, nil
-}
-
 func (s *SessionService) DeleteSession(ctx context.Context, id string, deleteBranch bool) error {
 	session, err := s.store.GetByID(id)
 	if err != nil {
@@ -295,7 +399,13 @@ func (s *SessionService) DeleteSession(ctx context.Context, id string, deleteBra
 		return ErrSessionAttached
 	}
 
-	cleanup := &Cleanup{}
+	if session.Status == StatusCreating {
+		return fmt.Errorf("cannot delete session while it is being created")
+	}
+
+	if session.Resources == nil {
+		session.Resources = &Resources{}
+	}
 
 	if session.WorkspaceID != "" {
 		ws, err := s.workspaceService.GetWorkspace(ctx, session.WorkspaceID)
@@ -303,21 +413,15 @@ func (s *SessionService) DeleteSession(ctx context.Context, id string, deleteBra
 			if session.WorktreePath != "" {
 				if rmErr := s.gitService.RemoveWorktree(ctx, ws.Path, session.WorktreePath); rmErr != nil {
 					slog.Warn("failed to remove worktree", "error", rmErr)
-				} else {
-					cleanup.WorktreeRemoved = true
+				} else if session.Resources.Worktree != nil {
+					session.Resources.Worktree.Status = ResourceRemoved
 				}
 			}
-			if deleteBranch {
-				branchToDelete := session.BranchName
-				if branchToDelete == "" {
-					branchToDelete = session.Branch
-				}
-				if branchToDelete != "" {
-					if brErr := s.gitService.DeleteBranch(ctx, ws.Path, branchToDelete); brErr != nil {
-						slog.Warn("failed to delete branch", "error", brErr)
-					} else {
-						cleanup.BranchDeleted = true
-					}
+			if deleteBranch && session.Branch != "" {
+				if brErr := s.gitService.DeleteBranch(ctx, ws.Path, session.Branch); brErr != nil {
+					slog.Warn("failed to delete branch", "error", brErr)
+				} else if session.Resources.Branch != nil {
+					session.Resources.Branch.Status = ResourceRemoved
 				}
 			}
 		} else {
@@ -327,12 +431,11 @@ func (s *SessionService) DeleteSession(ctx context.Context, id string, deleteBra
 
 	if err := s.tmuxManager.KillSession(session.TmuxSessionName); err != nil {
 		slog.Info("tmux session already gone or failed to kill", "session", session.TmuxSessionName, "error", err)
-	} else {
-		cleanup.TmuxSessionKilled = true
+	} else if session.Resources.Tmux != nil {
+		session.Resources.Tmux.Status = ResourceRemoved
 	}
 
-	session.IsDeleted = true
-	session.Cleanup = cleanup
+	session.Status = StatusDeleted
 
 	return s.store.Update(session)
 }
@@ -362,9 +465,8 @@ func (s *SessionService) handleTmuxSessionCreated(ctx context.Context, event eve
 		return nil
 	}
 
-	sess.IsActive = true
-	sess.IsDead = false
-	return s.store.Update(sess)
+	s.RefreshSession(ctx, sess.ID)
+	return nil
 }
 
 func (s *SessionService) handleTmuxSessionClosed(ctx context.Context, event eventbus.Event) error {
@@ -379,9 +481,11 @@ func (s *SessionService) handleTmuxSessionClosed(ctx context.Context, event even
 		return nil
 	}
 
-	sess.IsDead = true
-	sess.IsActive = false
 	sess.IsAttached = false
+	if sess.Resources != nil && sess.Resources.Tmux != nil {
+		sess.Resources.Tmux.Status = ResourceRemoved
+	}
+	sess.Status = StatusBroken
 	return s.store.Update(sess)
 }
 
@@ -446,26 +550,9 @@ func (s *SessionService) handleTmuxClientDetached(ctx context.Context, event eve
 }
 
 func (s *SessionService) reconcileTmuxState(ctx context.Context) {
-	tmuxNames, err := s.tmuxManager.ListSessionNames()
-	if err != nil {
-		slog.Warn("failed to list tmux sessions for reconciliation", "error", err)
-		return
-	}
-
-	activeSet := make(map[string]bool, len(tmuxNames))
-	for _, name := range tmuxNames {
-		activeSet[name] = true
-	}
-
 	for _, sess := range s.store.List() {
-		if sess.IsActive && !sess.IsDead && !sess.IsDeleted {
-			if !activeSet[sess.TmuxSessionName] {
-				slog.Info("reconciliation: marking session as dead (tmux session gone)", "session", sess.ID, "tmux_name", sess.TmuxSessionName)
-				sess.IsDead = true
-				sess.IsActive = false
-				sess.IsAttached = false
-				s.store.Update(&sess)
-			}
+		if sess.Status != StatusDeleted {
+			s.RefreshSession(ctx, sess.ID)
 		}
 	}
 }

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -73,17 +73,6 @@ func (s *SessionService) resolveWorkspaceName(session *Session) string {
 	return ws.Name
 }
 
-func (s *SessionService) resolveWorkspacePath(session *Session) string {
-	if session.WorkspaceID == "" {
-		return ""
-	}
-	ws, err := s.workspaceService.GetWorkspace(context.Background(), session.WorkspaceID)
-	if err != nil {
-		return ""
-	}
-	return ws.Path
-}
-
 func (s *SessionService) ListSessionsByWorkspace(ctx context.Context, workspaceID string) ([]Session, error) {
 	_, err := s.workspaceService.GetWorkspace(ctx, workspaceID)
 	if err != nil {

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -2,9 +2,11 @@ package session
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,14 +17,66 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type mockTmuxManager struct{}
+type mockTmuxManager struct {
+	mu        sync.Mutex
+	sessions  map[string]bool
+	createErr error
+	killErr   error
+}
 
-func (m *mockTmuxManager) CreateSession(name, startDir string) error { return nil }
-func (m *mockTmuxManager) KillSession(name string) error             { return nil }
-func (m *mockTmuxManager) HasSession(name string) bool               { return false }
-func (m *mockTmuxManager) ListSessionNames() ([]string, error)       { return nil, nil }
+func newMockTmuxManager() *mockTmuxManager {
+	return &mockTmuxManager{sessions: make(map[string]bool)}
+}
 
-func setupSessionService(t *testing.T) (*SessionService, *SessionStore, *workspace.WorkspaceStore) {
+func (m *mockTmuxManager) CreateSession(name, startDir string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.sessions[name] = true
+	return nil
+}
+
+func (m *mockTmuxManager) KillSession(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.killErr != nil {
+		return m.killErr
+	}
+	delete(m.sessions, name)
+	return nil
+}
+
+func (m *mockTmuxManager) HasSession(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.sessions[name]
+}
+
+func (m *mockTmuxManager) ListSessionNames() ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	names := make([]string, 0, len(m.sessions))
+	for name := range m.sessions {
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func (m *mockTmuxManager) setCreateErr(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createErr = err
+}
+
+func (m *mockTmuxManager) removeSession(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.sessions, name)
+}
+
+func setupSessionService(t *testing.T) (*SessionService, *SessionStore, *workspace.WorkspaceStore, *mockTmuxManager) {
 	t.Helper()
 
 	bus := eventbus.NewEventBus()
@@ -32,10 +86,11 @@ func setupSessionService(t *testing.T) (*SessionService, *SessionStore, *workspa
 	workspaceStore.Add(&workspace.Workspace{ID: "ws-1", Name: "utena", Path: "/tmp/utena"})
 	workspaceStore.Add(&workspace.Workspace{ID: "ws-2", Name: "other", Path: "/tmp/other"})
 
+	tmux := newMockTmuxManager()
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, &mockTmuxManager{}, bus, "eqt/")
-	return service, sessionStore, workspaceStore
+	service := NewSessionService(sessionStore, workspaceService, gitService, tmux, bus, "eqt/")
+	return service, sessionStore, workspaceStore, tmux
 }
 
 func waitForStatus(t *testing.T, store *SessionStore, id string, status SessionStatus, timeout time.Duration) {
@@ -48,32 +103,33 @@ func waitForStatus(t *testing.T, store *SessionStore, id string, status SessionS
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("session %q did not reach status %q within %v", id, status, timeout)
+	sess, _ := store.GetByID(id)
+	t.Fatalf("session %q did not reach status %q within %v (current: %q)", id, status, timeout, sess.Status)
 }
 
 func TestNewSessionService(t *testing.T) {
-	service, _, _ := setupSessionService(t)
+	service, _, _, _ := setupSessionService(t)
 	require.NotNil(t, service)
 	require.NotNil(t, service.store)
 	require.NotNil(t, service.workspaceService)
 }
 
 func TestSessionService_OnAppStart(t *testing.T) {
-	service, _, _ := setupSessionService(t)
+	service, _, _, _ := setupSessionService(t)
 	ctx := context.Background()
 	err := service.OnAppStart(ctx)
 	require.NoError(t, err)
 }
 
 func TestSessionService_OnAppEnd(t *testing.T) {
-	service, _, _ := setupSessionService(t)
+	service, _, _, _ := setupSessionService(t)
 	ctx := context.Background()
 	err := service.OnAppEnd(ctx)
 	require.NoError(t, err)
 }
 
 func TestSessionService_ListSessions(t *testing.T) {
-	service, sessionStore, _ := setupSessionService(t)
+	service, sessionStore, _, _ := setupSessionService(t)
 
 	now := time.Now()
 	session1 := &Session{ID: "session-1", Name: "session-1", WorkspaceID: "ws-1", Status: StatusReady, LastUsedAt: now.Add(-1 * time.Hour)}
@@ -90,7 +146,7 @@ func TestSessionService_ListSessions(t *testing.T) {
 }
 
 func TestSessionService_ListSessionsByWorkspace(t *testing.T) {
-	service, sessionStore, _ := setupSessionService(t)
+	service, sessionStore, _, _ := setupSessionService(t)
 
 	now := time.Now()
 	session1 := &Session{ID: "session-1", Name: "session-1", WorkspaceID: "ws-1", Status: StatusReady, LastUsedAt: now.Add(-1 * time.Hour)}
@@ -113,7 +169,7 @@ func TestSessionService_ListSessionsByWorkspace(t *testing.T) {
 }
 
 func TestSessionService_ListSessionsByWorkspace_InvalidWorkspace(t *testing.T) {
-	service, _, _ := setupSessionService(t)
+	service, _, _, _ := setupSessionService(t)
 
 	ctx := context.Background()
 	_, err := service.ListSessionsByWorkspace(ctx, "nonexistent")
@@ -122,7 +178,7 @@ func TestSessionService_ListSessionsByWorkspace_InvalidWorkspace(t *testing.T) {
 }
 
 func TestSessionService_GetSession(t *testing.T) {
-	service, sessionStore, _ := setupSessionService(t)
+	service, sessionStore, _, _ := setupSessionService(t)
 
 	session := &Session{
 		ID:          "session-1",
@@ -143,7 +199,7 @@ func TestSessionService_GetSession(t *testing.T) {
 }
 
 func TestSessionService_GetSession_NotFound(t *testing.T) {
-	service, _, _ := setupSessionService(t)
+	service, _, _, _ := setupSessionService(t)
 
 	ctx := context.Background()
 	_, err := service.GetSession(ctx, "nonexistent")
@@ -152,7 +208,7 @@ func TestSessionService_GetSession_NotFound(t *testing.T) {
 }
 
 func TestSessionService_CreateSession(t *testing.T) {
-	service, sessionStore, _ := setupSessionService(t)
+	service, sessionStore, _, tmux := setupSessionService(t)
 
 	session := &Session{
 		Name:        "session-1",
@@ -172,10 +228,34 @@ func TestSessionService_CreateSession(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "session-1", retrieved.Name)
 	require.False(t, retrieved.LastUsedAt.IsZero())
+	require.Equal(t, ResourceReady, retrieved.Resources.Tmux.Status)
+	require.True(t, tmux.HasSession("utena-session-1"))
+}
+
+func TestSessionService_CreateSession_TmuxFails(t *testing.T) {
+	service, sessionStore, _, tmux := setupSessionService(t)
+	tmux.setCreateErr(fmt.Errorf("connection refused"))
+
+	session := &Session{
+		Name:        "fail-session",
+		WorkspaceID: "ws-1",
+	}
+
+	ctx := context.Background()
+	err := service.CreateSession(ctx, session, false)
+	require.NoError(t, err)
+
+	waitForStatus(t, sessionStore, "utena-fail-session", StatusBroken, 2*time.Second)
+
+	retrieved, err := sessionStore.GetByID("utena-fail-session")
+	require.NoError(t, err)
+	require.Equal(t, StatusBroken, retrieved.Status)
+	require.Equal(t, ResourceFailed, retrieved.Resources.Tmux.Status)
+	require.Contains(t, retrieved.Resources.Tmux.Error, "connection refused")
 }
 
 func TestSessionService_CreateSession_InvalidWorkspace(t *testing.T) {
-	service, _, _ := setupSessionService(t)
+	service, _, _, _ := setupSessionService(t)
 
 	session := &Session{
 		Name:        "session-1",
@@ -190,7 +270,7 @@ func TestSessionService_CreateSession_InvalidWorkspace(t *testing.T) {
 }
 
 func TestSessionService_UpdateSession(t *testing.T) {
-	service, sessionStore, _ := setupSessionService(t)
+	service, sessionStore, _, _ := setupSessionService(t)
 
 	session := &Session{
 		ID:          "session-1",
@@ -213,7 +293,7 @@ func TestSessionService_UpdateSession(t *testing.T) {
 }
 
 func TestSessionService_UpdateSession_InvalidWorkspace(t *testing.T) {
-	service, sessionStore, _ := setupSessionService(t)
+	service, sessionStore, _, _ := setupSessionService(t)
 
 	session := &Session{
 		ID:          "session-1",
@@ -231,17 +311,19 @@ func TestSessionService_UpdateSession_InvalidWorkspace(t *testing.T) {
 }
 
 func TestSessionService_DeleteSession(t *testing.T) {
-	service, sessionStore, _ := setupSessionService(t)
+	service, sessionStore, _, tmux := setupSessionService(t)
 
 	session := &Session{
-		ID:          "session-1",
-		Name:        "session-1",
-		WorkspaceID: "ws-1",
-		Status:      StatusReady,
-		Resources:   &Resources{Tmux: &ResourceState{Status: ResourceReady}},
-		LastUsedAt:  time.Now(),
+		ID:              "session-1",
+		Name:            "session-1",
+		TmuxSessionName: "session-1",
+		WorkspaceID:     "ws-1",
+		Status:          StatusReady,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceReady}},
+		LastUsedAt:      time.Now(),
 	}
 	sessionStore.Add(session)
+	tmux.sessions["session-1"] = true
 
 	ctx := context.Background()
 	err := service.DeleteSession(ctx, "session-1", true)
@@ -250,11 +332,12 @@ func TestSessionService_DeleteSession(t *testing.T) {
 	retrieved, err := sessionStore.GetByID("session-1")
 	require.NoError(t, err)
 	require.Equal(t, StatusDeleted, retrieved.Status)
-	require.NotNil(t, retrieved.Resources)
+	require.Equal(t, ResourceRemoved, retrieved.Resources.Tmux.Status)
+	require.False(t, tmux.HasSession("session-1"))
 }
 
 func TestSessionService_DeleteSession_NotFound(t *testing.T) {
-	service, _, _ := setupSessionService(t)
+	service, _, _, _ := setupSessionService(t)
 
 	ctx := context.Background()
 	err := service.DeleteSession(ctx, "nonexistent", true)
@@ -302,9 +385,10 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 	workspaceStore := workspace.NewWorkspaceStore(afero.NewMemMapFs(), "/config")
 	workspaceStore.Add(&workspace.Workspace{ID: "ws-git", Name: "git-repo", Path: repoPath, IsGitRepo: true})
 
+	tmux := newMockTmuxManager()
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, &mockTmuxManager{}, bus, "eqt/")
+	service := NewSessionService(sessionStore, workspaceService, gitService, tmux, bus, "eqt/")
 
 	session := &Session{
 		Name:          "my-feature",
@@ -327,12 +411,16 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 	expectedPath := filepath.Join(repoPath, ".worktrees", "eqt-my-feature")
 	require.Equal(t, expectedPath, retrieved.WorktreePath)
 	require.Equal(t, "eqt/my-feature", retrieved.Branch)
+	require.Equal(t, ResourceReady, retrieved.Resources.Branch.Status)
+	require.Equal(t, ResourceReady, retrieved.Resources.Worktree.Status)
+	require.Equal(t, ResourceReady, retrieved.Resources.Tmux.Status)
 
 	info, err := os.Stat(expectedPath)
 	require.NoError(t, err)
 	require.True(t, info.IsDir())
 
 	require.Equal(t, "main", retrieved.BaseBranch)
+	require.True(t, tmux.HasSession("git-repo-my-feature"))
 }
 
 func TestSessionService_CreateSession_WithWorktree_InvalidBranch(t *testing.T) {
@@ -343,9 +431,10 @@ func TestSessionService_CreateSession_WithWorktree_InvalidBranch(t *testing.T) {
 	workspaceStore := workspace.NewWorkspaceStore(afero.NewMemMapFs(), "/config")
 	workspaceStore.Add(&workspace.Workspace{ID: "ws-git", Name: "git-repo", Path: repoPath, IsGitRepo: true})
 
+	tmux := newMockTmuxManager()
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, &mockTmuxManager{}, bus, "eqt/")
+	service := NewSessionService(sessionStore, workspaceService, gitService, tmux, bus, "eqt/")
 
 	session := &Session{
 		Name:          "my-feature",
@@ -363,11 +452,13 @@ func TestSessionService_CreateSession_WithWorktree_InvalidBranch(t *testing.T) {
 	retrieved, err := sessionStore.GetByID("git-repo-my-feature")
 	require.NoError(t, err)
 	require.Equal(t, StatusBroken, retrieved.Status)
+	require.Equal(t, ResourceFailed, retrieved.Resources.Branch.Status)
 	require.NotEmpty(t, retrieved.Resources.Branch.Error)
+	require.False(t, tmux.HasSession("git-repo-my-feature"))
 }
 
 func TestSessionService_CreateSession_WithName_ComputesID(t *testing.T) {
-	service, sessionStore, _ := setupSessionService(t)
+	service, sessionStore, _, _ := setupSessionService(t)
 
 	session := &Session{
 		Name:        "main",
@@ -390,7 +481,7 @@ func TestSessionService_CreateSession_WithName_ComputesID(t *testing.T) {
 }
 
 func TestSessionService_CreateSession_WithName_NoWorkspace(t *testing.T) {
-	service, sessionStore, _ := setupSessionService(t)
+	service, sessionStore, _, _ := setupSessionService(t)
 
 	session := &Session{
 		Name: "standalone",
@@ -410,7 +501,7 @@ func TestSessionService_CreateSession_WithName_NoWorkspace(t *testing.T) {
 }
 
 func TestSessionService_CreateSession_NoBranch_SkipsWorktree(t *testing.T) {
-	service, sessionStore, _ := setupSessionService(t)
+	service, sessionStore, _, _ := setupSessionService(t)
 
 	session := &Session{
 		Name:        "my-session",
@@ -434,9 +525,10 @@ func TestSessionService_CreateSession_NonGitWorkspace_SkipsWorktree(t *testing.T
 	workspaceStore := workspace.NewWorkspaceStore(afero.NewMemMapFs(), "/config")
 	workspaceStore.Add(&workspace.Workspace{ID: "ws-nogit", Name: "plain", Path: "/tmp/plain", IsGitRepo: false})
 
+	tmux := newMockTmuxManager()
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, &mockTmuxManager{}, bus, "eqt/")
+	service := NewSessionService(sessionStore, workspaceService, gitService, tmux, bus, "eqt/")
 
 	session := &Session{
 		Name:        "my-session",
@@ -458,7 +550,7 @@ func TestSessionService_CreateSession_NonGitWorkspace_SkipsWorktree(t *testing.T
 }
 
 func TestSessionService_CreateSession_TouchesWorkspace(t *testing.T) {
-	service, _, workspaceStore := setupSessionService(t)
+	service, _, workspaceStore, _ := setupSessionService(t)
 
 	session := &Session{
 		Name:        "session-1",
@@ -475,14 +567,16 @@ func TestSessionService_CreateSession_TouchesWorkspace(t *testing.T) {
 }
 
 func TestSessionService_ActivateSession_TouchesWorkspace(t *testing.T) {
-	service, sessionStore, workspaceStore := setupSessionService(t)
+	service, sessionStore, workspaceStore, tmux := setupSessionService(t)
 
+	tmux.sessions["session-1"] = true
 	session := &Session{
 		ID:              "session-1",
 		Name:            "session-1",
 		TmuxSessionName: "session-1",
 		WorkspaceID:     "ws-1",
 		Status:          StatusReady,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceReady}},
 		LastUsedAt:      time.Now().Add(-1 * time.Hour),
 	}
 	sessionStore.Add(session)
@@ -497,7 +591,7 @@ func TestSessionService_ActivateSession_TouchesWorkspace(t *testing.T) {
 }
 
 func TestSessionService_ActivateSession_RejectsBrokenSession(t *testing.T) {
-	service, sessionStore, _ := setupSessionService(t)
+	service, sessionStore, _, _ := setupSessionService(t)
 
 	session := &Session{
 		ID:              "broken-session",
@@ -514,4 +608,243 @@ func TestSessionService_ActivateSession_RejectsBrokenSession(t *testing.T) {
 	_, err := service.ActivateSession(ctx, "broken-session")
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrCannotActivate)
+}
+
+func TestSessionService_ActivateSession_RecreatesMissingTmux(t *testing.T) {
+	service, sessionStore, _, tmux := setupSessionService(t)
+
+	session := &Session{
+		ID:              "session-1",
+		Name:            "session-1",
+		TmuxSessionName: "session-1",
+		WorkspaceID:     "ws-1",
+		Status:          StatusReady,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceReady}},
+		LastUsedAt:      time.Now(),
+	}
+	sessionStore.Add(session)
+
+	ctx := context.Background()
+	result, err := service.ActivateSession(ctx, "session-1")
+	require.NoError(t, err)
+	require.Equal(t, StatusReady, result.Status)
+	require.True(t, result.IsAttached)
+	require.True(t, tmux.HasSession("session-1"))
+}
+
+func TestSessionService_RefreshSession_DetectsMissingTmux(t *testing.T) {
+	service, sessionStore, _, tmux := setupSessionService(t)
+
+	tmux.sessions["session-1"] = true
+	session := &Session{
+		ID:              "session-1",
+		Name:            "session-1",
+		TmuxSessionName: "session-1",
+		WorkspaceID:     "ws-1",
+		Status:          StatusReady,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceReady}},
+		LastUsedAt:      time.Now(),
+	}
+	sessionStore.Add(session)
+
+	tmux.removeSession("session-1")
+
+	ctx := context.Background()
+	refreshed, err := service.RefreshSession(ctx, "session-1")
+	require.NoError(t, err)
+	require.Equal(t, StatusBroken, refreshed.Status)
+	require.Equal(t, ResourceRemoved, refreshed.Resources.Tmux.Status)
+}
+
+func TestSessionService_RefreshSession_AllHealthy(t *testing.T) {
+	service, sessionStore, _, tmux := setupSessionService(t)
+
+	tmux.sessions["session-1"] = true
+	session := &Session{
+		ID:              "session-1",
+		Name:            "session-1",
+		TmuxSessionName: "session-1",
+		WorkspaceID:     "ws-1",
+		Status:          StatusReady,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceReady}},
+		LastUsedAt:      time.Now(),
+	}
+	sessionStore.Add(session)
+
+	ctx := context.Background()
+	refreshed, err := service.RefreshSession(ctx, "session-1")
+	require.NoError(t, err)
+	require.Equal(t, StatusReady, refreshed.Status)
+	require.Equal(t, ResourceReady, refreshed.Resources.Tmux.Status)
+}
+
+func TestSessionService_RepairSession_RecoversBroken(t *testing.T) {
+	service, sessionStore, _, tmux := setupSessionService(t)
+
+	session := &Session{
+		ID:              "broken-session",
+		Name:            "broken-session",
+		TmuxSessionName: "broken-session",
+		WorkspaceID:     "ws-1",
+		Status:          StatusBroken,
+		Resources: &Resources{
+			Tmux: &ResourceState{Status: ResourceRemoved},
+		},
+		LastUsedAt: time.Now(),
+	}
+	sessionStore.Add(session)
+
+	ctx := context.Background()
+	result, err := service.RepairSession(ctx, "broken-session")
+	require.NoError(t, err)
+	require.Equal(t, StatusCreating, result.Status)
+
+	waitForStatus(t, sessionStore, "broken-session", StatusReady, 2*time.Second)
+
+	retrieved, err := sessionStore.GetByID("broken-session")
+	require.NoError(t, err)
+	require.Equal(t, StatusReady, retrieved.Status)
+	require.Equal(t, ResourceReady, retrieved.Resources.Tmux.Status)
+	require.True(t, tmux.HasSession("broken-session"))
+}
+
+func TestSessionService_RepairSession_StillFailing(t *testing.T) {
+	service, sessionStore, _, tmux := setupSessionService(t)
+	tmux.setCreateErr(fmt.Errorf("still broken"))
+
+	session := &Session{
+		ID:              "broken-session",
+		Name:            "broken-session",
+		TmuxSessionName: "broken-session",
+		WorkspaceID:     "ws-1",
+		Status:          StatusBroken,
+		Resources: &Resources{
+			Tmux: &ResourceState{Status: ResourceRemoved},
+		},
+		LastUsedAt: time.Now(),
+	}
+	sessionStore.Add(session)
+
+	ctx := context.Background()
+	result, err := service.RepairSession(ctx, "broken-session")
+	require.NoError(t, err)
+	require.Equal(t, StatusCreating, result.Status)
+
+	waitForStatus(t, sessionStore, "broken-session", StatusBroken, 2*time.Second)
+
+	retrieved, err := sessionStore.GetByID("broken-session")
+	require.NoError(t, err)
+	require.Equal(t, StatusBroken, retrieved.Status)
+	require.Equal(t, ResourceFailed, retrieved.Resources.Tmux.Status)
+	require.Contains(t, retrieved.Resources.Tmux.Error, "still broken")
+}
+
+func TestSessionService_RepairSession_AlreadyReady(t *testing.T) {
+	service, sessionStore, _, tmux := setupSessionService(t)
+
+	tmux.sessions["ok-session"] = true
+	session := &Session{
+		ID:              "ok-session",
+		Name:            "ok-session",
+		TmuxSessionName: "ok-session",
+		WorkspaceID:     "ws-1",
+		Status:          StatusBroken,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceReady}},
+		LastUsedAt:      time.Now(),
+	}
+	sessionStore.Add(session)
+
+	ctx := context.Background()
+	result, err := service.RepairSession(ctx, "ok-session")
+	require.NoError(t, err)
+	require.Equal(t, StatusReady, result.Status)
+}
+
+func TestSessionService_RepairSession_NotBroken(t *testing.T) {
+	service, sessionStore, _, tmux := setupSessionService(t)
+
+	tmux.sessions["session-1"] = true
+	session := &Session{
+		ID:              "session-1",
+		Name:            "session-1",
+		TmuxSessionName: "session-1",
+		WorkspaceID:     "ws-1",
+		Status:          StatusReady,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceReady}},
+		LastUsedAt:      time.Now(),
+	}
+	sessionStore.Add(session)
+
+	ctx := context.Background()
+	result, err := service.RepairSession(ctx, "session-1")
+	require.NoError(t, err)
+	require.Equal(t, StatusReady, result.Status)
+}
+
+func TestSessionService_Reconcile_MarksMissingTmuxBroken(t *testing.T) {
+	service, sessionStore, _, _ := setupSessionService(t)
+
+	session := &Session{
+		ID:              "session-1",
+		Name:            "session-1",
+		TmuxSessionName: "session-1",
+		WorkspaceID:     "ws-1",
+		Status:          StatusReady,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceReady}},
+		LastUsedAt:      time.Now(),
+	}
+	sessionStore.Add(session)
+
+	ctx := context.Background()
+	service.reconcileTmuxState(ctx)
+
+	retrieved, err := sessionStore.GetByID("session-1")
+	require.NoError(t, err)
+	require.Equal(t, StatusBroken, retrieved.Status)
+	require.Equal(t, ResourceRemoved, retrieved.Resources.Tmux.Status)
+}
+
+func TestSessionService_Reconcile_KeepsHealthyReady(t *testing.T) {
+	service, sessionStore, _, tmux := setupSessionService(t)
+
+	tmux.sessions["session-1"] = true
+	session := &Session{
+		ID:              "session-1",
+		Name:            "session-1",
+		TmuxSessionName: "session-1",
+		WorkspaceID:     "ws-1",
+		Status:          StatusReady,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceReady}},
+		LastUsedAt:      time.Now(),
+	}
+	sessionStore.Add(session)
+
+	ctx := context.Background()
+	service.reconcileTmuxState(ctx)
+
+	retrieved, err := sessionStore.GetByID("session-1")
+	require.NoError(t, err)
+	require.Equal(t, StatusReady, retrieved.Status)
+}
+
+func TestSessionService_Reconcile_SkipsDeleted(t *testing.T) {
+	service, sessionStore, _, _ := setupSessionService(t)
+
+	session := &Session{
+		ID:              "deleted-1",
+		Name:            "deleted-1",
+		TmuxSessionName: "deleted-1",
+		WorkspaceID:     "ws-1",
+		Status:          StatusDeleted,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceRemoved}},
+		LastUsedAt:      time.Now(),
+	}
+	sessionStore.Add(session)
+
+	ctx := context.Background()
+	service.reconcileTmuxState(ctx)
+
+	retrieved, err := sessionStore.GetByID("deleted-1")
+	require.NoError(t, err)
+	require.Equal(t, StatusDeleted, retrieved.Status)
 }

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -38,6 +38,19 @@ func setupSessionService(t *testing.T) (*SessionService, *SessionStore, *workspa
 	return service, sessionStore, workspaceStore
 }
 
+func waitForStatus(t *testing.T, store *SessionStore, id string, status SessionStatus, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		sess, err := store.GetByID(id)
+		if err == nil && sess.Status == status {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("session %q did not reach status %q within %v", id, status, timeout)
+}
+
 func TestNewSessionService(t *testing.T) {
 	service, _, _ := setupSessionService(t)
 	require.NotNil(t, service)
@@ -62,10 +75,9 @@ func TestSessionService_OnAppEnd(t *testing.T) {
 func TestSessionService_ListSessions(t *testing.T) {
 	service, sessionStore, _ := setupSessionService(t)
 
-	// Add test sessions
 	now := time.Now()
-	session1 := &Session{ID: "session-1", Name: "session-1", WorkspaceID: "ws-1", LastUsedAt: now.Add(-1 * time.Hour)}
-	session2 := &Session{ID: "session-2", Name: "session-2", WorkspaceID: "ws-2", LastUsedAt: now}
+	session1 := &Session{ID: "session-1", Name: "session-1", WorkspaceID: "ws-1", Status: StatusReady, LastUsedAt: now.Add(-1 * time.Hour)}
+	session2 := &Session{ID: "session-2", Name: "session-2", WorkspaceID: "ws-2", Status: StatusReady, LastUsedAt: now}
 	sessionStore.Add(session1)
 	sessionStore.Add(session2)
 
@@ -74,18 +86,16 @@ func TestSessionService_ListSessions(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, sessions, 2)
 
-	// Verify MRU sorting
 	require.Equal(t, "session-2", sessions[0].ID, "Most recent session should be first")
 }
 
 func TestSessionService_ListSessionsByWorkspace(t *testing.T) {
 	service, sessionStore, _ := setupSessionService(t)
 
-	// Add test sessions
 	now := time.Now()
-	session1 := &Session{ID: "session-1", Name: "session-1", WorkspaceID: "ws-1", LastUsedAt: now.Add(-1 * time.Hour)}
-	session2 := &Session{ID: "session-2", Name: "session-2", WorkspaceID: "ws-2", LastUsedAt: now}
-	session3 := &Session{ID: "session-3", Name: "session-3", WorkspaceID: "ws-1", LastUsedAt: now}
+	session1 := &Session{ID: "session-1", Name: "session-1", WorkspaceID: "ws-1", Status: StatusReady, LastUsedAt: now.Add(-1 * time.Hour)}
+	session2 := &Session{ID: "session-2", Name: "session-2", WorkspaceID: "ws-2", Status: StatusReady, LastUsedAt: now}
+	session3 := &Session{ID: "session-3", Name: "session-3", WorkspaceID: "ws-1", Status: StatusReady, LastUsedAt: now}
 	sessionStore.Add(session1)
 	sessionStore.Add(session2)
 	sessionStore.Add(session3)
@@ -95,12 +105,10 @@ func TestSessionService_ListSessionsByWorkspace(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, sessions, 2)
 
-	// Verify only ws-1 sessions returned
 	for _, session := range sessions {
 		require.Equal(t, "ws-1", session.WorkspaceID)
 	}
 
-	// Verify MRU sorting
 	require.Equal(t, "session-3", sessions[0].ID, "Most recent ws-1 session should be first")
 }
 
@@ -121,7 +129,7 @@ func TestSessionService_GetSession(t *testing.T) {
 		Name:        "session-1",
 		WorkspaceID: "ws-1",
 		IsAttached:  true,
-		IsActive:    true,
+		Status:      StatusReady,
 		LastUsedAt:  time.Now(),
 	}
 	sessionStore.Add(session)
@@ -147,24 +155,22 @@ func TestSessionService_CreateSession(t *testing.T) {
 	service, sessionStore, _ := setupSessionService(t)
 
 	session := &Session{
-		ID:          "session-1",
 		Name:        "session-1",
 		WorkspaceID: "ws-1",
-		IsAttached:  true,
-		IsActive:    true,
 	}
 
 	ctx := context.Background()
 	err := service.CreateSession(ctx, session, false)
 	require.NoError(t, err)
 
-	// Name is set and workspace exists, so ID is computed as {workspace}-{name}
 	require.Equal(t, "utena-session-1", session.ID)
+	require.Equal(t, StatusCreating, session.Status)
+
+	waitForStatus(t, sessionStore, "utena-session-1", StatusReady, 2*time.Second)
+
 	retrieved, err := sessionStore.GetByID("utena-session-1")
 	require.NoError(t, err)
 	require.Equal(t, "session-1", retrieved.Name)
-
-	// Verify LastUsedAt was set
 	require.False(t, retrieved.LastUsedAt.IsZero())
 }
 
@@ -172,7 +178,6 @@ func TestSessionService_CreateSession_InvalidWorkspace(t *testing.T) {
 	service, _, _ := setupSessionService(t)
 
 	session := &Session{
-		ID:          "session-1",
 		Name:        "session-1",
 		WorkspaceID: "nonexistent",
 		LastUsedAt:  time.Now(),
@@ -192,18 +197,16 @@ func TestSessionService_UpdateSession(t *testing.T) {
 		Name:        "session-1",
 		WorkspaceID: "ws-1",
 		IsAttached:  false,
-		IsActive:    true,
+		Status:      StatusReady,
 		LastUsedAt:  time.Now(),
 	}
 	sessionStore.Add(session)
 
-	// Update session
 	session.IsAttached = true
 	ctx := context.Background()
 	err := service.UpdateSession(ctx, session)
 	require.NoError(t, err)
 
-	// Verify update
 	retrieved, err := sessionStore.GetByID("session-1")
 	require.NoError(t, err)
 	require.True(t, retrieved.IsAttached)
@@ -220,7 +223,6 @@ func TestSessionService_UpdateSession_InvalidWorkspace(t *testing.T) {
 	}
 	sessionStore.Add(session)
 
-	// Try to update with invalid workspace
 	session.WorkspaceID = "nonexistent"
 	ctx := context.Background()
 	err := service.UpdateSession(ctx, session)
@@ -235,6 +237,8 @@ func TestSessionService_DeleteSession(t *testing.T) {
 		ID:          "session-1",
 		Name:        "session-1",
 		WorkspaceID: "ws-1",
+		Status:      StatusReady,
+		Resources:   &Resources{Tmux: &ResourceState{Status: ResourceReady}},
 		LastUsedAt:  time.Now(),
 	}
 	sessionStore.Add(session)
@@ -245,8 +249,8 @@ func TestSessionService_DeleteSession(t *testing.T) {
 
 	retrieved, err := sessionStore.GetByID("session-1")
 	require.NoError(t, err)
-	require.True(t, retrieved.IsDeleted)
-	require.NotNil(t, retrieved.Cleanup)
+	require.Equal(t, StatusDeleted, retrieved.Status)
+	require.NotNil(t, retrieved.Resources)
 }
 
 func TestSessionService_DeleteSession_NotFound(t *testing.T) {
@@ -314,18 +318,20 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "git-repo-my-feature", session.ID)
+
+	waitForStatus(t, sessionStore, "git-repo-my-feature", StatusReady, 5*time.Second)
+
+	retrieved, err := sessionStore.GetByID("git-repo-my-feature")
+	require.NoError(t, err)
+
 	expectedPath := filepath.Join(repoPath, ".worktrees", "eqt-my-feature")
-	require.Equal(t, expectedPath, session.WorktreePath)
-	require.Equal(t, "eqt/my-feature", session.BranchName)
+	require.Equal(t, expectedPath, retrieved.WorktreePath)
+	require.Equal(t, "eqt/my-feature", retrieved.Branch)
 
 	info, err := os.Stat(expectedPath)
 	require.NoError(t, err)
 	require.True(t, info.IsDir())
 
-	retrieved, err := sessionStore.GetByID("git-repo-my-feature")
-	require.NoError(t, err)
-	require.Equal(t, expectedPath, retrieved.WorktreePath)
-	require.Equal(t, "eqt/my-feature", retrieved.BranchName)
 	require.Equal(t, "main", retrieved.BaseBranch)
 }
 
@@ -350,11 +356,14 @@ func TestSessionService_CreateSession_WithWorktree_InvalidBranch(t *testing.T) {
 
 	ctx := context.Background()
 	err := service.CreateSession(ctx, session, true)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to pull branch")
+	require.NoError(t, err)
 
-	_, err = sessionStore.GetByID("git-repo-my-feature")
-	require.Error(t, err)
+	waitForStatus(t, sessionStore, "git-repo-my-feature", StatusBroken, 5*time.Second)
+
+	retrieved, err := sessionStore.GetByID("git-repo-my-feature")
+	require.NoError(t, err)
+	require.Equal(t, StatusBroken, retrieved.Status)
+	require.NotEmpty(t, retrieved.Resources.Branch.Error)
 }
 
 func TestSessionService_CreateSession_WithName_ComputesID(t *testing.T) {
@@ -371,6 +380,8 @@ func TestSessionService_CreateSession_WithName_ComputesID(t *testing.T) {
 
 	require.Equal(t, "utena-main", session.ID)
 	require.Equal(t, "main", session.Name)
+
+	waitForStatus(t, sessionStore, "utena-main", StatusReady, 2*time.Second)
 
 	retrieved, err := sessionStore.GetByID("utena-main")
 	require.NoError(t, err)
@@ -391,6 +402,8 @@ func TestSessionService_CreateSession_WithName_NoWorkspace(t *testing.T) {
 
 	require.Equal(t, "standalone", session.ID)
 
+	waitForStatus(t, sessionStore, "standalone", StatusReady, 2*time.Second)
+
 	retrieved, err := sessionStore.GetByID("standalone")
 	require.NoError(t, err)
 	require.Equal(t, "standalone", retrieved.Name)
@@ -407,7 +420,8 @@ func TestSessionService_CreateSession_NoBranch_SkipsWorktree(t *testing.T) {
 	ctx := context.Background()
 	err := service.CreateSession(ctx, session, false)
 	require.NoError(t, err)
-	require.Empty(t, session.WorktreePath)
+
+	waitForStatus(t, sessionStore, "utena-my-session", StatusReady, 2*time.Second)
 
 	retrieved, err := sessionStore.GetByID("utena-my-session")
 	require.NoError(t, err)
@@ -433,15 +447,20 @@ func TestSessionService_CreateSession_NonGitWorkspace_SkipsWorktree(t *testing.T
 	ctx := context.Background()
 	err := service.CreateSession(ctx, session, false)
 	require.NoError(t, err)
+
 	require.Equal(t, "plain-my-session", session.ID)
-	require.Empty(t, session.WorktreePath)
+
+	waitForStatus(t, sessionStore, "plain-my-session", StatusReady, 2*time.Second)
+
+	retrieved, err := sessionStore.GetByID("plain-my-session")
+	require.NoError(t, err)
+	require.Empty(t, retrieved.WorktreePath)
 }
 
 func TestSessionService_CreateSession_TouchesWorkspace(t *testing.T) {
 	service, _, workspaceStore := setupSessionService(t)
 
 	session := &Session{
-		ID:          "session-1",
 		Name:        "session-1",
 		WorkspaceID: "ws-1",
 	}
@@ -463,6 +482,7 @@ func TestSessionService_ActivateSession_TouchesWorkspace(t *testing.T) {
 		Name:            "session-1",
 		TmuxSessionName: "session-1",
 		WorkspaceID:     "ws-1",
+		Status:          StatusReady,
 		LastUsedAt:      time.Now().Add(-1 * time.Hour),
 	}
 	sessionStore.Add(session)
@@ -476,23 +496,22 @@ func TestSessionService_ActivateSession_TouchesWorkspace(t *testing.T) {
 	require.False(t, ws.LastUsedAt.IsZero())
 }
 
-func TestSessionService_ActivateSession_AutoRevivesDeadSession(t *testing.T) {
+func TestSessionService_ActivateSession_RejectsBrokenSession(t *testing.T) {
 	service, sessionStore, _ := setupSessionService(t)
 
 	session := &Session{
-		ID:              "dead-session",
-		Name:            "dead-session",
-		TmuxSessionName: "dead-session",
+		ID:              "broken-session",
+		Name:            "broken-session",
+		TmuxSessionName: "broken-session",
 		WorkspaceID:     "ws-1",
-		IsDead:          true,
+		Status:          StatusBroken,
+		Resources:       &Resources{Tmux: &ResourceState{Status: ResourceRemoved}},
 		LastUsedAt:      time.Now(),
 	}
 	sessionStore.Add(session)
 
 	ctx := context.Background()
-	result, err := service.ActivateSession(ctx, "dead-session")
-	require.NoError(t, err)
-	require.False(t, result.IsDead)
-	require.True(t, result.IsActive)
-	require.True(t, result.IsAttached)
+	_, err := service.ActivateSession(ctx, "broken-session")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrCannotActivate)
 }

--- a/internal/session/sessionstore.go
+++ b/internal/session/sessionstore.go
@@ -37,6 +37,22 @@ func (s *SessionStore) GetByID(id string) (*Session, error) {
 	}
 
 	copy := *session
+	if session.Resources != nil {
+		resCopy := *session.Resources
+		if session.Resources.Branch != nil {
+			brCopy := *session.Resources.Branch
+			resCopy.Branch = &brCopy
+		}
+		if session.Resources.Worktree != nil {
+			wtCopy := *session.Resources.Worktree
+			resCopy.Worktree = &wtCopy
+		}
+		if session.Resources.Tmux != nil {
+			tmCopy := *session.Resources.Tmux
+			resCopy.Tmux = &tmCopy
+		}
+		copy.Resources = &resCopy
+	}
 	return &copy, nil
 }
 
@@ -163,30 +179,89 @@ func (s *SessionStore) Delete(id string) error {
 	return nil
 }
 
+type legacySession struct {
+	Session
+	IsActive      bool     `json:"is_active"`
+	IsDead        bool     `json:"is_dead"`
+	IsDeleted     bool     `json:"is_deleted"`
+	BranchName    string   `json:"branch_name,omitempty"`
+	WorkspaceName string   `json:"workspace_name,omitempty"`
+	Cleanup       *Cleanup `json:"cleanup,omitempty"`
+}
+
+type Cleanup struct {
+	TmuxSessionKilled bool `json:"tmux_session_killed"`
+	WorktreeRemoved   bool `json:"worktree_removed"`
+	BranchDeleted     bool `json:"branch_deleted"`
+}
+
 func (s *SessionStore) OnAppStart(ctx context.Context) error {
 	data, err := afero.ReadFile(s.fs, s.sessionsPath())
 	if err != nil {
 		return nil
 	}
 
-	loaded := make(map[string]*Session)
-	if err := json.Unmarshal(data, &loaded); err != nil {
+	legacy := make(map[string]*legacySession)
+	if err := json.Unmarshal(data, &legacy); err != nil {
 		return nil
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.sessions = loaded
 
-	for _, session := range s.sessions {
-		if session.Name == "" {
-			session.Name = session.ID
+	s.sessions = make(map[string]*Session, len(legacy))
+	for id, ls := range legacy {
+		sess := &ls.Session
+		sess.ID = id
+
+		if sess.Name == "" {
+			sess.Name = sess.ID
 		}
-		if session.TmuxSessionName == "" {
-			session.TmuxSessionName = session.ID
+		if sess.TmuxSessionName == "" {
+			sess.TmuxSessionName = sess.ID
 		}
+
+		if ls.BranchName != "" && sess.Branch == "" {
+			sess.Branch = ls.BranchName
+		}
+
+		if sess.Status == "" {
+			switch {
+			case ls.IsDeleted:
+				sess.Status = StatusDeleted
+			case ls.IsDead:
+				sess.Status = StatusBroken
+			default:
+				sess.Status = StatusReady
+			}
+		}
+
+		if sess.Resources == nil {
+			res := &Resources{}
+			if sess.Branch != "" {
+				status := ResourceReady
+				if sess.Status == StatusBroken {
+					status = ResourceReady
+				}
+				res.Branch = &ResourceState{Status: status}
+			}
+			if sess.WorktreePath != "" {
+				res.Worktree = &ResourceState{Status: ResourceReady}
+			}
+			tmuxStatus := ResourceReady
+			if sess.Status == StatusBroken {
+				tmuxStatus = ResourceRemoved
+			} else if sess.Status == StatusDeleted {
+				tmuxStatus = ResourceRemoved
+			}
+			res.Tmux = &ResourceState{Status: tmuxStatus}
+			sess.Resources = res
+		}
+
+		s.sessions[id] = sess
 	}
 
+	s.save()
 	return nil
 }
 

--- a/internal/session/sessionstore_test.go
+++ b/internal/session/sessionstore_test.go
@@ -29,7 +29,7 @@ func TestSessionStore_Add(t *testing.T) {
 		ID:          "session-1",
 		WorkspaceID: "ws-1",
 		IsAttached:  true,
-		IsActive:    true,
+		Status:      StatusReady,
 		LastUsedAt:  time.Now(),
 	}
 
@@ -87,7 +87,7 @@ func TestSessionStore_GetByID(t *testing.T) {
 		ID:          "session-1",
 		WorkspaceID: "ws-1",
 		IsAttached:  false,
-		IsActive:    true,
+		Status:      StatusReady,
 		LastUsedAt:  time.Now(),
 	}
 
@@ -98,7 +98,7 @@ func TestSessionStore_GetByID(t *testing.T) {
 	require.Equal(t, session.ID, retrieved.ID)
 	require.Equal(t, session.WorkspaceID, retrieved.WorkspaceID)
 	require.Equal(t, session.IsAttached, retrieved.IsAttached)
-	require.Equal(t, session.IsActive, retrieved.IsActive)
+	require.Equal(t, session.Status, retrieved.Status)
 }
 
 func TestSessionStore_GetByID_NotFound(t *testing.T) {
@@ -180,7 +180,7 @@ func TestSessionStore_Update(t *testing.T) {
 		ID:          "session-1",
 		WorkspaceID: "ws-1",
 		IsAttached:  false,
-		IsActive:    true,
+		Status:      StatusReady,
 		LastUsedAt:  time.Now(),
 	}
 

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -9,6 +9,7 @@ import (
 
 type SessionResponse struct {
 	*Session
+	WorkspaceName string `json:"workspace_name,omitempty"`
 	WorkspacePath string `json:"workspace_path,omitempty"`
 }
 
@@ -16,20 +17,7 @@ func NewSessionResponse(session *Session) *SessionResponse {
 	return &SessionResponse{Session: session}
 }
 
-type ReviveResult struct {
-	Session       *Session
-	WorkspacePath string
-}
-
-func NewReviveResponse(result *ReviveResult) *SessionResponse {
-	return &SessionResponse{
-		Session:       result.Session,
-		WorkspacePath: result.WorkspacePath,
-	}
-}
-
 func (sr *SessionResponse) Render(w http.ResponseWriter, r *http.Request) error {
-
 	return nil
 }
 
@@ -42,7 +30,6 @@ func NewSessionListResponse(sessions []Session) *SessionListResponse {
 }
 
 func (slr *SessionListResponse) Render(w http.ResponseWriter, r *http.Request) error {
-
 	return nil
 }
 
@@ -79,10 +66,8 @@ type UpdateSessionRequest struct {
 }
 
 func (u *UpdateSessionRequest) Bind(r *http.Request) error {
-
 	if u.Session == nil {
 		return errors.New("session cannot be nil")
 	}
-
 	return ValidateSession(u.Session)
 }

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/eleonorayaya/utena/internal/workspace"
 	"github.com/go-chi/render"
 )
 
@@ -13,8 +14,13 @@ type SessionResponse struct {
 	WorkspacePath string `json:"workspace_path,omitempty"`
 }
 
-func NewSessionResponse(session *Session) *SessionResponse {
-	return &SessionResponse{Session: session}
+func NewSessionResponse(session *Session, ws *workspace.Workspace) *SessionResponse {
+	resp := &SessionResponse{Session: session}
+	if ws != nil {
+		resp.WorkspaceName = ws.Name
+		resp.WorkspacePath = ws.Path
+	}
+	return resp
 }
 
 func (sr *SessionResponse) Render(w http.ResponseWriter, r *http.Request) error {
@@ -37,7 +43,7 @@ func RenderSessionList(sessions []Session) []render.Renderer {
 	list := make([]render.Renderer, len(sessions))
 	for i, session := range sessions {
 		s := session
-		list[i] = NewSessionResponse(&s)
+		list[i] = NewSessionResponse(&s, nil)
 	}
 	return list
 }

--- a/internal/tmux/tmuxservice.go
+++ b/internal/tmux/tmuxservice.go
@@ -2,11 +2,14 @@ package tmux
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/GianlucaP106/gotmux/gotmux"
 	"github.com/eleonorayaya/utena/internal/eventbus"
 )
+
+var ErrTmuxNotAvailable = errors.New("tmux is not available")
 
 type TmuxService struct {
 	tmux             *gotmux.Tmux
@@ -37,7 +40,7 @@ func (t *TmuxService) OnAppEnd(ctx context.Context) error {
 
 func (t *TmuxService) CreateSession(name, startDir string) error {
 	if t.tmux == nil {
-		return nil
+		return ErrTmuxNotAvailable
 	}
 	opts := &gotmux.SessionOptions{
 		Name:           name,
@@ -49,7 +52,7 @@ func (t *TmuxService) CreateSession(name, startDir string) error {
 
 func (t *TmuxService) KillSession(name string) error {
 	if t.tmux == nil {
-		return nil
+		return ErrTmuxNotAvailable
 	}
 	sess, err := t.tmux.GetSessionByName(name)
 	if err != nil {
@@ -67,7 +70,7 @@ func (t *TmuxService) HasSession(name string) bool {
 
 func (t *TmuxService) ListSessionNames() ([]string, error) {
 	if t.tmux == nil {
-		return nil, nil
+		return nil, ErrTmuxNotAvailable
 	}
 	sessions, err := t.tmux.ListSessions()
 	if err != nil {

--- a/internal/tmux/tmuxservice.go
+++ b/internal/tmux/tmuxservice.go
@@ -36,6 +36,9 @@ func (t *TmuxService) OnAppEnd(ctx context.Context) error {
 }
 
 func (t *TmuxService) CreateSession(name, startDir string) error {
+	if t.tmux == nil {
+		return nil
+	}
 	opts := &gotmux.SessionOptions{
 		Name:           name,
 		StartDirectory: startDir,
@@ -45,6 +48,9 @@ func (t *TmuxService) CreateSession(name, startDir string) error {
 }
 
 func (t *TmuxService) KillSession(name string) error {
+	if t.tmux == nil {
+		return nil
+	}
 	sess, err := t.tmux.GetSessionByName(name)
 	if err != nil {
 		return err
@@ -53,10 +59,16 @@ func (t *TmuxService) KillSession(name string) error {
 }
 
 func (t *TmuxService) HasSession(name string) bool {
+	if t.tmux == nil {
+		return false
+	}
 	return t.tmux.HasSession(name)
 }
 
 func (t *TmuxService) ListSessionNames() ([]string, error) {
+	if t.tmux == nil {
+		return nil, nil
+	}
 	sessions, err := t.tmux.ListSessions()
 	if err != nil {
 		return nil, err

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/eleonorayaya/utena/internal/tui/router"
 	"github.com/eleonorayaya/utena/internal/tui/sessionform"
 	"github.com/eleonorayaya/utena/internal/tui/sessionlist"
+	"github.com/eleonorayaya/utena/internal/tui/sessionprogress"
 	"github.com/eleonorayaya/utena/internal/tui/statusview"
 	"github.com/eleonorayaya/utena/internal/tui/todoform"
 	"github.com/eleonorayaya/utena/internal/tui/todolist"
@@ -26,12 +27,13 @@ type App struct {
 func NewApp(logPath, port string, initialView router.View) App {
 	baseURL := fmt.Sprintf("http://localhost:%s", port)
 	views := map[router.View]router.ViewEntry{
-		router.SessionListView: &router.ViewAdapter[sessionlist.Model]{Model: sessionlist.New()},
-		router.SessionFormView: &router.ViewAdapter[sessionform.Model]{Model: sessionform.New()},
-		router.TodoListView:    &router.ViewAdapter[todolist.Model]{Model: todolist.New()},
-		router.TodoFormView:    &router.ViewAdapter[todoform.Model]{Model: todoform.New()},
-		router.DebugView:       &router.ViewAdapter[debug.Model]{Model: debug.New(logPath, baseURL)},
-		router.StatusView:      &router.ViewAdapter[statusview.Model]{Model: statusview.New()},
+		router.SessionListView:     &router.ViewAdapter[sessionlist.Model]{Model: sessionlist.New()},
+		router.SessionFormView:     &router.ViewAdapter[sessionform.Model]{Model: sessionform.New()},
+		router.SessionProgressView: &router.ViewAdapter[sessionprogress.Model]{Model: sessionprogress.New()},
+		router.TodoListView:        &router.ViewAdapter[todolist.Model]{Model: todolist.New()},
+		router.TodoFormView:        &router.ViewAdapter[todoform.Model]{Model: todoform.New()},
+		router.DebugView:           &router.ViewAdapter[debug.Model]{Model: debug.New(logPath, baseURL)},
+		router.StatusView:          &router.ViewAdapter[statusview.Model]{Model: statusview.New()},
 	}
 
 	return App{

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -8,6 +8,7 @@ import (
 	"github.com/eleonorayaya/utena/internal/tui/router"
 	"github.com/eleonorayaya/utena/internal/tui/sessionform"
 	"github.com/eleonorayaya/utena/internal/tui/sessionlist"
+	"github.com/eleonorayaya/utena/internal/tui/sessionprogress"
 	"github.com/eleonorayaya/utena/internal/tui/todoform"
 	"github.com/eleonorayaya/utena/internal/tui/todolist"
 	"github.com/eleonorayaya/utena/internal/tui/workspacepicker"
@@ -23,6 +24,7 @@ var (
 	_ ViewModel[router.Router]         = router.Router{}
 	_ ViewModel[sessionlist.Model]     = sessionlist.Model{}
 	_ ViewModel[sessionform.Model]     = sessionform.Model{}
+	_ ViewModel[sessionprogress.Model] = sessionprogress.Model{}
 	_ ViewModel[todolist.Model]        = todolist.Model{}
 	_ ViewModel[todoform.Model]        = todoform.Model{}
 	_ ViewModel[debug.Model]           = debug.Model{}

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -166,35 +166,25 @@ func (c *client) activateSession(name string) tea.Cmd {
 	}
 }
 
-func (c *client) reviveSession(name string) tea.Cmd {
+func (c *client) repairSession(id string) tea.Cmd {
 	return func() tea.Msg {
-		req, err := http.NewRequest(http.MethodPut, c.baseURL+"/sessions/"+name+"/revive", nil)
+		req, err := http.NewRequest(http.MethodPut, c.baseURL+"/sessions/"+id+"/repair", nil)
 		if err != nil {
 			return ErrMsg{err}
 		}
 
 		res, err := c.httpClient.Do(req)
 		if err != nil {
-			log.Printf("[ERROR] revive session %q: %v", name, err)
+			log.Printf("[ERROR] repair session %q: %v", id, err)
 			return ErrMsg{err}
 		}
 		defer res.Body.Close()
 
 		if res.StatusCode != http.StatusOK {
-			return parseAPIError(res, "revive session")
+			return parseAPIError(res, "repair session")
 		}
 
-		var resp struct {
-			WorkspacePath string `json:"workspace_path"`
-			WorktreePath  string `json:"worktree_path"`
-		}
-		json.NewDecoder(res.Body).Decode(&resp)
-
-		return sessionRevivedMsg{
-			name:          name,
-			workspacePath: resp.WorkspacePath,
-			worktreePath:  resp.WorktreePath,
-		}
+		return sessionRepairedMsg{id: id}
 	}
 }
 
@@ -227,17 +217,17 @@ func (c *client) createSession(name, workspaceID, branch string, branchCreated b
 		}
 		defer res.Body.Close()
 
-		if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
+		if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusAccepted {
 			return parseAPIError(res, "create session")
 		}
 
 		var resp struct {
-			ID           string `json:"id"`
-			WorktreePath string `json:"worktree_path"`
+			ID     string `json:"id"`
+			Status string `json:"status"`
 		}
 		json.NewDecoder(res.Body).Decode(&resp)
 
-		return sessionCreatedMsg{id: resp.ID, worktreePath: resp.WorktreePath}
+		return sessionCreatedMsg{id: resp.ID, status: session.SessionStatus(resp.Status)}
 	}
 }
 

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -227,7 +227,7 @@ func (c *client) createSession(name, workspaceID, branch string, branchCreated b
 		}
 		json.NewDecoder(res.Body).Decode(&resp)
 
-		return sessionCreatedMsg{id: resp.ID, status: session.SessionStatus(resp.Status)}
+		return SessionCreatedMsg{ID: resp.ID, Status: session.SessionStatus(resp.Status)}
 	}
 }
 

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -376,6 +376,27 @@ func (c *client) deleteTodo(id string) tea.Cmd {
 	}
 }
 
+func (c *client) getSession(id string) tea.Cmd {
+	return func() tea.Msg {
+		res, err := c.httpClient.Get(c.baseURL + "/sessions/" + id)
+		if err != nil {
+			return ErrMsg{err}
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			return parseAPIError(res, "get session")
+		}
+
+		var resp session.SessionResponse
+		if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+			return ErrMsg{err}
+		}
+
+		return sessionPolledMsg{session: *resp.Session}
+	}
+}
+
 func (c *client) switchTmuxSession(name string) tea.Cmd {
 	return func() tea.Msg {
 		t, err := gotmux.DefaultTmux()

--- a/internal/tui/provider/sessionsprovider.go
+++ b/internal/tui/provider/sessionsprovider.go
@@ -46,8 +46,8 @@ func CreateSession(name, workspaceID, branch, workspacePath string, branchCreate
 	}
 }
 
-func ReviveSession(name string) tea.Cmd {
-	return func() tea.Msg { return reviveSessionIntentMsg{name: name} }
+func RepairSession(id string) tea.Cmd {
+	return func() tea.Msg { return repairSessionIntentMsg{id: id} }
 }
 
 func DeleteSession(id string) tea.Cmd {
@@ -69,8 +69,8 @@ type createSessionIntentMsg struct {
 	branchCreated bool
 }
 
-type reviveSessionIntentMsg struct {
-	name string
+type repairSessionIntentMsg struct {
+	id string
 }
 
 type deleteSessionIntentMsg struct {
@@ -102,14 +102,12 @@ type sessionActivatedMsg struct {
 }
 
 type sessionCreatedMsg struct {
-	id           string
-	worktreePath string
+	id     string
+	status session.SessionStatus
 }
 
-type sessionRevivedMsg struct {
-	name          string
-	workspacePath string
-	worktreePath  string
+type sessionRepairedMsg struct {
+	id string
 }
 
 type sessionDeletedMsg struct {
@@ -117,9 +115,10 @@ type sessionDeletedMsg struct {
 }
 
 type sessionsProvider struct {
-	client         *client
-	sessions       []session.Session
-	claudeSessions map[string][]claude.ClaudeSession
+	client           *client
+	sessions         []session.Session
+	claudeSessions   map[string][]claude.ClaudeSession
+	pendingSessionID string
 }
 
 func newSessionsProvider(c *client) sessionsProvider {
@@ -151,11 +150,43 @@ func (p sessionsProvider) deriveActiveWorkspace() tea.Cmd {
 	}
 }
 
+func (p sessionsProvider) checkPendingSession() tea.Cmd {
+	if p.pendingSessionID == "" {
+		return nil
+	}
+	pendingID := p.pendingSessionID
+	for _, s := range p.sessions {
+		if s.ID == pendingID {
+			switch s.Status {
+			case session.StatusReady:
+				return ActivateSession(pendingID)
+			case session.StatusBroken:
+				errMsg := "session creation failed"
+				if s.Resources != nil {
+					if e := s.Resources.FirstError(); e != "" {
+						errMsg = e
+					}
+				}
+				return func() tea.Msg {
+					return ErrMsg{Err: fmt.Errorf("%s", errMsg)}
+				}
+			}
+			break
+		}
+	}
+	return nil
+}
+
 func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 	switch msg := msg.(type) {
 	case sessionsLoadedMsg:
 		p.sessions = msg.sessions
-		return p, tea.Batch(p.emitState(), p.deriveActiveWorkspace())
+		cmds := []tea.Cmd{p.emitState(), p.deriveActiveWorkspace()}
+		if pendingCmd := p.checkPendingSession(); pendingCmd != nil {
+			p.pendingSessionID = ""
+			cmds = append(cmds, pendingCmd)
+		}
+		return p, tea.Batch(cmds...)
 
 	case claudeSessionsLoadedMsg:
 		p.claudeSessions = make(map[string][]claude.ClaudeSession)
@@ -184,19 +215,13 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 			return p.client.activateSession(name)()
 		}
 
-	case reviveSessionIntentMsg:
-		name := msg.name
-		return p, func() tea.Msg {
-			reviveResult := p.client.reviveSession(name)()
-			if err, ok := reviveResult.(ErrMsg); ok {
-				return err
-			}
-			if _, ok := reviveResult.(sessionRevivedMsg); !ok {
-				return ErrMsg{Err: fmt.Errorf("unexpected result from reviveSession")}
-			}
+	case repairSessionIntentMsg:
+		id := msg.id
+		return p, p.client.repairSession(id)
 
-			return p.client.activateSession(name)()
-		}
+	case sessionRepairedMsg:
+		p.pendingSessionID = msg.id
+		return p, p.client.fetchSessions()
 
 	case createSessionIntentMsg:
 		name := msg.name
@@ -212,12 +237,15 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 			if !ok {
 				return ErrMsg{Err: fmt.Errorf("unexpected result from createSession")}
 			}
-			sessionID := created.id
-
-			return p.client.activateSession(sessionID)()
+			return created
 		}
 
+	case sessionCreatedMsg:
+		p.pendingSessionID = msg.id
+		return p, p.client.fetchSessions()
+
 	case sessionActivatedMsg:
+		p.pendingSessionID = ""
 		return p, p.client.switchTmuxSession(msg.tmuxSessionName)
 
 	case deleteSessionIntentMsg:

--- a/internal/tui/provider/sessionsprovider.go
+++ b/internal/tui/provider/sessionsprovider.go
@@ -1,8 +1,6 @@
 package provider
 
 import (
-	"fmt"
-
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/eleonorayaya/utena/internal/claude"
 	"github.com/eleonorayaya/utena/internal/session"
@@ -105,9 +103,9 @@ type sessionActivatedMsg struct {
 	tmuxSessionName string
 }
 
-type sessionCreatedMsg struct {
-	id     string
-	status session.SessionStatus
+type SessionCreatedMsg struct {
+	ID     string
+	Status session.SessionStatus
 }
 
 type sessionRepairedMsg struct {
@@ -128,11 +126,6 @@ type pollSessionIntentMsg struct {
 
 type SessionPolledMsg struct {
 	Session session.Session
-}
-
-type SessionCreatedMsg struct {
-	ID     string
-	Status session.SessionStatus
 }
 
 type sessionsProvider struct {
@@ -215,24 +208,10 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 		workspaceID := msg.workspaceID
 		branch := msg.branch
 		branchCreated := msg.branchCreated
-		return p, func() tea.Msg {
-			createResult := p.client.createSession(name, workspaceID, branch, branchCreated)()
-			if err, ok := createResult.(ErrMsg); ok {
-				return err
-			}
-			created, ok := createResult.(sessionCreatedMsg)
-			if !ok {
-				return ErrMsg{Err: fmt.Errorf("unexpected result from createSession")}
-			}
-			return created
-		}
+		return p, p.client.createSession(name, workspaceID, branch, branchCreated)
 
-	case sessionCreatedMsg:
-		id := msg.id
-		status := msg.status
-		return p, tea.Batch(p.client.fetchSessions(), func() tea.Msg {
-			return SessionCreatedMsg{ID: id, Status: status}
-		})
+	case SessionCreatedMsg:
+		return p, p.client.fetchSessions()
 
 	case sessionActivatedMsg:
 		return p, p.client.switchTmuxSession(msg.tmuxSessionName)

--- a/internal/tui/provider/sessionsprovider.go
+++ b/internal/tui/provider/sessionsprovider.go
@@ -50,6 +50,10 @@ func RepairSession(id string) tea.Cmd {
 	return func() tea.Msg { return repairSessionIntentMsg{id: id} }
 }
 
+func PollSession(id string) tea.Cmd {
+	return func() tea.Msg { return pollSessionIntentMsg{id: id} }
+}
+
 func DeleteSession(id string) tea.Cmd {
 	return func() tea.Msg { return deleteSessionIntentMsg{id: id} }
 }
@@ -114,11 +118,27 @@ type sessionDeletedMsg struct {
 	id string
 }
 
+type sessionPolledMsg struct {
+	session session.Session
+}
+
+type pollSessionIntentMsg struct {
+	id string
+}
+
+type SessionPolledMsg struct {
+	Session session.Session
+}
+
+type SessionCreatedMsg struct {
+	ID     string
+	Status session.SessionStatus
+}
+
 type sessionsProvider struct {
-	client           *client
-	sessions         []session.Session
-	claudeSessions   map[string][]claude.ClaudeSession
-	pendingSessionID string
+	client         *client
+	sessions       []session.Session
+	claudeSessions map[string][]claude.ClaudeSession
 }
 
 func newSessionsProvider(c *client) sessionsProvider {
@@ -150,43 +170,11 @@ func (p sessionsProvider) deriveActiveWorkspace() tea.Cmd {
 	}
 }
 
-func (p sessionsProvider) checkPendingSession() tea.Cmd {
-	if p.pendingSessionID == "" {
-		return nil
-	}
-	pendingID := p.pendingSessionID
-	for _, s := range p.sessions {
-		if s.ID == pendingID {
-			switch s.Status {
-			case session.StatusReady:
-				return ActivateSession(pendingID)
-			case session.StatusBroken:
-				errMsg := "session creation failed"
-				if s.Resources != nil {
-					if e := s.Resources.FirstError(); e != "" {
-						errMsg = e
-					}
-				}
-				return func() tea.Msg {
-					return ErrMsg{Err: fmt.Errorf("%s", errMsg)}
-				}
-			}
-			break
-		}
-	}
-	return nil
-}
-
 func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 	switch msg := msg.(type) {
 	case sessionsLoadedMsg:
 		p.sessions = msg.sessions
-		cmds := []tea.Cmd{p.emitState(), p.deriveActiveWorkspace()}
-		if pendingCmd := p.checkPendingSession(); pendingCmd != nil {
-			p.pendingSessionID = ""
-			cmds = append(cmds, pendingCmd)
-		}
-		return p, tea.Batch(cmds...)
+		return p, tea.Batch(p.emitState(), p.deriveActiveWorkspace())
 
 	case claudeSessionsLoadedMsg:
 		p.claudeSessions = make(map[string][]claude.ClaudeSession)
@@ -220,7 +208,6 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 		return p, p.client.repairSession(id)
 
 	case sessionRepairedMsg:
-		p.pendingSessionID = msg.id
 		return p, p.client.fetchSessions()
 
 	case createSessionIntentMsg:
@@ -241,11 +228,13 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 		}
 
 	case sessionCreatedMsg:
-		p.pendingSessionID = msg.id
-		return p, p.client.fetchSessions()
+		id := msg.id
+		status := msg.status
+		return p, tea.Batch(p.client.fetchSessions(), func() tea.Msg {
+			return SessionCreatedMsg{ID: id, Status: status}
+		})
 
 	case sessionActivatedMsg:
-		p.pendingSessionID = ""
 		return p, p.client.switchTmuxSession(msg.tmuxSessionName)
 
 	case deleteSessionIntentMsg:
@@ -253,6 +242,14 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 
 	case sessionDeletedMsg:
 		return p, p.client.fetchSessions()
+
+	case pollSessionIntentMsg:
+		return p, p.client.getSession(msg.id)
+
+	case sessionPolledMsg:
+		return p, func() tea.Msg {
+			return SessionPolledMsg{Session: msg.session}
+		}
 	}
 
 	return p, nil

--- a/internal/tui/router/messages.go
+++ b/internal/tui/router/messages.go
@@ -2,12 +2,19 @@ package router
 
 import tea "github.com/charmbracelet/bubbletea"
 
-type NavigateToMsg struct{ Target View }
+type NavigateToMsg struct {
+	Target View
+	Data   any
+}
 
 type BackMsg struct{}
 
 func NavigateTo(target View) tea.Cmd {
 	return func() tea.Msg { return NavigateToMsg{Target: target} }
+}
+
+func NavigateToWithData(target View, data any) tea.Cmd {
+	return func() tea.Msg { return NavigateToMsg{Target: target, Data: data} }
 }
 
 func Back() tea.Cmd {

--- a/internal/tui/router/messages.go
+++ b/internal/tui/router/messages.go
@@ -4,17 +4,12 @@ import tea "github.com/charmbracelet/bubbletea"
 
 type NavigateToMsg struct {
 	Target View
-	Data   any
 }
 
 type BackMsg struct{}
 
 func NavigateTo(target View) tea.Cmd {
 	return func() tea.Msg { return NavigateToMsg{Target: target} }
-}
-
-func NavigateToWithData(target View, data any) tea.Cmd {
-	return func() tea.Msg { return NavigateToMsg{Target: target, Data: data} }
 }
 
 func Back() tea.Cmd {

--- a/internal/tui/router/view.go
+++ b/internal/tui/router/view.go
@@ -5,6 +5,7 @@ type View int
 const (
 	SessionListView View = iota
 	SessionFormView
+	SessionProgressView
 	TodoListView
 	TodoFormView
 	DebugView

--- a/internal/tui/sessionform/sessionform.go
+++ b/internal/tui/sessionform/sessionform.go
@@ -14,6 +14,7 @@ import (
 	"github.com/eleonorayaya/utena/internal/tui/filepicker"
 	"github.com/eleonorayaya/utena/internal/tui/provider"
 	"github.com/eleonorayaya/utena/internal/tui/router"
+	"github.com/eleonorayaya/utena/internal/tui/sessionprogress"
 	"github.com/eleonorayaya/utena/internal/tui/workspacepicker"
 	"github.com/eleonorayaya/utena/internal/workspace"
 )
@@ -102,6 +103,12 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case provider.ErrMsg:
 		m.nameErr = msg.Err.Error()
 		return m, nil
+	case provider.SessionCreatedMsg:
+		id := msg.ID
+		return m, tea.Sequence(
+			router.NavigateTo(router.SessionProgressView),
+			sessionprogress.Start(id),
+		)
 	}
 
 	switch m.activeStep {

--- a/internal/tui/sessionlist/keys.go
+++ b/internal/tui/sessionlist/keys.go
@@ -6,27 +6,27 @@ import (
 )
 
 type keyMap struct {
-	Select     key.Binding
-	Close      key.Binding
-	New        key.Binding
-	Todos      key.Binding
-	ToggleDead key.Binding
+	Select       key.Binding
+	Close        key.Binding
+	New          key.Binding
+	Todos        key.Binding
+	ToggleBroken key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Select, k.Close, k.New, k.Todos, k.ToggleDead}
+	return []key.Binding{k.Select, k.Close, k.New, k.Todos, k.ToggleBroken}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.Select, k.Close, k.New, k.Todos, k.ToggleDead}}
+	return [][]key.Binding{{k.Select, k.Close, k.New, k.Todos, k.ToggleBroken}}
 }
 
 var keys = keyMap{
-	Select:     key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
-	Close:      key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "close")),
-	New:        key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
-	Todos:      key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "todos")),
-	ToggleDead: key.NewBinding(key.WithKeys("."), key.WithHelp(".", "toggle dead")),
+	Select:       key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+	Close:        key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "close")),
+	New:          key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
+	Todos:        key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "todos")),
+	ToggleBroken: key.NewBinding(key.WithKeys("."), key.WithHelp(".", "toggle broken")),
 }
 
 var _ help.KeyMap = keys

--- a/internal/tui/sessionlist/sessionitem.go
+++ b/internal/tui/sessionlist/sessionitem.go
@@ -20,10 +20,15 @@ func (i sessionItem) displayName() string {
 
 func (i sessionItem) Title() string {
 	title := i.displayName()
-	if i.session.IsDead {
-		title += " (dead)"
-	} else if i.session.IsAttached {
-		title += " (attached)"
+	switch i.session.Status {
+	case session.StatusCreating:
+		title += " (creating...)"
+	case session.StatusBroken:
+		title += " (broken)"
+	default:
+		if i.session.IsAttached {
+			title += " (attached)"
+		}
 	}
 	if i.claudeStatus != "" {
 		title += " " + i.claudeStatus

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -17,7 +17,8 @@ type Model struct {
 	sessions        []session.Session
 	claudeSessions  map[string][]claude.ClaudeSession
 	pendingDeleteID string
-	showDead        bool
+	pendingRepairID string
+	showBroken      bool
 }
 
 func New() Model {
@@ -41,10 +42,10 @@ func (m Model) Keys() help.KeyMap {
 func (m *Model) rebuildItems() tea.Cmd {
 	var items []list.Item
 	for _, s := range m.sessions {
-		if s.IsDeleted {
+		if s.Status == session.StatusDeleted {
 			continue
 		}
-		if s.IsDead && !m.showDead {
+		if s.Status == session.StatusBroken && !m.showBroken {
 			continue
 		}
 		status := aggregateClaudeStatus(m.claudeSessions[s.ID])
@@ -90,9 +91,12 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 	if !key.Matches(msg, keys.Close) {
 		m.pendingDeleteID = ""
 	}
+	if !key.Matches(msg, keys.Select) {
+		m.pendingRepairID = ""
+	}
 	switch {
-	case key.Matches(msg, keys.ToggleDead):
-		m.showDead = !m.showDead
+	case key.Matches(msg, keys.ToggleBroken):
+		m.showBroken = !m.showBroken
 		return m, m.rebuildItems(), true
 	case key.Matches(msg, keys.New):
 		return m, router.NavigateTo(router.SessionFormView), true
@@ -103,10 +107,25 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 			if item.session.IsAttached {
 				return m, m.list.NewStatusMessage("already attached to this session"), true
 			}
-			if item.session.IsDead {
-				return m, provider.ReviveSession(item.session.ID), true
+			switch item.session.Status {
+			case session.StatusCreating:
+				return m, m.list.NewStatusMessage("session is still being created"), true
+			case session.StatusBroken:
+				if m.pendingRepairID == item.session.ID {
+					m.pendingRepairID = ""
+					return m, provider.RepairSession(item.session.ID), true
+				}
+				errMsg := "broken"
+				if item.session.Resources != nil {
+					if e := item.session.Resources.FirstError(); e != "" {
+						errMsg = e
+					}
+				}
+				m.pendingRepairID = item.session.ID
+				return m, m.list.NewStatusMessage(errMsg + " — press enter again to repair"), true
+			default:
+				return m, provider.ActivateSession(item.session.ID), true
 			}
-			return m, provider.ActivateSession(item.session.ID), true
 		}
 	case key.Matches(msg, keys.Close):
 		item, ok := m.list.SelectedItem().(sessionItem)

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -10,6 +10,7 @@ import (
 	ulist "github.com/eleonorayaya/utena/internal/tui/list"
 	"github.com/eleonorayaya/utena/internal/tui/provider"
 	"github.com/eleonorayaya/utena/internal/tui/router"
+	"github.com/eleonorayaya/utena/internal/tui/sessionprogress"
 )
 
 type Model struct {
@@ -113,7 +114,14 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 			case session.StatusBroken:
 				if m.pendingRepairID == item.session.ID {
 					m.pendingRepairID = ""
-					return m, provider.RepairSession(item.session.ID), true
+					id := item.session.ID
+					return m, tea.Batch(
+						provider.RepairSession(id),
+						tea.Sequence(
+							router.NavigateTo(router.SessionProgressView),
+							sessionprogress.Start(id),
+						),
+					), true
 				}
 				errMsg := "broken"
 				if item.session.Resources != nil {

--- a/internal/tui/sessionprogress/keys.go
+++ b/internal/tui/sessionprogress/keys.go
@@ -1,0 +1,21 @@
+package sessionprogress
+
+import "github.com/charmbracelet/bubbles/key"
+
+type keyMap struct {
+	Back   key.Binding
+	Repair key.Binding
+}
+
+func (k keyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Repair, k.Back}
+}
+
+func (k keyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{k.Repair, k.Back}}
+}
+
+var keys = keyMap{
+	Back:   key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+	Repair: key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "retry")),
+}

--- a/internal/tui/sessionprogress/model.go
+++ b/internal/tui/sessionprogress/model.go
@@ -1,0 +1,217 @@
+package sessionprogress
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/eleonorayaya/utena/internal/session"
+	"github.com/eleonorayaya/utena/internal/tui/provider"
+	"github.com/eleonorayaya/utena/internal/tui/router"
+)
+
+var (
+	titleStyle   = lipgloss.NewStyle().Bold(true)
+	readyStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	pendingStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	activeStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	failedStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+)
+
+type tickMsg time.Time
+
+type StartMsg struct {
+	SessionID string
+}
+
+func Start(sessionID string) tea.Cmd {
+	return func() tea.Msg { return StartMsg{SessionID: sessionID} }
+}
+
+type Model struct {
+	sessionID string
+	session   *session.Session
+	done      bool
+	err       error
+	width     int
+	height    int
+}
+
+func New() Model {
+	return Model{}
+}
+
+func (m Model) Init() (Model, tea.Cmd) {
+	m.session = nil
+	m.done = false
+	m.err = nil
+	return m, nil
+}
+
+func (m *Model) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+func (m Model) Keys() help.KeyMap {
+	return keys
+}
+
+func tick() tea.Cmd {
+	return tea.Tick(200*time.Millisecond, func(t time.Time) tea.Msg {
+		return tickMsg(t)
+	})
+}
+
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.SetSize(msg.Width, msg.Height)
+		return m, nil
+
+	case StartMsg:
+		m.sessionID = msg.SessionID
+		m.session = nil
+		m.done = false
+		m.err = nil
+		return m, tea.Batch(provider.PollSession(m.sessionID), tick())
+
+	case tickMsg:
+		if m.done || m.sessionID == "" {
+			return m, nil
+		}
+		return m, tea.Batch(provider.PollSession(m.sessionID), tick())
+
+	case provider.SessionPolledMsg:
+		s := msg.Session
+		if s.ID != m.sessionID {
+			return m, nil
+		}
+		m.session = &s
+		switch s.Status {
+		case session.StatusReady:
+			m.done = true
+			return m, provider.ActivateSession(s.ID)
+		case session.StatusBroken:
+			m.done = true
+			errMsg := "session creation failed"
+			if s.Resources != nil {
+				if e := s.Resources.FirstError(); e != "" {
+					errMsg = e
+				}
+			}
+			m.err = fmt.Errorf("%s", errMsg)
+			return m, nil
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.done {
+			if key.Matches(msg, keys.Back) {
+				return m, router.Back()
+			}
+			if m.err != nil && key.Matches(msg, keys.Repair) {
+				m.done = false
+				m.err = nil
+				return m, tea.Batch(
+					provider.RepairSession(m.sessionID),
+					provider.PollSession(m.sessionID),
+					tick(),
+				)
+			}
+		}
+	}
+
+	return m, nil
+}
+
+func (m Model) OnWindowSizeMsg(msg tea.WindowSizeMsg) (Model, tea.Cmd) {
+	m.SetSize(msg.Width, msg.Height)
+	return m, nil
+}
+
+func (m Model) OnKeyMsg(_ tea.KeyMsg) (Model, tea.Cmd, bool) {
+	return m, nil, false
+}
+
+func (m Model) View() string {
+	var b strings.Builder
+
+	name := m.sessionID
+	if m.session != nil && m.session.Name != "" {
+		name = m.session.Name
+	}
+	b.WriteString(titleStyle.Render("Creating session: " + name))
+	b.WriteString("\n\n")
+
+	if m.session != nil && m.session.Resources != nil {
+		res := m.session.Resources
+		if res.Branch != nil {
+			b.WriteString(resourceLine("Branch", res.Branch))
+			b.WriteString("\n")
+		}
+		if res.Worktree != nil {
+			b.WriteString(resourceLine("Worktree", res.Worktree))
+			b.WriteString("\n")
+		}
+		if res.Tmux != nil {
+			b.WriteString(resourceLine("Tmux", res.Tmux))
+			b.WriteString("\n")
+		}
+	} else {
+		b.WriteString(pendingStyle.Render("  Loading..."))
+		b.WriteString("\n")
+	}
+
+	if m.err != nil {
+		b.WriteString("\n")
+		b.WriteString(failedStyle.Render("Error: " + m.err.Error()))
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func resourceLine(name string, rs *session.ResourceState) string {
+	icon := statusIcon(rs.Status)
+	style := statusStyle(rs.Status)
+	line := fmt.Sprintf("  %s %s", icon, style.Render(name))
+	if rs.Error != "" {
+		line += " " + failedStyle.Render("— "+rs.Error)
+	}
+	return line
+}
+
+func statusIcon(s session.ResourceStatus) string {
+	switch s {
+	case session.ResourceReady:
+		return readyStyle.Render("✓")
+	case session.ResourceCreating:
+		return activeStyle.Render("●")
+	case session.ResourcePending:
+		return pendingStyle.Render("○")
+	case session.ResourceFailed:
+		return failedStyle.Render("✗")
+	case session.ResourceRemoved:
+		return failedStyle.Render("–")
+	default:
+		return " "
+	}
+}
+
+func statusStyle(s session.ResourceStatus) lipgloss.Style {
+	switch s {
+	case session.ResourceReady:
+		return readyStyle
+	case session.ResourceCreating:
+		return activeStyle
+	case session.ResourceFailed, session.ResourceRemoved:
+		return failedStyle
+	default:
+		return pendingStyle
+	}
+}

--- a/internal/tui/statusview/model.go
+++ b/internal/tui/statusview/model.go
@@ -187,7 +187,7 @@ func (m Model) collapsePane() {
 func (m Model) activeSessions() []session.Session {
 	var result []session.Session
 	for _, s := range m.sessions {
-		if !s.IsDeleted && !s.IsDead {
+		if s.Status == session.StatusReady || s.Status == session.StatusCreating {
 			result = append(result, s)
 		}
 	}


### PR DESCRIPTION
## Summary
- Replace boolean status fields (IsActive/IsDead/IsDeleted) with a `SessionStatus` enum and per-resource `Resources` tracking (Branch, Worktree, Tmux)
- Make `CreateSession` async — returns immediately with `StatusCreating`, runs setup in a background goroutine with granular resource state updates
- Add `RefreshSession` and `RepairSession` (replaces `ReviveSession`) for health checks and recovery
- Add session progress TUI view that polls `GET /sessions/{id}` to show per-resource creation status with live updates
- Add stateful tmux test mocks with `sync.Mutex` for testing both failure and success paths
- Add migration logic for existing `sessions.json` data

## Test plan
- [x] All existing tests pass with new stateful mocks
- [ ] Create a session with a git workspace — verify progress view shows Branch → Worktree → Tmux transitioning through pending/creating/ready
- [ ] Kill tmux session externally, verify reconciliation marks it broken
- [ ] Repair a broken session from session list — verify progress view shows recovery
- [ ] Verify migration: start daemon with old-format sessions.json, confirm sessions load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)