### PR TITLE
fix(tui): improve statusbar reliability for expand/collapse and cleanup

### DIFF
--- a/internal/tui/statusview/model.go
+++ b/internal/tui/statusview/model.go
@@ -145,7 +145,7 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case key.Matches(msg, keys.Collapse):
 		m.expanded = false
 		m.collapsePane()
-		return m, router.SetHelpVisible(false)
+		return m, tea.Batch(tea.ClearScreen, router.SetHelpVisible(false))
 	}
 	return m, nil
 }
@@ -162,14 +162,27 @@ func (m *Model) syncFocusState() tea.Cmd {
 	active := strings.TrimSpace(output) == "1"
 	if active && !m.expanded {
 		m.expanded = true
-		return router.SetHelpVisible(true)
+		m.expandPane()
+		return tea.Batch(tea.ClearScreen, router.SetHelpVisible(true))
 	}
 	if !active && m.expanded {
 		m.expanded = false
 		m.collapsePane()
-		return router.SetHelpVisible(false)
+		return tea.Batch(tea.ClearScreen, router.SetHelpVisible(false))
 	}
 	return nil
+}
+
+func (m Model) expandPane() {
+	if m.paneID == "" {
+		return
+	}
+	t, err := gotmux.DefaultTmux()
+	if err != nil {
+		return
+	}
+	t.Command("resize-pane", "-y", "8", "-t", m.paneID)
+	t.Command("select-pane", "-e", "-t", m.paneID)
 }
 
 func (m Model) collapsePane() {

--- a/plugins/utena-tmux/scripts/cleanup-status-pane.sh
+++ b/plugins/utena-tmux/scripts/cleanup-status-pane.sh
@@ -10,10 +10,9 @@ if [ -z "$PANES" ]; then
     exit 0
 fi
 
-PANE_COUNT=$(echo "$PANES" | wc -l | tr -d ' ')
-if [ "$PANE_COUNT" -eq 1 ]; then
-    STATUS_PANE=$(echo "$PANES" | grep ' 1$' | awk '{print $1}')
-    if [ -n "$STATUS_PANE" ]; then
-        tmux kill-pane -t "$STATUS_PANE"
-    fi
+NON_STATUS_COUNT=$(echo "$PANES" | grep -v ' 1$' | grep -c . || true)
+if [ "$NON_STATUS_COUNT" -le 1 ]; then
+    echo "$PANES" | grep ' 1$' | awk '{print $1}' | while read -r status_pane; do
+        tmux kill-pane -t "$status_pane" 2>/dev/null
+    done
 fi


### PR DESCRIPTION
- Add expandPane() to actually resize the tmux pane on auto-expand
- Return tea.ClearScreen on expand/collapse transitions to prevent stacked content from broken cursor tracking
- Fix cleanup script to count non-status panes, avoiding race where the dying pane is still listed by tmux list-panes