### PR TITLE
feat: worktree setup scripts on session creation

### DIFF
--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -43,7 +43,7 @@ func newApp(gormDB *gorm.DB, tmuxClient tmux.TmuxClient, fs afero.Fs, cfg Config
 
 	workspaceModule := workspace.NewWorkspaceModule(database, fs, cfg.ConfigDir)
 	tmuxModule := tmux.NewTmuxModule(tmuxClient, bus)
-	sessionModule := session.NewSessionModule(tmuxModule.Service, workspaceModule, bus, database, cfg.BranchPrefix)
+	sessionModule := session.NewSessionModule(tmuxModule.Service, workspaceModule, bus, database, cfg.BranchPrefix, cfg.ConfigDir)
 
 	app := &App{
 		DB:        dbModule,

--- a/internal/session/resources.go
+++ b/internal/session/resources.go
@@ -16,16 +16,17 @@ type ResourceState struct {
 }
 
 type Resources struct {
-	Branch   *ResourceState `json:"branch,omitempty"`
-	Worktree *ResourceState `json:"worktree,omitempty"`
-	Tmux     *ResourceState `json:"tmux,omitempty"`
+	Branch       *ResourceState `json:"branch,omitempty"`
+	Worktree     *ResourceState `json:"worktree,omitempty"`
+	WorktreeInit *ResourceState `json:"worktree_init,omitempty"`
+	Tmux         *ResourceState `json:"tmux,omitempty"`
 }
 
 func (r *Resources) AllReady() bool {
 	if r == nil {
 		return true
 	}
-	for _, rs := range []*ResourceState{r.Branch, r.Worktree, r.Tmux} {
+	for _, rs := range []*ResourceState{r.Branch, r.Worktree, r.WorktreeInit, r.Tmux} {
 		if rs != nil && rs.Status != ResourceReady {
 			return false
 		}
@@ -37,7 +38,7 @@ func (r *Resources) FirstError() string {
 	if r == nil {
 		return ""
 	}
-	for _, rs := range []*ResourceState{r.Branch, r.Worktree, r.Tmux} {
+	for _, rs := range []*ResourceState{r.Branch, r.Worktree, r.WorktreeInit, r.Tmux} {
 		if rs != nil && rs.Error != "" {
 			return rs.Error
 		}

--- a/internal/session/sessionmodule.go
+++ b/internal/session/sessionmodule.go
@@ -17,9 +17,9 @@ type SessionModule struct {
 	Router     *SessionRouter
 }
 
-func NewSessionModule(tmuxService *utmux.TmuxService, workspaceModule *workspace.WorkspaceModule, bus eventbus.EventBus, database db.Database, branchPrefix string) *SessionModule {
+func NewSessionModule(tmuxService *utmux.TmuxService, workspaceModule *workspace.WorkspaceModule, bus eventbus.EventBus, database db.Database, branchPrefix string, configDir string) *SessionModule {
 	store := NewSessionStore(database)
-	service := NewSessionService(store, workspaceModule.Service, workspaceModule.GitService, tmuxService, bus, branchPrefix)
+	service := NewSessionService(store, workspaceModule.Service, workspaceModule.GitService, tmuxService, bus, branchPrefix, configDir)
 	controller := NewSessionController(service)
 	router := NewSessionRouter(controller)
 

--- a/internal/session/sessionrouter_test.go
+++ b/internal/session/sessionrouter_test.go
@@ -34,7 +34,7 @@ func setupSessionRouter(t *testing.T) (*SessionRouter, *SessionStore, *workspace
 	tmuxService := utmux.NewTmuxService(mock, bus)
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, tmuxService, bus, "eqt/")
+	service := NewSessionService(sessionStore, workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir())
 	controller := NewSessionController(service)
 	router := NewSessionRouter(controller)
 

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/eleonorayaya/utena/internal/eventbus"
@@ -20,9 +23,10 @@ type SessionService struct {
 	tmuxService      *utmux.TmuxService
 	eventBus         eventbus.EventBus
 	branchPrefix     string
+	configDir        string
 }
 
-func NewSessionService(store *SessionStore, workspaceService *workspace.WorkspaceService, gitService *git.GitService, tmuxService *utmux.TmuxService, bus eventbus.EventBus, branchPrefix string) *SessionService {
+func NewSessionService(store *SessionStore, workspaceService *workspace.WorkspaceService, gitService *git.GitService, tmuxService *utmux.TmuxService, bus eventbus.EventBus, branchPrefix string, configDir string) *SessionService {
 	return &SessionService{
 		store:            store,
 		workspaceService: workspaceService,
@@ -30,6 +34,7 @@ func NewSessionService(store *SessionStore, workspaceService *workspace.Workspac
 		tmuxService:      tmuxService,
 		eventBus:         bus,
 		branchPrefix:     branchPrefix,
+		configDir:        configDir,
 	}
 }
 
@@ -105,6 +110,7 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, cr
 	if ws != nil && ws.IsGitRepo && createWorktree {
 		res.Branch = &ResourceState{Status: ResourcePending}
 		res.Worktree = &ResourceState{Status: ResourcePending}
+		res.WorktreeInit = &ResourceState{Status: ResourcePending}
 	}
 	session.Resources = res
 	session.Status = StatusCreating
@@ -135,13 +141,23 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace) {
 		return
 	}
 
+	var worktreeCreated bool
+
 	steps := []struct {
-		resource *ResourceState
-		run      func() error
+		resource        *ResourceState
+		run             func() error
+		continueOnError bool
 	}{
-		{sess.Resources.Branch, func() error { return s.setupBranch(ctx, sess, ws) }},
-		{sess.Resources.Worktree, func() error { return s.setupWorktree(ctx, sess, ws) }},
-		{sess.Resources.Tmux, func() error { return s.setupTmux(ctx, sess) }},
+		{sess.Resources.Branch, func() error { return s.setupBranch(ctx, sess, ws) }, false},
+		{sess.Resources.Worktree, func() error {
+			created, err := s.setupWorktree(ctx, sess, ws)
+			worktreeCreated = created
+			return err
+		}, false},
+		{sess.Resources.WorktreeInit, func() error {
+			return s.setupWorktreeInit(ctx, sess, ws, worktreeCreated)
+		}, true},
+		{sess.Resources.Tmux, func() error { return s.setupTmux(ctx, sess) }, false},
 	}
 
 	for _, step := range steps {
@@ -152,6 +168,13 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace) {
 		s.store.Update(sess)
 
 		if err := step.run(); err != nil {
+			if step.continueOnError {
+				slog.Warn("setup step failed, continuing", "error", err)
+				step.resource.Status = ResourceReady
+				step.resource.Error = err.Error()
+				s.store.Update(sess)
+				continue
+			}
 			step.resource.Status = ResourceFailed
 			step.resource.Error = err.Error()
 			sess.Status = StatusBroken
@@ -179,7 +202,7 @@ func (s *SessionService) setupBranch(ctx context.Context, sess *Session, ws *wor
 	return nil
 }
 
-func (s *SessionService) setupWorktree(ctx context.Context, sess *Session, ws *workspace.Workspace) error {
+func (s *SessionService) setupWorktree(ctx context.Context, sess *Session, ws *workspace.Workspace) (bool, error) {
 	creatingNewBranch := sess.BaseBranch != ""
 
 	branchName := sess.Branch
@@ -189,48 +212,110 @@ func (s *SessionService) setupWorktree(ctx context.Context, sess *Session, ws *w
 
 	branchExists, err := s.gitService.HasBranch(ctx, ws.Path, branchName)
 	if err != nil {
-		return fmt.Errorf("failed to check branch %q: %v", branchName, err)
+		return false, fmt.Errorf("failed to check branch %q: %v", branchName, err)
 	}
 	if creatingNewBranch && branchExists {
-		return fmt.Errorf("branch %q already exists; use it as an existing branch instead", branchName)
+		return false, fmt.Errorf("branch %q already exists; use it as an existing branch instead", branchName)
 	}
 	if !creatingNewBranch && !branchExists {
-		return fmt.Errorf("branch %q does not exist; provide a base branch to create it", branchName)
+		return false, fmt.Errorf("branch %q does not exist; provide a base branch to create it", branchName)
 	}
 
 	worktreePath := s.gitService.WorktreePath(ws.Path, branchName)
 
 	exists, err := s.gitService.ValidateWorktree(ctx, worktreePath, branchName)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if exists {
 		sess.WorktreePath = worktreePath
 		sess.Branch = branchName
-		return nil
+		return false, nil
 	}
 
 	if creatingNewBranch {
 		path, err := s.gitService.CreateWorktree(ctx, ws.Path, branchName, sess.BaseBranch)
 		if err != nil {
-			return fmt.Errorf("failed to create worktree: %v", err)
+			return false, fmt.Errorf("failed to create worktree: %v", err)
 		}
 		sess.WorktreePath = path
 		sess.Branch = branchName
 	} else {
 		path, err := s.gitService.CheckoutWorktree(ctx, ws.Path, sess.Branch)
 		if err != nil {
-			return fmt.Errorf("failed to checkout worktree: %v", err)
+			return false, fmt.Errorf("failed to checkout worktree: %v", err)
 		}
 		sess.WorktreePath = path
 	}
-	return nil
+	return true, nil
 }
 
 func (s *SessionService) setupTmux(ctx context.Context, sess *Session) error {
 	startDir := s.resolveStartDir(ctx, sess)
 	if err := s.tmuxService.CreateSession(sess.TmuxSessionName, startDir); err != nil {
 		return fmt.Errorf("failed to create tmux session: %v", err)
+	}
+	return nil
+}
+
+func (s *SessionService) setupWorktreeInit(ctx context.Context, sess *Session, ws *workspace.Workspace, worktreeCreated bool) error {
+	if !worktreeCreated {
+		return nil
+	}
+
+	env := []string{
+		"UTENA_WORKTREE_PATH=" + sess.WorktreePath,
+		"UTENA_BRANCH=" + sess.Branch,
+		"UTENA_SESSION_NAME=" + sess.Name,
+	}
+	if ws != nil {
+		env = append(env,
+			"UTENA_WORKSPACE_NAME="+ws.Name,
+			"UTENA_WORKSPACE_PATH="+ws.Path,
+		)
+	}
+
+	scripts := []string{
+		filepath.Join(s.configDir, "worktree-setup"),
+	}
+	if ws != nil {
+		scripts = append(scripts, filepath.Join(ws.Path, ".utena", "worktree-setup"))
+	}
+
+	var warnings []string
+	for _, script := range scripts {
+		if err := s.runScript(ctx, script, sess.WorktreePath, env); err != nil {
+			slog.Warn("worktree setup script failed", "script", script, "error", err)
+			warnings = append(warnings, err.Error())
+		}
+	}
+
+	if len(warnings) > 0 {
+		return fmt.Errorf("%s", strings.Join(warnings, "; "))
+	}
+	return nil
+}
+
+func (s *SessionService) runScript(ctx context.Context, path string, workDir string, env []string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to stat script %s: %w", path, err)
+	}
+
+	if info.Mode()&0111 == 0 {
+		return fmt.Errorf("script %s exists but is not executable", path)
+	}
+
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(), env...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("script %s failed: %s: %w", path, strings.TrimSpace(string(output)), err)
 	}
 	return nil
 }
@@ -286,7 +371,7 @@ func (s *SessionService) RepairSession(ctx context.Context, id uint) (*Session, 
 	}
 
 	if sess.Resources != nil {
-		for _, rs := range []*ResourceState{sess.Resources.Branch, sess.Resources.Worktree, sess.Resources.Tmux} {
+		for _, rs := range []*ResourceState{sess.Resources.Branch, sess.Resources.Worktree, sess.Resources.WorktreeInit, sess.Resources.Tmux} {
 			if rs != nil && rs.Status != ResourceReady {
 				rs.Status = ResourcePending
 				rs.Error = ""

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -102,7 +102,7 @@ func setupSessionService(t *testing.T) (*SessionService, *SessionStore, *workspa
 	tmuxService := utmux.NewTmuxService(mock, bus)
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, tmuxService, bus, "eqt/")
+	service := NewSessionService(sessionStore, workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir())
 	return service, sessionStore, workspaceStore, mock, ws1.ID, ws2.ID
 }
 
@@ -389,8 +389,8 @@ func initTestRepo(t *testing.T) string {
 	return dir
 }
 
-func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
-	repoPath := initTestRepo(t)
+func setupWorktreeSessionService(t *testing.T, repoPath string, configDir string) (*SessionService, *SessionStore, *mockTmuxClient, uint) {
+	t.Helper()
 
 	database := setupTestDB(t)
 	bus := eventbus.NewEventBus()
@@ -403,11 +403,17 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 	tmuxService := utmux.NewTmuxService(mock, bus)
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, tmuxService, bus, "eqt/")
+	service := NewSessionService(sessionStore, workspaceService, gitService, tmuxService, bus, "eqt/", configDir)
+	return service, sessionStore, mock, wsGit.ID
+}
+
+func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
+	repoPath := initTestRepo(t)
+	service, sessionStore, mock, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
 
 	session := &Session{
 		Name:        "my-feature",
-		WorkspaceID: wsGit.ID,
+		WorkspaceID: wsGitID,
 		BaseBranch:  "main",
 	}
 
@@ -427,6 +433,7 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 	require.Equal(t, "eqt/my-feature", retrieved.Branch)
 	require.Equal(t, ResourceReady, retrieved.Resources.Branch.Status)
 	require.Equal(t, ResourceReady, retrieved.Resources.Worktree.Status)
+	require.Equal(t, ResourceReady, retrieved.Resources.WorktreeInit.Status)
 	require.Equal(t, ResourceReady, retrieved.Resources.Tmux.Status)
 
 	info, err := os.Stat(expectedPath)
@@ -439,19 +446,7 @@ func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
 
 func TestSessionService_CreateSession_WithWorktree_ReusesExistingBranch(t *testing.T) {
 	repoPath := initTestRepo(t)
-
-	database := setupTestDB(t)
-	bus := eventbus.NewEventBus()
-	sessionStore := NewSessionStore(database)
-	workspaceStore := workspace.NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
-	wsGit := &workspace.Workspace{Name: "git-repo", Path: repoPath, IsGitRepo: true}
-	workspaceStore.Add(wsGit)
-
-	mock := newMockTmuxClient()
-	tmuxService := utmux.NewTmuxService(mock, bus)
-	workspaceService := workspace.NewWorkspaceService(workspaceStore)
-	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, tmuxService, bus, "eqt/")
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
 
 	ctx := context.Background()
 	branchName := "feature/checkout-me"
@@ -466,7 +461,7 @@ func TestSessionService_CreateSession_WithWorktree_ReusesExistingBranch(t *testi
 
 	session := &Session{
 		Name:        branchName,
-		WorkspaceID: wsGit.ID,
+		WorkspaceID: wsGitID,
 		Branch:      branchName,
 	}
 
@@ -484,23 +479,11 @@ func TestSessionService_CreateSession_WithWorktree_ReusesExistingBranch(t *testi
 
 func TestSessionService_CreateSession_WithWorktree_InvalidBranch(t *testing.T) {
 	repoPath := initTestRepo(t)
-
-	database := setupTestDB(t)
-	bus := eventbus.NewEventBus()
-	sessionStore := NewSessionStore(database)
-	workspaceStore := workspace.NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
-	wsGit := &workspace.Workspace{Name: "git-repo", Path: repoPath, IsGitRepo: true}
-	workspaceStore.Add(wsGit)
-
-	mock := newMockTmuxClient()
-	tmuxService := utmux.NewTmuxService(mock, bus)
-	workspaceService := workspace.NewWorkspaceService(workspaceStore)
-	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, tmuxService, bus, "eqt/")
+	service, sessionStore, mock, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
 
 	session := &Session{
 		Name:        "my-feature",
-		WorkspaceID: wsGit.ID,
+		WorkspaceID: wsGitID,
 		BaseBranch:  "nonexistent",
 	}
 
@@ -593,7 +576,7 @@ func TestSessionService_CreateSession_NonGitWorkspace_SkipsWorktree(t *testing.T
 	tmuxService := utmux.NewTmuxService(mock, bus)
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitService := git.NewGitService()
-	service := NewSessionService(sessionStore, workspaceService, gitService, tmuxService, bus, "eqt/")
+	service := NewSessionService(sessionStore, workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir())
 
 	session := &Session{
 		Name:        "my-session",
@@ -900,4 +883,176 @@ func TestSessionService_Reconcile_SkipsDeleted(t *testing.T) {
 	retrieved, err := sessionStore.GetByID(session.ID)
 	require.NoError(t, err)
 	require.Equal(t, StatusDeleted, retrieved.Status)
+}
+
+func writeScript(t *testing.T, path string, script string) {
+	t.Helper()
+	dir := filepath.Dir(path)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, os.WriteFile(path, []byte(script), 0755))
+}
+
+func TestSessionService_WorktreeInit_RunsUserLevelScript(t *testing.T) {
+	repoPath := initTestRepo(t)
+	configDir := t.TempDir()
+	markerFile := filepath.Join(t.TempDir(), "user-marker")
+
+	writeScript(t, filepath.Join(configDir, "worktree-setup"), fmt.Sprintf("#!/bin/sh\necho \"$UTENA_BRANCH\" > %s\n", markerFile))
+
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, configDir)
+
+	session := &Session{
+		Name:        "init-test",
+		WorkspaceID: wsGitID,
+		BaseBranch:  "main",
+	}
+
+	ctx := context.Background()
+	err := service.CreateSession(ctx, session, true)
+	require.NoError(t, err)
+
+	waitForStatus(t, sessionStore, session.ID, StatusReady, 5*time.Second)
+
+	data, err := os.ReadFile(markerFile)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "eqt/init-test")
+}
+
+func TestSessionService_WorktreeInit_RunsRepoLevelScript(t *testing.T) {
+	repoPath := initTestRepo(t)
+	markerFile := filepath.Join(t.TempDir(), "repo-marker")
+
+	writeScript(t, filepath.Join(repoPath, ".utena", "worktree-setup"), fmt.Sprintf("#!/bin/sh\necho \"$UTENA_WORKSPACE_NAME\" > %s\n", markerFile))
+
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	session := &Session{
+		Name:        "repo-init",
+		WorkspaceID: wsGitID,
+		BaseBranch:  "main",
+	}
+
+	ctx := context.Background()
+	err := service.CreateSession(ctx, session, true)
+	require.NoError(t, err)
+
+	waitForStatus(t, sessionStore, session.ID, StatusReady, 5*time.Second)
+
+	data, err := os.ReadFile(markerFile)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "git-repo")
+}
+
+func TestSessionService_WorktreeInit_SkipsWhenReusingWorktree(t *testing.T) {
+	repoPath := initTestRepo(t)
+	configDir := t.TempDir()
+	markerFile := filepath.Join(t.TempDir(), "should-not-exist")
+
+	writeScript(t, filepath.Join(configDir, "worktree-setup"), fmt.Sprintf("#!/bin/sh\ntouch %s\n", markerFile))
+
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, configDir)
+
+	branchName := "feature/reuse-me"
+	worktreePath := filepath.Join(repoPath, ".worktrees", "feature-reuse-me")
+	cmd := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branchName, worktreePath, "main")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "pre-create worktree failed: %s", string(out))
+
+	pushCmd := exec.Command("git", "-C", worktreePath, "push", "-u", "origin", branchName)
+	out, err = pushCmd.CombinedOutput()
+	require.NoError(t, err, "push branch failed: %s", string(out))
+
+	session := &Session{
+		Name:        branchName,
+		WorkspaceID: wsGitID,
+		Branch:      branchName,
+	}
+
+	ctx := context.Background()
+	err = service.CreateSession(ctx, session, true)
+	require.NoError(t, err)
+
+	waitForStatus(t, sessionStore, session.ID, StatusReady, 5*time.Second)
+
+	_, err = os.Stat(markerFile)
+	require.True(t, os.IsNotExist(err), "script should not have run for reused worktree")
+}
+
+func TestSessionService_WorktreeInit_FailingScriptContinues(t *testing.T) {
+	repoPath := initTestRepo(t)
+	configDir := t.TempDir()
+
+	writeScript(t, filepath.Join(configDir, "worktree-setup"), "#!/bin/sh\nexit 1\n")
+
+	service, sessionStore, mock, wsGitID := setupWorktreeSessionService(t, repoPath, configDir)
+
+	session := &Session{
+		Name:        "fail-init",
+		WorkspaceID: wsGitID,
+		BaseBranch:  "main",
+	}
+
+	ctx := context.Background()
+	err := service.CreateSession(ctx, session, true)
+	require.NoError(t, err)
+
+	waitForStatus(t, sessionStore, session.ID, StatusReady, 5*time.Second)
+
+	retrieved, err := sessionStore.GetByID(session.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusReady, retrieved.Status)
+	require.Equal(t, ResourceReady, retrieved.Resources.WorktreeInit.Status)
+	require.NotEmpty(t, retrieved.Resources.WorktreeInit.Error)
+	require.True(t, mock.HasSession("git-repo-fail-init"))
+}
+
+func TestSessionService_WorktreeInit_MissingScriptsSkipped(t *testing.T) {
+	repoPath := initTestRepo(t)
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	session := &Session{
+		Name:        "no-scripts",
+		WorkspaceID: wsGitID,
+		BaseBranch:  "main",
+	}
+
+	ctx := context.Background()
+	err := service.CreateSession(ctx, session, true)
+	require.NoError(t, err)
+
+	waitForStatus(t, sessionStore, session.ID, StatusReady, 5*time.Second)
+
+	retrieved, err := sessionStore.GetByID(session.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusReady, retrieved.Status)
+	require.Equal(t, ResourceReady, retrieved.Resources.WorktreeInit.Status)
+	require.Empty(t, retrieved.Resources.WorktreeInit.Error)
+}
+
+func TestSessionService_WorktreeInit_WorkingDirIsWorktree(t *testing.T) {
+	repoPath := initTestRepo(t)
+	configDir := t.TempDir()
+	markerFile := filepath.Join(t.TempDir(), "pwd-marker")
+
+	writeScript(t, filepath.Join(configDir, "worktree-setup"), fmt.Sprintf("#!/bin/sh\npwd > %s\n", markerFile))
+
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, configDir)
+
+	session := &Session{
+		Name:        "wd-test",
+		WorkspaceID: wsGitID,
+		BaseBranch:  "main",
+	}
+
+	ctx := context.Background()
+	err := service.CreateSession(ctx, session, true)
+	require.NoError(t, err)
+
+	waitForStatus(t, sessionStore, session.ID, StatusReady, 5*time.Second)
+
+	data, err := os.ReadFile(markerFile)
+	require.NoError(t, err)
+
+	retrieved, _ := sessionStore.GetByID(session.ID)
+	require.Contains(t, string(data), retrieved.WorktreePath)
 }

--- a/internal/tui/sessionprogress/model.go
+++ b/internal/tui/sessionprogress/model.go
@@ -158,6 +158,10 @@ func (m Model) View() string {
 			b.WriteString(resourceLine("Worktree", res.Worktree))
 			b.WriteString("\n")
 		}
+		if res.WorktreeInit != nil {
+			b.WriteString(resourceLine("Setup", res.WorktreeInit))
+			b.WriteString("\n")
+		}
 		if res.Tmux != nil {
 			b.WriteString(resourceLine("Tmux", res.Tmux))
 			b.WriteString("\n")


### PR DESCRIPTION
## Summary
- Add a `WorktreeInit` step to the session creation pipeline that runs optional setup scripts after a new worktree is created
- Supports two script layers: user-level (`~/.config/utena/worktree-setup`) for global setup and repo-level (`.utena/worktree-setup`) for project-specific setup
- Scripts receive context via env vars (`UTENA_WORKTREE_PATH`, `UTENA_BRANCH`, `UTENA_SESSION_NAME`, `UTENA_WORKSPACE_NAME`, `UTENA_WORKSPACE_PATH`) and run with the worktree as working directory
- Script failures log warnings but do not break session creation — the `continueOnError` pipeline flag ensures the session still becomes ready

## Test plan
- [x] All existing tests pass
- [x] New tests: user-level script runs with correct env vars
- [x] New tests: repo-level script runs
- [x] New tests: scripts skipped when reusing existing worktree
- [x] New tests: failing script continues without breaking session
- [x] New tests: missing scripts silently skipped
- [x] New tests: working directory set to worktree path