### PR TITLE
fix(claude): improve session status transitions for hooks

### DIFF
--- a/internal/claude/claudeservice.go
+++ b/internal/claude/claudeservice.go
@@ -22,6 +22,7 @@ func NewClaudeService(store *ClaudeStore, bus eventbus.EventBus) *ClaudeService 
 
 func (s *ClaudeService) OnAppStart(ctx context.Context) error {
 	s.eventBus.Subscribe(eventbus.SessionActivated, s.handleSessionActivated)
+	s.eventBus.Subscribe(eventbus.TmuxClientSessionChanged, s.handleTmuxClientSessionChanged)
 	return nil
 }
 
@@ -32,6 +33,15 @@ func (s *ClaudeService) handleSessionActivated(ctx context.Context, event eventb
 	}
 
 	s.store.UpdateStatusBySessionID(data.SessionName, StatusReadyForReview, StatusCompleted)
+	return nil
+}
+
+func (s *ClaudeService) handleTmuxClientSessionChanged(ctx context.Context, event eventbus.Event) error {
+	data, ok := event.Data.(eventbus.TmuxHookEvent)
+	if !ok {
+		return fmt.Errorf("unexpected event data type: %T", event.Data)
+	}
+	s.store.UpdateStatusBySessionID(data.TmuxSessionName, StatusReadyForReview, StatusCompleted)
 	return nil
 }
 
@@ -52,6 +62,9 @@ func (s *ClaudeService) HandleHookEvent(ctx context.Context, req *HookEventReque
 			return s.upsertWithStatus(req, StatusNeedsAttention)
 		}
 		return nil
+
+	case "PreToolUse":
+		return s.store.UpdateStatusByClaudeSessionID(req.ClaudeSessionID, StatusNeedsAttention, StatusWorking)
 
 	case "TaskCompleted":
 		return s.upsertWithStatus(req, StatusReadyForReview)

--- a/internal/claude/claudeservice_test.go
+++ b/internal/claude/claudeservice_test.go
@@ -1,0 +1,175 @@
+package claude
+
+import (
+	"context"
+	"testing"
+
+	"github.com/eleonorayaya/utena/internal/eventbus"
+	"github.com/stretchr/testify/require"
+)
+
+func setupService(t *testing.T) (*ClaudeService, *ClaudeStore) {
+	t.Helper()
+	database := setupTestDB(t)
+	store := NewClaudeStore(database)
+	bus := eventbus.NewEventBus()
+	service := NewClaudeService(store, bus)
+	service.OnAppStart(context.Background())
+	return service, store
+}
+
+func TestPreToolUse_ClearsNeedsAttention(t *testing.T) {
+	service, store := setupService(t)
+	store.Upsert(&ClaudeSession{
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+		Status:          StatusNeedsAttention,
+	})
+
+	err := service.HandleHookEvent(context.Background(), &HookEventRequest{
+		Event:           "PreToolUse",
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+	})
+	require.NoError(t, err)
+
+	sessions := store.ListBySessionID("sess-1")
+	require.Len(t, sessions, 1)
+	require.Equal(t, StatusWorking, sessions[0].Status)
+}
+
+func TestPreToolUse_NoOpWhenWorking(t *testing.T) {
+	service, store := setupService(t)
+	store.Upsert(&ClaudeSession{
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+		Status:          StatusWorking,
+	})
+
+	err := service.HandleHookEvent(context.Background(), &HookEventRequest{
+		Event:           "PreToolUse",
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+	})
+	require.NoError(t, err)
+
+	sessions := store.ListBySessionID("sess-1")
+	require.Len(t, sessions, 1)
+	require.Equal(t, StatusWorking, sessions[0].Status)
+}
+
+func TestPreToolUse_NoOpWhenReadyForReview(t *testing.T) {
+	service, store := setupService(t)
+	store.Upsert(&ClaudeSession{
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+		Status:          StatusReadyForReview,
+	})
+
+	err := service.HandleHookEvent(context.Background(), &HookEventRequest{
+		Event:           "PreToolUse",
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+	})
+	require.NoError(t, err)
+
+	sessions := store.ListBySessionID("sess-1")
+	require.Len(t, sessions, 1)
+	require.Equal(t, StatusReadyForReview, sessions[0].Status)
+}
+
+func TestFullFlow_NeedsAttentionToWorkingViaPreToolUse(t *testing.T) {
+	service, store := setupService(t)
+	ctx := context.Background()
+
+	service.HandleHookEvent(ctx, &HookEventRequest{
+		Event:           "SessionStart",
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+		CWD:             "/tmp",
+	})
+	sessions := store.ListBySessionID("sess-1")
+	require.Equal(t, StatusWorking, sessions[0].Status)
+
+	service.HandleHookEvent(ctx, &HookEventRequest{
+		Event:            "Notification",
+		ClaudeSessionID:  "cs-1",
+		SessionID:        "sess-1",
+		NotificationType: "permission_prompt",
+	})
+	sessions = store.ListBySessionID("sess-1")
+	require.Equal(t, StatusNeedsAttention, sessions[0].Status)
+
+	service.HandleHookEvent(ctx, &HookEventRequest{
+		Event:           "PreToolUse",
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+	})
+	sessions = store.ListBySessionID("sess-1")
+	require.Equal(t, StatusWorking, sessions[0].Status)
+
+	service.HandleHookEvent(ctx, &HookEventRequest{
+		Event:           "Stop",
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+	})
+	sessions = store.ListBySessionID("sess-1")
+	require.Equal(t, StatusReadyForReview, sessions[0].Status)
+}
+
+func TestTmuxClientSessionChanged_ClearsReadyForReview(t *testing.T) {
+	service, store := setupService(t)
+	store.Upsert(&ClaudeSession{
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+		Status:          StatusReadyForReview,
+	})
+
+	err := service.eventBus.Publish(context.Background(), eventbus.Event{
+		Type: eventbus.TmuxClientSessionChanged,
+		Data: eventbus.TmuxHookEvent{TmuxSessionName: "sess-1"},
+	})
+	require.NoError(t, err)
+
+	sessions := store.ListBySessionID("sess-1")
+	require.Len(t, sessions, 1)
+	require.Equal(t, StatusCompleted, sessions[0].Status)
+}
+
+func TestTmuxClientSessionChanged_DoesNotAffectWorking(t *testing.T) {
+	service, store := setupService(t)
+	store.Upsert(&ClaudeSession{
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+		Status:          StatusWorking,
+	})
+
+	err := service.eventBus.Publish(context.Background(), eventbus.Event{
+		Type: eventbus.TmuxClientSessionChanged,
+		Data: eventbus.TmuxHookEvent{TmuxSessionName: "sess-1"},
+	})
+	require.NoError(t, err)
+
+	sessions := store.ListBySessionID("sess-1")
+	require.Len(t, sessions, 1)
+	require.Equal(t, StatusWorking, sessions[0].Status)
+}
+
+func TestTmuxClientSessionChanged_DoesNotAffectNeedsAttention(t *testing.T) {
+	service, store := setupService(t)
+	store.Upsert(&ClaudeSession{
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+		Status:          StatusNeedsAttention,
+	})
+
+	err := service.eventBus.Publish(context.Background(), eventbus.Event{
+		Type: eventbus.TmuxClientSessionChanged,
+		Data: eventbus.TmuxHookEvent{TmuxSessionName: "sess-1"},
+	})
+	require.NoError(t, err)
+
+	sessions := store.ListBySessionID("sess-1")
+	require.Len(t, sessions, 1)
+	require.Equal(t, StatusNeedsAttention, sessions[0].Status)
+}

--- a/internal/claude/claudestore.go
+++ b/internal/claude/claudestore.go
@@ -55,6 +55,12 @@ func (s *ClaudeStore) UpdateStatusBySessionID(sessionID string, from, to ClaudeS
 		Update("status", to)
 }
 
+func (s *ClaudeStore) UpdateStatusByClaudeSessionID(claudeSessionID string, from, to ClaudeSessionStatus) error {
+	return s.db.Model(&ClaudeSession{}).
+		Where("claude_session_id = ? AND status = ?", claudeSessionID, from).
+		Update("status", to).Error
+}
+
 func (s *ClaudeStore) DeleteByClaudeSessionID(claudeSessionID string) error {
 	if claudeSessionID == "" {
 		return errors.New("claude session ID cannot be empty")

--- a/internal/claude/claudestore_test.go
+++ b/internal/claude/claudestore_test.go
@@ -1,0 +1,63 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestDB(t *testing.T) db.Database {
+	t.Helper()
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	database.Migrate(&ClaudeSession{})
+	t.Cleanup(func() { database.Close() })
+	return database
+}
+
+func setupStore(t *testing.T) *ClaudeStore {
+	t.Helper()
+	return NewClaudeStore(setupTestDB(t))
+}
+
+func TestUpdateStatusByClaudeSessionID_MatchingFromStatus(t *testing.T) {
+	store := setupStore(t)
+	store.Upsert(&ClaudeSession{
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+		Status:          StatusNeedsAttention,
+	})
+
+	err := store.UpdateStatusByClaudeSessionID("cs-1", StatusNeedsAttention, StatusWorking)
+	require.NoError(t, err)
+
+	sessions := store.ListBySessionID("sess-1")
+	require.Len(t, sessions, 1)
+	require.Equal(t, StatusWorking, sessions[0].Status)
+}
+
+func TestUpdateStatusByClaudeSessionID_NonMatchingFromStatus(t *testing.T) {
+	store := setupStore(t)
+	store.Upsert(&ClaudeSession{
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+		Status:          StatusWorking,
+	})
+
+	err := store.UpdateStatusByClaudeSessionID("cs-1", StatusNeedsAttention, StatusWorking)
+	require.NoError(t, err)
+
+	sessions := store.ListBySessionID("sess-1")
+	require.Len(t, sessions, 1)
+	require.Equal(t, StatusWorking, sessions[0].Status)
+}
+
+func TestUpdateStatusByClaudeSessionID_NonExistentSession(t *testing.T) {
+	store := setupStore(t)
+
+	err := store.UpdateStatusByClaudeSessionID("nonexistent", StatusNeedsAttention, StatusWorking)
+	require.NoError(t, err)
+}

--- a/plugins/utena-claude/.claude-plugin/plugin.json
+++ b/plugins/utena-claude/.claude-plugin/plugin.json
@@ -33,6 +33,16 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/utena-claude-hook.sh"
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "matcher": "permission_prompt",


### PR DESCRIPTION
## Summary
- **Clear `needs_attention` after permission approval**: Added `PreToolUse` hook that conditionally transitions `needs_attention` → `working` when Claude resumes tool use after a permission is approved. Uses a conditional SQL update (no-op when already `working`) to avoid unnecessary writes since `PreToolUse` fires on every tool use.
- **Clear `ready_for_review` on tmux session switch**: ClaudeService now subscribes to `TmuxClientSessionChanged` events, so switching sessions via tmux directly (not just via TUI) marks `ready_for_review` sessions as `completed`.

## Test plan
- [x] Store tests: conditional update with matching/non-matching status
- [x] Service tests: PreToolUse clears needs_attention, no-op for other statuses
- [x] Service tests: TmuxClientSessionChanged clears ready_for_review, no-op for working/needs_attention
- [x] Full flow test: SessionStart → Notification → PreToolUse → Stop
- [ ] Manual: trigger permission prompt, approve it, verify status clears from `!` to `~`
- [ ] Manual: switch tmux session directly, verify `✓` clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)