### PR TITLE
feat(tui): add prefix+t hotkey to open new task form

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/eleonorayaya/utena/internal/shellinit"
 	"github.com/eleonorayaya/utena/internal/tui"
 	"github.com/eleonorayaya/utena/internal/tui/router"
-	"github.com/eleonorayaya/utena/internal/tui/todoform"
 )
 
 var (
@@ -94,7 +93,6 @@ func newTaskCmd() *cobra.Command {
 
 			p := tea.NewProgram(tui.NewApp(
 				resolvedLogPath, port, router.TodoListView,
-				tui.WithTodoFormOptions(todoform.WithPreSelectActiveWorkspace()),
 				tui.WithNavigateTo(router.TodoFormView),
 			))
 			if _, err := p.Run(); err != nil {

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/eleonorayaya/utena/internal/shellinit"
 	"github.com/eleonorayaya/utena/internal/tui"
 	"github.com/eleonorayaya/utena/internal/tui/router"
+	"github.com/eleonorayaya/utena/internal/tui/todoform"
 )
 
 var (
@@ -31,6 +32,7 @@ func main() {
 
 	rootCmd.AddCommand(shellInitCmd())
 	rootCmd.AddCommand(todosCmd())
+	rootCmd.AddCommand(newTaskCmd())
 	rootCmd.AddCommand(statusCmd())
 
 	if err := rootCmd.Execute(); err != nil {
@@ -72,6 +74,29 @@ func todosCmd() *cobra.Command {
 			resolvedLogPath := setupLogging()
 
 			p := tea.NewProgram(tui.NewApp(resolvedLogPath, port, router.TodoListView))
+			if _, err := p.Run(); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newTaskCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "new-task",
+		Short:        "Open new task form with current workspace preselected",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			port, _ := cmd.Root().Flags().GetString("port")
+			resolvedLogPath := setupLogging()
+
+			p := tea.NewProgram(tui.NewApp(
+				resolvedLogPath, port, router.TodoListView,
+				tui.WithTodoFormOptions(todoform.WithPreSelectActiveWorkspace()),
+				tui.WithNavigateTo(router.TodoFormView),
+			))
 			if _, err := p.Run(); err != nil {
 				return err
 			}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -17,34 +17,64 @@ import (
 )
 
 type App struct {
-	provider provider.Provider
-	router   router.Router
-	help     helpModel
-	width    int
-	height   int
+	provider   provider.Provider
+	router     router.Router
+	help       helpModel
+	navigateTo *router.View
+	width      int
+	height     int
 }
 
-func NewApp(logPath, port string, initialView router.View) App {
+type AppOption func(*appConfig)
+
+type appConfig struct {
+	todoFormOpts []todoform.Option
+	navigateTo   *router.View
+}
+
+func WithTodoFormOptions(opts ...todoform.Option) AppOption {
+	return func(c *appConfig) {
+		c.todoFormOpts = append(c.todoFormOpts, opts...)
+	}
+}
+
+func WithNavigateTo(view router.View) AppOption {
+	return func(c *appConfig) {
+		c.navigateTo = &view
+	}
+}
+
+func NewApp(logPath, port string, initialView router.View, opts ...AppOption) App {
+	var cfg appConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	baseURL := fmt.Sprintf("http://localhost:%s", port)
 	views := map[router.View]router.ViewEntry{
 		router.SessionListView:     &router.ViewAdapter[sessionlist.Model]{Model: sessionlist.New()},
 		router.SessionFormView:     &router.ViewAdapter[sessionform.Model]{Model: sessionform.New()},
 		router.SessionProgressView: &router.ViewAdapter[sessionprogress.Model]{Model: sessionprogress.New()},
 		router.TodoListView:        &router.ViewAdapter[todolist.Model]{Model: todolist.New()},
-		router.TodoFormView:        &router.ViewAdapter[todoform.Model]{Model: todoform.New()},
+		router.TodoFormView:        &router.ViewAdapter[todoform.Model]{Model: todoform.New(cfg.todoFormOpts...)},
 		router.DebugView:           &router.ViewAdapter[debug.Model]{Model: debug.New(logPath, baseURL)},
 		router.StatusView:          &router.ViewAdapter[statusview.Model]{Model: statusview.New()},
 	}
 
 	return App{
-		provider: provider.NewRootProvider(baseURL),
-		router:   router.New(views, initialView),
-		help:     newHelpModel(initialView != router.StatusView),
+		provider:   provider.NewRootProvider(baseURL),
+		router:     router.New(views, initialView),
+		help:       newHelpModel(initialView != router.StatusView),
+		navigateTo: cfg.navigateTo,
 	}
 }
 
 func (a App) Init() tea.Cmd {
 	_, cmd := a.router.Init()
+	if a.navigateTo != nil {
+		target := *a.navigateTo
+		return tea.Sequence(cmd, router.NavigateTo(target))
+	}
 	return cmd
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -28,14 +28,7 @@ type App struct {
 type AppOption func(*appConfig)
 
 type appConfig struct {
-	todoFormOpts []todoform.Option
-	navigateTo   *router.View
-}
-
-func WithTodoFormOptions(opts ...todoform.Option) AppOption {
-	return func(c *appConfig) {
-		c.todoFormOpts = append(c.todoFormOpts, opts...)
-	}
+	navigateTo *router.View
 }
 
 func WithNavigateTo(view router.View) AppOption {
@@ -56,7 +49,7 @@ func NewApp(logPath, port string, initialView router.View, opts ...AppOption) Ap
 		router.SessionFormView:     &router.ViewAdapter[sessionform.Model]{Model: sessionform.New()},
 		router.SessionProgressView: &router.ViewAdapter[sessionprogress.Model]{Model: sessionprogress.New()},
 		router.TodoListView:        &router.ViewAdapter[todolist.Model]{Model: todolist.New()},
-		router.TodoFormView:        &router.ViewAdapter[todoform.Model]{Model: todoform.New(cfg.todoFormOpts...)},
+		router.TodoFormView:        &router.ViewAdapter[todoform.Model]{Model: todoform.New()},
 		router.DebugView:           &router.ViewAdapter[debug.Model]{Model: debug.New(logPath, baseURL)},
 		router.StatusView:          &router.ViewAdapter[statusview.Model]{Model: statusview.New()},
 	}

--- a/internal/tui/todoform/todoform.go
+++ b/internal/tui/todoform/todoform.go
@@ -37,12 +37,22 @@ type Model struct {
 	focusIndex        int
 	selectedWorkspace *workspace.Workspace
 	selectedDirPath   string
-	activeWorkspaceID uint
-	nameErr           string
-	width, height     int
+	activeWorkspaceID  uint
+	preSelectActive    bool
+	preSelectConsumed  bool
+	nameErr            string
+	width, height      int
 }
 
-func New() Model {
+type Option func(*Model)
+
+func WithPreSelectActiveWorkspace() Option {
+	return func(m *Model) {
+		m.preSelectActive = true
+	}
+}
+
+func New(opts ...Option) Model {
 	nameInput := textinput.New()
 	nameInput.Prompt = "Name: "
 	nameInput.Placeholder = "todo name"
@@ -52,12 +62,16 @@ func New() Model {
 	descInput.Prompt = "Description: "
 	descInput.Placeholder = "optional description"
 
-	return Model{
+	m := Model{
 		activeStep:      workspacePickerStep,
 		workspacePicker: workspacepicker.New("Select workspace for todo", true),
 		nameInput:       nameInput,
 		descInput:       descInput,
 	}
+	for _, opt := range opts {
+		opt(&m)
+	}
+	return m
 }
 
 func (m *Model) SetSize(width, height int) {
@@ -73,6 +87,7 @@ func (m Model) Init() (Model, tea.Cmd) {
 	m.selectedDirPath = ""
 	m.focusIndex = 0
 	m.nameErr = ""
+	m.preSelectConsumed = false
 	m.nameInput.SetValue("")
 	m.descInput.SetValue("")
 	return m, provider.FetchWorkspaces()
@@ -97,6 +112,19 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m.OnWindowSizeMsg(msg)
 	case provider.WorkspacesStateUpdatedMsg:
 		m.activeWorkspaceID = msg.ActiveWorkspaceID
+		if m.preSelectActive && !m.preSelectConsumed && msg.ActiveWorkspaceID != 0 {
+			m.preSelectConsumed = true
+			for _, ws := range msg.Workspaces {
+				if ws.ID == msg.ActiveWorkspaceID {
+					m.selectedWorkspace = &ws
+					m.activeStep = nameInputStep
+					m.focusIndex = 0
+					m.nameInput.Focus()
+					m.descInput.Blur()
+					return m, textinput.Blink
+				}
+			}
+		}
 		var cmd tea.Cmd
 		m.workspacePicker, cmd = m.workspacePicker.Update(msg)
 		return m, cmd

--- a/internal/tui/todoform/todoform.go
+++ b/internal/tui/todoform/todoform.go
@@ -37,22 +37,12 @@ type Model struct {
 	focusIndex        int
 	selectedWorkspace *workspace.Workspace
 	selectedDirPath   string
-	activeWorkspaceID  uint
-	preSelectActive    bool
-	preSelectConsumed  bool
-	nameErr            string
-	width, height      int
+	activeWorkspaceID uint
+	nameErr           string
+	width, height     int
 }
 
-type Option func(*Model)
-
-func WithPreSelectActiveWorkspace() Option {
-	return func(m *Model) {
-		m.preSelectActive = true
-	}
-}
-
-func New(opts ...Option) Model {
+func New() Model {
 	nameInput := textinput.New()
 	nameInput.Prompt = "Name: "
 	nameInput.Placeholder = "todo name"
@@ -62,16 +52,12 @@ func New(opts ...Option) Model {
 	descInput.Prompt = "Description: "
 	descInput.Placeholder = "optional description"
 
-	m := Model{
+	return Model{
 		activeStep:      workspacePickerStep,
 		workspacePicker: workspacepicker.New("Select workspace for todo", true),
 		nameInput:       nameInput,
 		descInput:       descInput,
 	}
-	for _, opt := range opts {
-		opt(&m)
-	}
-	return m
 }
 
 func (m *Model) SetSize(width, height int) {
@@ -87,7 +73,6 @@ func (m Model) Init() (Model, tea.Cmd) {
 	m.selectedDirPath = ""
 	m.focusIndex = 0
 	m.nameErr = ""
-	m.preSelectConsumed = false
 	m.nameInput.SetValue("")
 	m.descInput.SetValue("")
 	return m, provider.FetchWorkspaces()
@@ -112,8 +97,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m.OnWindowSizeMsg(msg)
 	case provider.WorkspacesStateUpdatedMsg:
 		m.activeWorkspaceID = msg.ActiveWorkspaceID
-		if m.preSelectActive && !m.preSelectConsumed && msg.ActiveWorkspaceID != 0 {
-			m.preSelectConsumed = true
+		if m.activeStep == workspacePickerStep && m.selectedWorkspace == nil && msg.ActiveWorkspaceID != 0 {
 			for _, ws := range msg.Workspaces {
 				if ws.ID == msg.ActiveWorkspaceID {
 					m.selectedWorkspace = &ws

--- a/plugins/utena-tmux/utena.tmux
+++ b/plugins/utena-tmux/utena.tmux
@@ -21,6 +21,7 @@ tmux set-hook -g after-kill-window "run-shell '${script_dir}/sync-windows.sh \"#
 tmux set-hook -g after-select-window "run-shell '${script_dir}/sync-windows.sh \"#{session_name}\"'"
 
 tmux bind-key p display-popup -E -w 80% -h 80% "utena"
+tmux bind-key t display-popup -E -w 80% -h 80% "utena new-task"
 tmux bind-key s run-shell "${script_dir}/toggle-status.sh"
 
 tmux run-shell "${script_dir}/create-status-panes.sh"


### PR DESCRIPTION
## Summary
- Add `prefix+t` tmux hotkey that opens a popup with the new task form
- New `utena new-task` CLI command starts on the todo list then navigates to the form, so escape returns to the task list
- Todo form supports pre-selecting the active workspace, skipping the workspace picker step

## Test plan
- [ ] Press `prefix+t` in tmux — popup opens with task form, workspace pre-filled
- [ ] Press escape in the form — returns to the task list
- [ ] Press escape in the task list — closes the popup
- [ ] `utena new-task` works standalone outside tmux popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)