### PR TITLE
feat(tui): create session from task

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -29,6 +29,7 @@ type Session struct {
 	TmuxSessionName string               `json:"tmux_session_name,omitempty" gorm:"uniqueIndex"`
 	Name            string               `json:"name,omitempty"`
 	WorkspaceID     uint                 `json:"workspace_id" gorm:"index"`
+	TodoID          *uint                `json:"todo_id,omitempty" gorm:"index"`
 	Branch          string               `json:"branch,omitempty"`
 	BaseBranch      string               `json:"base_branch,omitempty"`
 	WorktreePath    string               `json:"worktree_path,omitempty"`

--- a/internal/session/sessioncontroller.go
+++ b/internal/session/sessioncontroller.go
@@ -93,6 +93,7 @@ func (c *SessionController) CreateSession(w http.ResponseWriter, r *http.Request
 		WorkspaceID: data.WorkspaceID,
 		Branch:      data.Branch,
 		BaseBranch:  data.BaseBranch,
+		TodoID:      data.TodoID,
 	}
 
 	if err := c.service.CreateSession(ctx, session, data.CreateWorktree); err != nil {

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -84,6 +84,11 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, cr
 		}
 	}
 
+	if session.TodoID != nil && ws != nil && ws.IsGitRepo && session.BaseBranch == "" {
+		session.BaseBranch = "main"
+		createWorktree = true
+	}
+
 	switch {
 	case session.Name != "":
 		if ws != nil {

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -50,6 +50,7 @@ type CreateSessionRequest struct {
 	Branch         string `json:"branch,omitempty"`
 	BaseBranch     string `json:"base_branch,omitempty"`
 	CreateWorktree bool   `json:"create_worktree"`
+	TodoID         *uint  `json:"todo_id,omitempty"`
 }
 
 func (c *CreateSessionRequest) Bind(r *http.Request) error {

--- a/internal/session/validation.go
+++ b/internal/session/validation.go
@@ -4,9 +4,27 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 var validSessionNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+var invalidCharsPattern = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
+var multiDash = regexp.MustCompile(`-{2,}`)
+
+func SanitizeSessionName(name string) string {
+	s := strings.ToLower(name)
+	s = invalidCharsPattern.ReplaceAllString(s, "-")
+	s = multiDash.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if len(s) > 50 {
+		s = strings.TrimRight(s[:50], "-")
+	}
+	if s == "" {
+		return "session"
+	}
+	return s
+}
 
 func ValidateSessionName(name string) error {
 	if name == "" {

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -192,7 +192,7 @@ func (c *client) repairSession(id uint) tea.Cmd {
 	}
 }
 
-func (c *client) createSession(name string, workspaceID uint, branch string, baseBranch string) tea.Cmd {
+func (c *client) createSession(name string, workspaceID uint, branch string, baseBranch string, todoID *uint) tea.Cmd {
 	return func() tea.Msg {
 		body := map[string]interface{}{
 			"workspace_id": workspaceID,
@@ -208,6 +208,9 @@ func (c *client) createSession(name string, workspaceID uint, branch string, bas
 			if baseBranch != "" {
 				body["base_branch"] = baseBranch
 			}
+		}
+		if todoID != nil {
+			body["todo_id"] = *todoID
 		}
 		jsonBody, err := json.Marshal(body)
 		if err != nil {

--- a/internal/tui/provider/sessionsprovider.go
+++ b/internal/tui/provider/sessionsprovider.go
@@ -45,6 +45,16 @@ func CreateSession(name string, workspaceID uint, branch, baseBranch, workspaceP
 	}
 }
 
+func CreateSessionFromTodo(name string, workspaceID uint, todoID uint) tea.Cmd {
+	return func() tea.Msg {
+		return createSessionIntentMsg{
+			name:        name,
+			workspaceID: workspaceID,
+			todoID:      &todoID,
+		}
+	}
+}
+
 func RepairSession(id uint) tea.Cmd {
 	return func() tea.Msg { return repairSessionIntentMsg{id: id} }
 }
@@ -70,6 +80,7 @@ type createSessionIntentMsg struct {
 	branch        string
 	baseBranch    string
 	workspacePath string
+	todoID        *uint
 }
 
 type repairSessionIntentMsg struct {
@@ -208,7 +219,7 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 		return p, p.client.fetchSessions()
 
 	case createSessionIntentMsg:
-		return p, p.client.createSession(msg.name, msg.workspaceID, msg.branch, msg.baseBranch)
+		return p, p.client.createSession(msg.name, msg.workspaceID, msg.branch, msg.baseBranch, msg.todoID)
 
 	case SessionCreatedMsg:
 		return p, p.client.fetchSessions()

--- a/internal/tui/todolist/keys.go
+++ b/internal/tui/todolist/keys.go
@@ -6,25 +6,27 @@ import (
 )
 
 type keyMap struct {
-	Delete    key.Binding
-	ToggleAll key.Binding
-	New       key.Binding
-	Back      key.Binding
+	Delete        key.Binding
+	ToggleAll     key.Binding
+	New           key.Binding
+	CreateSession key.Binding
+	Back          key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Delete, k.ToggleAll, k.New, k.Back}
+	return []key.Binding{k.CreateSession, k.Delete, k.ToggleAll, k.New, k.Back}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.Delete, k.ToggleAll, k.New, k.Back}}
+	return [][]key.Binding{{k.CreateSession, k.Delete, k.ToggleAll, k.New, k.Back}}
 }
 
 var keys = keyMap{
-	Delete:    key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
-	ToggleAll: key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "all/current")),
-	New:       key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
-	Back:      key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+	Delete:        key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
+	ToggleAll:     key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "all/current")),
+	New:           key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
+	CreateSession: key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "start session")),
+	Back:          key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
 }
 
 var _ help.KeyMap = keys

--- a/internal/tui/todolist/todolist.go
+++ b/internal/tui/todolist/todolist.go
@@ -5,10 +5,12 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/eleonorayaya/utena/internal/session"
 	"github.com/eleonorayaya/utena/internal/todo"
 	ulist "github.com/eleonorayaya/utena/internal/tui/list"
 	"github.com/eleonorayaya/utena/internal/tui/provider"
 	"github.com/eleonorayaya/utena/internal/tui/router"
+	"github.com/eleonorayaya/utena/internal/tui/sessionprogress"
 )
 
 type Model struct {
@@ -66,6 +68,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case provider.WorkspacesStateUpdatedMsg:
 		m.activeWorkspaceID = msg.ActiveWorkspaceID
 		return m, m.rebuildItems()
+	case provider.SessionCreatedMsg:
+		return m, tea.Sequence(
+			router.NavigateTo(router.SessionProgressView),
+			sessionprogress.Start(msg.ID),
+		)
 	case provider.ErrMsg:
 		return m, m.list.NewStatusMessage(msg.Err.Error())
 	case tea.KeyMsg:
@@ -111,6 +118,13 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 		}
 		m.pendingDeleteID = item.todo.ID
 		return m, m.list.NewStatusMessage("press d again to delete " + item.todo.Name), true
+	case key.Matches(msg, keys.CreateSession):
+		item, ok := m.list.SelectedItem().(todoItem)
+		if !ok || item.todo.WorkspaceID == nil {
+			return m, nil, false
+		}
+		name := session.SanitizeSessionName(item.todo.Name)
+		return m, provider.CreateSessionFromTodo(name, *item.todo.WorkspaceID, item.todo.ID), true
 	case key.Matches(msg, keys.ToggleAll):
 		m.showAllWorkspaces = !m.showAllWorkspaces
 		m.updateTitle()


### PR DESCRIPTION
## Summary
- Press `s` on a task in the todo list to directly create a session — no form needed
- Backend auto-creates a new branch off `main` for git-repo workspaces, stores `todo_id` on the session
- Adds `SanitizeSessionName` to derive valid session names from task names

## Test plan
- [ ] Open TUI → todo list → select a task with a workspace → press `s` → session progress view appears, session is created with auto-branch
- [ ] Task without workspace → `s` key does nothing
- [ ] Verify session has `todo_id` set after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)