### PR TITLE
fix(claude): improve needs-attention status clearing in plan mode

### DIFF
--- a/internal/claude/claudeservice.go
+++ b/internal/claude/claudeservice.go
@@ -64,7 +64,7 @@ func (s *ClaudeService) HandleHookEvent(ctx context.Context, req *HookEventReque
 		return nil
 
 	case "PreToolUse":
-		return s.store.UpdateStatusByClaudeSessionID(req.ClaudeSessionID, StatusNeedsAttention, StatusWorking)
+		return s.store.UpdateStatusByClaudeSessionID(req.ClaudeSessionID, StatusWorking)
 
 	case "TaskCompleted":
 		return s.upsertWithStatus(req, StatusReadyForReview)

--- a/internal/claude/claudeservice_test.go
+++ b/internal/claude/claudeservice_test.go
@@ -58,7 +58,7 @@ func TestPreToolUse_NoOpWhenWorking(t *testing.T) {
 	require.Equal(t, StatusWorking, sessions[0].Status)
 }
 
-func TestPreToolUse_NoOpWhenReadyForReview(t *testing.T) {
+func TestPreToolUse_ClearsReadyForReview(t *testing.T) {
 	service, store := setupService(t)
 	store.Upsert(&ClaudeSession{
 		ClaudeSessionID: "cs-1",
@@ -75,7 +75,27 @@ func TestPreToolUse_NoOpWhenReadyForReview(t *testing.T) {
 
 	sessions := store.ListBySessionID("sess-1")
 	require.Len(t, sessions, 1)
-	require.Equal(t, StatusReadyForReview, sessions[0].Status)
+	require.Equal(t, StatusWorking, sessions[0].Status)
+}
+
+func TestPreToolUse_ClearsCompleted(t *testing.T) {
+	service, store := setupService(t)
+	store.Upsert(&ClaudeSession{
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+		Status:          StatusCompleted,
+	})
+
+	err := service.HandleHookEvent(context.Background(), &HookEventRequest{
+		Event:           "PreToolUse",
+		ClaudeSessionID: "cs-1",
+		SessionID:       "sess-1",
+	})
+	require.NoError(t, err)
+
+	sessions := store.ListBySessionID("sess-1")
+	require.Len(t, sessions, 1)
+	require.Equal(t, StatusWorking, sessions[0].Status)
 }
 
 func TestFullFlow_NeedsAttentionToWorkingViaPreToolUse(t *testing.T) {

--- a/internal/claude/claudestore.go
+++ b/internal/claude/claudestore.go
@@ -55,10 +55,10 @@ func (s *ClaudeStore) UpdateStatusBySessionID(sessionID string, from, to ClaudeS
 		Update("status", to)
 }
 
-func (s *ClaudeStore) UpdateStatusByClaudeSessionID(claudeSessionID string, from, to ClaudeSessionStatus) error {
+func (s *ClaudeStore) UpdateStatusByClaudeSessionID(claudeSessionID string, status ClaudeSessionStatus) error {
 	return s.db.Model(&ClaudeSession{}).
-		Where("claude_session_id = ? AND status = ?", claudeSessionID, from).
-		Update("status", to).Error
+		Where("claude_session_id = ?", claudeSessionID).
+		Update("status", status).Error
 }
 
 func (s *ClaudeStore) DeleteByClaudeSessionID(claudeSessionID string) error {

--- a/internal/claude/claudestore_test.go
+++ b/internal/claude/claudestore_test.go
@@ -23,7 +23,7 @@ func setupStore(t *testing.T) *ClaudeStore {
 	return NewClaudeStore(setupTestDB(t))
 }
 
-func TestUpdateStatusByClaudeSessionID_MatchingFromStatus(t *testing.T) {
+func TestUpdateStatusByClaudeSessionID(t *testing.T) {
 	store := setupStore(t)
 	store.Upsert(&ClaudeSession{
 		ClaudeSessionID: "cs-1",
@@ -31,23 +31,7 @@ func TestUpdateStatusByClaudeSessionID_MatchingFromStatus(t *testing.T) {
 		Status:          StatusNeedsAttention,
 	})
 
-	err := store.UpdateStatusByClaudeSessionID("cs-1", StatusNeedsAttention, StatusWorking)
-	require.NoError(t, err)
-
-	sessions := store.ListBySessionID("sess-1")
-	require.Len(t, sessions, 1)
-	require.Equal(t, StatusWorking, sessions[0].Status)
-}
-
-func TestUpdateStatusByClaudeSessionID_NonMatchingFromStatus(t *testing.T) {
-	store := setupStore(t)
-	store.Upsert(&ClaudeSession{
-		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
-		Status:          StatusWorking,
-	})
-
-	err := store.UpdateStatusByClaudeSessionID("cs-1", StatusNeedsAttention, StatusWorking)
+	err := store.UpdateStatusByClaudeSessionID("cs-1", StatusWorking)
 	require.NoError(t, err)
 
 	sessions := store.ListBySessionID("sess-1")
@@ -58,6 +42,6 @@ func TestUpdateStatusByClaudeSessionID_NonMatchingFromStatus(t *testing.T) {
 func TestUpdateStatusByClaudeSessionID_NonExistentSession(t *testing.T) {
 	store := setupStore(t)
 
-	err := store.UpdateStatusByClaudeSessionID("nonexistent", StatusNeedsAttention, StatusWorking)
+	err := store.UpdateStatusByClaudeSessionID("nonexistent", StatusWorking)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
- **Bug**: When accepting a plan in plan mode, the sidebar didn't show the session as "working" because `PreToolUse` only cleared `NeedsAttention → Working`, not `ReadyForReview → Working`
- **Fix**: Replace the conditional status transition with `SetWorkingByClaudeSessionID` which sets status to `working` from any non-working state when a tool is about to be used
- Covers all resume scenarios: after permission prompts, plan acceptance, and edge cases with `completed` status

## Test plan
- [x] Existing tests updated and pass
- [x] New test for `PreToolUse` clearing `Completed` status
- [ ] Manual: enter plan mode, accept plan, verify sidebar shows working status

🤖 Generated with [Claude Code](https://claude.com/claude-code)