### PR TITLE
refactor(claude): proper has-many from Session to ClaudeSession

### DIFF
--- a/.claude/plans/cosmic-puzzling-fern.md
+++ b/.claude/plans/cosmic-puzzling-fern.md
@@ -1,0 +1,306 @@
+# Plan: GORM Has-Many from Session to ClaudeSession
+
+## Context
+
+Currently `ClaudeSession.SessionID` is a string matching `Session.TmuxSessionName`. There's no GORM foreign key — the TUI correlates them client-side by fetching both datasets separately (`GET /sessions` + `GET /claude/sessions`) and building a `map[string][]claude.ClaudeSession`.
+
+Additionally, the claude service subscribes to eventbus events to mark claude sessions as completed when the user switches tmux sessions. This couples claude session lifecycle to utena session navigation.
+
+**Goals**:
+1. Create a proper GORM has-many: `Session` has many `ClaudeSession`s via uint FK
+2. `ClaudeSession` stays in the `claude` package — `session` imports `claude`, not the reverse
+3. Claude sessions manage their own status purely via hooks — remove eventbus-driven status changes
+4. Hook events send the utena session DB ID directly (not tmux name) — claude has zero knowledge of sessions
+5. Eliminate separate TUI fetch for claude sessions (preload via has-many)
+
+## Dependency direction
+
+```
+session  -->  claude      (for ClaudeSession type in has-many field)
+session  -->  workspace   (existing)
+claude   -/-> session     (claude has no concept of utena sessions — just stores a uint FK)
+tui      -->  session     (gets claude sessions via preloaded Session.ClaudeSessions)
+tui      -/-> claude      (no longer needed)
+```
+
+## Steps
+
+### 1. Set `UTENA_SESSION_ID` to DB ID on tmux session creation
+
+**`internal/session/sessionservice.go`** — `setupTmux()`:
+After creating the tmux session, set the env var via tmux:
+```go
+func (s *SessionService) setupTmux(ctx context.Context, sess *Session) error {
+    startDir := s.resolveStartDir(ctx, sess)
+    if err := s.tmuxService.CreateSession(sess.TmuxSessionName, startDir); err != nil {
+        return fmt.Errorf("failed to create tmux session: %v", err)
+    }
+    s.tmuxService.SetSessionEnv(sess.TmuxSessionName, "UTENA_SESSION_ID", fmt.Sprintf("%d", sess.ID))
+    return nil
+}
+```
+
+Also update `ActivateSession()` (line 430) which revives dead tmux sessions — set the env var there too.
+
+**`internal/tmux/tmuxservice.go`** — add `SetSessionEnv` method:
+```go
+func (s *TmuxService) SetSessionEnv(sessionName, key, value string) {
+    s.client.RunCommand("set-environment", "-t", sessionName, key, value)
+}
+```
+
+### 2. Update `shellinit` to read from tmux environment
+
+**`internal/shellinit/shellinit.go`**:
+```go
+func Script() string {
+    return `if [ -n "$TMUX" ]; then
+  _utena_val=$(tmux show-environment UTENA_SESSION_ID 2>/dev/null)
+  if [ -n "$_utena_val" ] && [ "${_utena_val#-}" = "$_utena_val" ]; then
+    export "$_utena_val"
+  fi
+  unset _utena_val
+fi
+`
+}
+```
+
+(`tmux show-environment` returns `KEY=value` or `-KEY` if unset — the check ensures we only export valid assignments)
+
+### 3. Update hook script to send uint session ID
+
+**`plugins/utena-claude/hooks/utena-claude-hook.sh`**:
+No structural change needed — it already sends `$UTENA_SESSION_ID` as `session_id`. The value is now a uint string instead of a tmux name.
+
+### 4. Update `ClaudeSession` model (`internal/claude/claudesession.go`)
+
+Change `SessionID` to uint. Add `StatusIdle` and `StatusDone` statuses. Remove `StatusCompleted`:
+
+```go
+const (
+    StatusIdle           ClaudeSessionStatus = "idle"
+    StatusWorking        ClaudeSessionStatus = "working"
+    StatusNeedsAttention ClaudeSessionStatus = "needs_attention"
+    StatusReadyForReview ClaudeSessionStatus = "ready_for_review"
+    StatusDone           ClaudeSessionStatus = "done"
+)
+
+type ClaudeSession struct {
+    gorm.Model
+    ClaudeSessionID string              `json:"claude_session_id" gorm:"uniqueIndex"`
+    SessionID       uint                `json:"session_id" gorm:"index"`
+    Status          ClaudeSessionStatus `json:"status"`
+    CWD             string              `json:"cwd,omitempty"`
+}
+```
+
+### 5. Update `HookEventRequest` (`internal/claude/types.go`)
+
+Change `SessionID` from string to uint:
+```go
+type HookEventRequest struct {
+    Event            string `json:"event"`
+    ClaudeSessionID  string `json:"claude_session_id"`
+    SessionID        uint   `json:"session_id,string"`
+    CWD              string `json:"cwd,omitempty"`
+    NotificationType string `json:"notification_type,omitempty"`
+}
+```
+
+Note: `json:"session_id,string"` handles JSON string→uint parsing since the hook script sends it as a string in JSON.
+
+### 6. Add has-many field to `Session` (`internal/session/session.go`)
+
+Import `claude` package, add field:
+```go
+ClaudeSessions []claude.ClaudeSession `json:"claude_sessions,omitempty" gorm:"foreignKey:SessionID"`
+```
+
+### 7. Update `SessionStore` (`internal/session/sessionstore.go`)
+
+- Add `.Preload("ClaudeSessions")` to `List()`, `ListByWorkspace()`, `GetByID()`, `GetByTmuxName()`:
+  ```go
+  s.db.Joins("Workspace").Preload("ClaudeSessions").Order("sessions.last_used_at DESC").Find(&sessions)
+  ```
+- Add `Omit("ClaudeSessions")` alongside existing `Omit("Workspace")` in `Add()` and `Update()`
+
+### 8. Restructure `ClaudeService` (`internal/claude/claudeservice.go`)
+
+Remove eventbus dependency entirely. Simplify to just hook handling:
+
+```go
+type ClaudeService struct {
+    store *ClaudeStore
+}
+
+func NewClaudeService(store *ClaudeStore) *ClaudeService {
+    return &ClaudeService{store: store}
+}
+
+func (s *ClaudeService) HandleHookEvent(ctx context.Context, req *HookEventRequest) error {
+    switch req.Event {
+    case "SessionStart":
+        return s.store.Create(&ClaudeSession{
+            ClaudeSessionID: req.ClaudeSessionID,
+            SessionID:       req.SessionID,
+            Status:          StatusIdle,
+            CWD:             req.CWD,
+        })
+
+    case "UserPromptSubmit", "PreToolUse":
+        return s.store.UpdateStatus(req.ClaudeSessionID, StatusWorking)
+
+    case "Stop", "TaskCompleted":
+        return s.store.UpdateStatus(req.ClaudeSessionID, StatusReadyForReview)
+
+    case "Notification":
+        if req.NotificationType == "permission_prompt" {
+            return s.store.UpdateStatus(req.ClaudeSessionID, StatusNeedsAttention)
+        }
+        return nil
+
+    case "SessionEnd":
+        return s.store.UpdateStatus(req.ClaudeSessionID, StatusDone)
+
+    default:
+        slog.Warn("unknown hook event", "event", req.Event)
+        return nil
+    }
+}
+
+func (s *ClaudeService) ListAll(ctx context.Context) ([]ClaudeSession, error) {
+    return s.store.List(), nil
+}
+
+func (s *ClaudeService) ListBySessionID(ctx context.Context, sessionID uint) ([]ClaudeSession, error) {
+    return s.store.ListBySessionID(sessionID), nil
+}
+```
+
+### 9. Simplify `ClaudeStore` (`internal/claude/claudestore.go`)
+
+Replace current methods with cleaner API:
+
+- `Create(cs *ClaudeSession) error` — insert new record
+- `UpdateStatus(claudeSessionID string, status ClaudeSessionStatus) error` — update by external ID
+- `List() []ClaudeSession` — list all (keep as-is)
+- `ListBySessionID(sessionID uint) []ClaudeSession` — change param from string to uint
+- Remove `Upsert()` — creation and updates are separate paths
+- Remove `UpdateStatusBySessionID()` — eventbus handlers removed
+- Remove `DeleteByClaudeSessionID()` — SessionEnd now sets status to done instead of deleting
+
+### 10. Update `ClaudeController` (`internal/claude/claudecontroller.go`)
+
+- `ListClaudeSessionsBySession`: change route param `{sessionId}` to be a uint (parsed from URL). Call `service.ListBySessionID(ctx, uint)`.
+
+### 11. Update `ClaudeModule` (`internal/claude/claudemodule.go`)
+
+```go
+func NewClaudeModule(database db.Database) *ClaudeModule {
+    store := NewClaudeStore(database)
+    service := NewClaudeService(store)
+    ...
+}
+```
+
+Remove `eventbus.EventBus` parameter. `OnAppStart`/`OnAppEnd` become no-ops (or delegate to store only). `Models()` stays as `[]any{&ClaudeSession{}}`.
+
+### 12. Update `App` wiring (`internal/api/app.go`)
+
+```go
+Claude: claude.NewClaudeModule(database),
+```
+
+Remove `bus` from the call. The `session -> claude` import already exists implicitly via the Session struct.
+
+### 13. Simplify TUI — use `session.ClaudeSessions` directly
+
+Claude sessions are now nested on each session via the has-many preload. No separate map or fetch needed.
+
+**`internal/tui/provider/client.go`**:
+- Remove `fetchClaudeSessions()` method
+- Remove `claude` import
+
+**`internal/tui/provider/sessionsprovider.go`**:
+- Remove `claudeSessionsLoadedMsg` type and its handler
+- Remove `claudeSessions map[string][]claude.ClaudeSession` field from `sessionsProvider`
+- Remove `ClaudeSessions` field from `SessionsStateUpdatedMsg` — sessions already carry their claude sessions
+- In `fetchSessionsIntentMsg` handler: just `p.client.fetchSessions()` (drop `tea.Batch`)
+- `sessionsLoadedMsg` handler simplifies to just store sessions and emit state
+
+**`internal/tui/sessionlist/sessionlist.go`**:
+- Remove `claudeSessions` map field from Model
+- In `rebuildItems()`: use `s.ClaudeSessions` directly instead of looking up from a separate map
+- In `SessionsStateUpdatedMsg` handler: just store sessions, no separate claude sessions to track
+
+**`internal/tui/sessionlist/sessionitem.go`**:
+- Change `claudeStatus` field from `string` to `claude.ClaudeSessionStatus`
+- Replace `aggregateClaudeStatus()` (returns string) with a call to the shared `aggregateStatus()` pattern that returns `claude.ClaudeSessionStatus` (matching `statusview/model.go`'s existing approach)
+- Move display formatting (e.g., `"[needs attention]"`) into `Title()` by switching on the enum
+- Replace `StatusCompleted` → `StatusDone`, add `StatusIdle` handling
+
+**`internal/tui/statusview/model.go`**:
+- Remove `claudeSessions` map field
+- Use `session.ClaudeSessions` directly when rendering session rows
+- Replace `StatusCompleted` → `StatusDone` references
+- Add handling for `StatusIdle`
+
+### 14. SQLite migration (`internal/claude/claudestore.go`)
+
+Drop the table on startup (data is transient — tracks active Claude Code instances):
+
+```go
+func (s *ClaudeStore) OnAppStart(ctx context.Context) error {
+    s.db.Exec("DROP TABLE IF EXISTS claude_sessions")
+    return nil
+}
+```
+
+GORM's AutoMigrate will recreate with correct schema.
+
+### 15. Update tests
+
+**`internal/claude/claudestore_test.go`**:
+- `setupTestDB`: also migrate a minimal Session model (for FK target)
+- Create session records as FK targets
+- Use uint session IDs
+- Update to new store API (`Create`/`UpdateStatus`/`Delete`)
+- Remove `UpdateStatusBySessionID` tests
+
+**`internal/claude/claudeservice_test.go`**:
+- Same DB setup
+- Remove eventbus setup and all eventbus-related tests
+- Test create-then-update-by-ID flow
+- `SessionStart` creates record, subsequent events update by `ClaudeSessionID`
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `internal/session/sessionservice.go` | Set `UTENA_SESSION_ID` env var after tmux session creation |
+| `internal/tmux/tmuxservice.go` | Add `SetSessionEnv()` method |
+| `internal/shellinit/shellinit.go` | Read from tmux environment instead of deriving from session name |
+| `internal/claude/claudesession.go` | `SessionID` string → uint |
+| `internal/claude/types.go` | `SessionID` string → uint with `json:",string"` |
+| `internal/session/session.go` | Add `ClaudeSessions` has-many field, import `claude` |
+| `internal/session/sessionstore.go` | Preload on reads, Omit on writes |
+| `internal/claude/claudestore.go` | New API (`Create`/`UpdateStatus`/`Delete`), uint SessionID, drop table migration |
+| `internal/claude/claudeservice.go` | Remove eventbus, simplify to pure hook handler |
+| `internal/claude/claudemodule.go` | Drop eventbus param |
+| `internal/claude/claudecontroller.go` | Parse uint session ID from route param |
+| `internal/api/app.go` | Remove bus from claude module |
+| `internal/tui/provider/client.go` | Remove `fetchClaudeSessions` |
+| `internal/tui/provider/sessionsprovider.go` | Remove claude sessions map/msg/fetch, sessions carry their own |
+| `internal/tui/sessionlist/sessionlist.go` | Remove claude sessions map, use `s.ClaudeSessions` directly |
+| `internal/tui/sessionlist/sessionitem.go` | `StatusCompleted` → `StatusDone`, add `StatusIdle` handling |
+| `internal/tui/statusview/model.go` | Remove claude sessions map, use nested data, update status refs |
+| `internal/claude/claudestore_test.go` | New store API, uint IDs |
+| `internal/claude/claudeservice_test.go` | Remove eventbus tests, test hook flow |
+
+## Verification
+
+1. `task test` — all tests pass
+2. `task fmt` — no formatting issues
+3. `task daemon:run` + `task tui:run` — TUI shows session list with claude status indicators
+4. Start a Claude Code session in a managed tmux session → verify `UTENA_SESSION_ID` is the DB uint ID (check with `echo $UTENA_SESSION_ID`)
+5. Verify hook events update claude session status in the TUI

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -50,7 +50,7 @@ func newApp(gormDB *gorm.DB, tmuxClient tmux.TmuxClient, fs afero.Fs, cfg Config
 		Workspace: workspaceModule,
 		Session:   sessionModule,
 		Tmux:      tmuxModule,
-		Claude:    claude.NewClaudeModule(bus, database),
+		Claude:    claude.NewClaudeModule(database),
 		Todo:      todo.NewTodoModule(workspaceModule, database),
 	}
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -29,7 +29,7 @@ func newTestTmuxClient() *testTmuxClient {
 	return &testTmuxClient{sessions: make(map[string]bool)}
 }
 
-func (m *testTmuxClient) CreateSession(name, startDir string) error {
+func (m *testTmuxClient) CreateSession(name, startDir string, env map[string]string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.createErr != nil {

--- a/internal/claude/claudecontroller.go
+++ b/internal/claude/claudecontroller.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/eleonorayaya/utena/internal/common"
 	"github.com/go-chi/chi/v5"
@@ -50,14 +51,17 @@ func (c *ClaudeController) ListClaudeSessions(w http.ResponseWriter, r *http.Req
 
 func (c *ClaudeController) ListClaudeSessionsBySession(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	sessionID := chi.URLParam(r, "sessionId")
-
-	sessions, err := c.service.ListBySession(ctx, sessionID)
+	raw := chi.URLParam(r, "sessionId")
+	sessionID, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		render.Render(w, r, common.ErrInvalidRequest(err))
+		return
+	}
+	sessions, err := c.service.ListBySessionID(ctx, uint(sessionID))
 	if err != nil {
 		render.Render(w, r, common.ErrUnknown(err))
 		return
 	}
-
 	response := NewClaudeSessionListResponse(sessions)
 	render.Render(w, r, response)
 }

--- a/internal/claude/claudecontroller.go
+++ b/internal/claude/claudecontroller.go
@@ -2,10 +2,8 @@ package claude
 
 import (
 	"net/http"
-	"strconv"
 
 	"github.com/eleonorayaya/utena/internal/common"
-	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 )
 
@@ -45,23 +43,6 @@ func (c *ClaudeController) ListClaudeSessions(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	response := NewClaudeSessionListResponse(sessions)
-	render.Render(w, r, response)
-}
-
-func (c *ClaudeController) ListClaudeSessionsBySession(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	raw := chi.URLParam(r, "sessionId")
-	sessionID, err := strconv.ParseUint(raw, 10, 64)
-	if err != nil {
-		render.Render(w, r, common.ErrInvalidRequest(err))
-		return
-	}
-	sessions, err := c.service.ListBySessionID(ctx, uint(sessionID))
-	if err != nil {
-		render.Render(w, r, common.ErrUnknown(err))
-		return
-	}
 	response := NewClaudeSessionListResponse(sessions)
 	render.Render(w, r, response)
 }

--- a/internal/claude/claudemodule.go
+++ b/internal/claude/claudemodule.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/eleonorayaya/utena/internal/db"
-	"github.com/eleonorayaya/utena/internal/eventbus"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -15,9 +14,9 @@ type ClaudeModule struct {
 	Router     *ClaudeRouter
 }
 
-func NewClaudeModule(bus eventbus.EventBus, database db.Database) *ClaudeModule {
+func NewClaudeModule(database db.Database) *ClaudeModule {
 	store := NewClaudeStore(database)
-	service := NewClaudeService(store, bus)
+	service := NewClaudeService(store)
 	controller := NewClaudeController(service)
 	router := NewClaudeRouter(controller)
 

--- a/internal/claude/clauderouter.go
+++ b/internal/claude/clauderouter.go
@@ -19,7 +19,6 @@ func (cr *ClaudeRouter) Routes() chi.Router {
 
 	r.Put("/hook", cr.controller.HandleHookEvent)
 	r.Get("/sessions", cr.controller.ListClaudeSessions)
-	r.Get("/sessions/{sessionId}", cr.controller.ListClaudeSessionsBySession)
 
 	return r
 }

--- a/internal/claude/claudeservice.go
+++ b/internal/claude/claudeservice.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 )
 
@@ -24,6 +25,9 @@ func (s *ClaudeService) OnAppEnd(ctx context.Context) error {
 func (s *ClaudeService) HandleHookEvent(ctx context.Context, req *HookEventRequest) error {
 	switch req.Event {
 	case "SessionStart":
+		if req.SessionID == 0 {
+			return errors.New("session_id is required for SessionStart")
+		}
 		return s.store.Create(&ClaudeSession{
 			ClaudeSessionID: req.ClaudeSessionID,
 			SessionID:       req.SessionID,
@@ -49,8 +53,4 @@ func (s *ClaudeService) HandleHookEvent(ctx context.Context, req *HookEventReque
 
 func (s *ClaudeService) ListAll(ctx context.Context) ([]ClaudeSession, error) {
 	return s.store.List(), nil
-}
-
-func (s *ClaudeService) ListBySessionID(ctx context.Context, sessionID uint) ([]ClaudeSession, error) {
-	return s.store.ListBySessionID(sessionID), nil
 }

--- a/internal/claude/claudeservice.go
+++ b/internal/claude/claudeservice.go
@@ -2,46 +2,18 @@ package claude
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-
-	"github.com/eleonorayaya/utena/internal/eventbus"
 )
 
 type ClaudeService struct {
-	store    *ClaudeStore
-	eventBus eventbus.EventBus
+	store *ClaudeStore
 }
 
-func NewClaudeService(store *ClaudeStore, bus eventbus.EventBus) *ClaudeService {
-	return &ClaudeService{
-		store:    store,
-		eventBus: bus,
-	}
+func NewClaudeService(store *ClaudeStore) *ClaudeService {
+	return &ClaudeService{store: store}
 }
 
 func (s *ClaudeService) OnAppStart(ctx context.Context) error {
-	s.eventBus.Subscribe(eventbus.SessionActivated, s.handleSessionActivated)
-	s.eventBus.Subscribe(eventbus.TmuxClientSessionChanged, s.handleTmuxClientSessionChanged)
-	return nil
-}
-
-func (s *ClaudeService) handleSessionActivated(ctx context.Context, event eventbus.Event) error {
-	data, ok := event.Data.(eventbus.SessionActivatedEvent)
-	if !ok {
-		return fmt.Errorf("unexpected event data type: %T", event.Data)
-	}
-
-	s.store.UpdateStatusBySessionID(data.SessionName, StatusReadyForReview, StatusCompleted)
-	return nil
-}
-
-func (s *ClaudeService) handleTmuxClientSessionChanged(ctx context.Context, event eventbus.Event) error {
-	data, ok := event.Data.(eventbus.TmuxHookEvent)
-	if !ok {
-		return fmt.Errorf("unexpected event data type: %T", event.Data)
-	}
-	s.store.UpdateStatusBySessionID(data.TmuxSessionName, StatusReadyForReview, StatusCompleted)
 	return nil
 }
 
@@ -51,51 +23,34 @@ func (s *ClaudeService) OnAppEnd(ctx context.Context) error {
 
 func (s *ClaudeService) HandleHookEvent(ctx context.Context, req *HookEventRequest) error {
 	switch req.Event {
-	case "SessionStart", "UserPromptSubmit":
-		return s.upsertWithStatus(req, StatusWorking)
-
-	case "Stop":
-		return s.upsertWithStatus(req, StatusReadyForReview)
-
+	case "SessionStart":
+		return s.store.Create(&ClaudeSession{
+			ClaudeSessionID: req.ClaudeSessionID,
+			SessionID:       req.SessionID,
+			Status:          StatusIdle,
+			CWD:             req.CWD,
+		})
+	case "UserPromptSubmit", "PreToolUse":
+		return s.store.UpdateStatus(req.ClaudeSessionID, StatusWorking)
+	case "Stop", "TaskCompleted":
+		return s.store.UpdateStatus(req.ClaudeSessionID, StatusReadyForReview)
 	case "Notification":
 		if req.NotificationType == "permission_prompt" {
-			return s.upsertWithStatus(req, StatusNeedsAttention)
+			return s.store.UpdateStatus(req.ClaudeSessionID, StatusNeedsAttention)
 		}
 		return nil
-
-	case "PreToolUse":
-		return s.store.UpdateStatusByClaudeSessionID(req.ClaudeSessionID, StatusWorking)
-
-	case "TaskCompleted":
-		return s.upsertWithStatus(req, StatusReadyForReview)
-
 	case "SessionEnd":
-		err := s.store.DeleteByClaudeSessionID(req.ClaudeSessionID)
-		if err != nil {
-			slog.Warn("failed to delete claude session on SessionEnd", "claude_session_id", req.ClaudeSessionID, "error", err)
-		}
-		return nil
-
+		return s.store.UpdateStatus(req.ClaudeSessionID, StatusDone)
 	default:
 		slog.Warn("unknown hook event", "event", req.Event)
 		return nil
 	}
 }
 
-func (s *ClaudeService) upsertWithStatus(req *HookEventRequest, status ClaudeSessionStatus) error {
-	session := &ClaudeSession{
-		ClaudeSessionID: req.ClaudeSessionID,
-		SessionID:       req.SessionID,
-		Status:          status,
-		CWD:             req.CWD,
-	}
-	return s.store.Upsert(session)
-}
-
 func (s *ClaudeService) ListAll(ctx context.Context) ([]ClaudeSession, error) {
 	return s.store.List(), nil
 }
 
-func (s *ClaudeService) ListBySession(ctx context.Context, sessionID string) ([]ClaudeSession, error) {
+func (s *ClaudeService) ListBySessionID(ctx context.Context, sessionID uint) ([]ClaudeSession, error) {
 	return s.store.ListBySessionID(sessionID), nil
 }

--- a/internal/claude/claudeservice_test.go
+++ b/internal/claude/claudeservice_test.go
@@ -33,7 +33,7 @@ func TestPreToolUse_ClearsNeedsAttention(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	sessions := store.ListBySessionID(sessionID)
+	sessions := store.List()
 	require.Len(t, sessions, 1)
 	require.Equal(t, StatusWorking, sessions[0].Status)
 }
@@ -55,7 +55,7 @@ func TestPreToolUse_NoOpWhenWorking(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	sessions := store.ListBySessionID(sessionID)
+	sessions := store.List()
 	require.Len(t, sessions, 1)
 	require.Equal(t, StatusWorking, sessions[0].Status)
 }
@@ -77,7 +77,7 @@ func TestPreToolUse_ClearsReadyForReview(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	sessions := store.ListBySessionID(sessionID)
+	sessions := store.List()
 	require.Len(t, sessions, 1)
 	require.Equal(t, StatusWorking, sessions[0].Status)
 }
@@ -99,7 +99,7 @@ func TestPreToolUse_ClearsDone(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	sessions := store.ListBySessionID(sessionID)
+	sessions := store.List()
 	require.Len(t, sessions, 1)
 	require.Equal(t, StatusWorking, sessions[0].Status)
 }
@@ -115,7 +115,7 @@ func TestFullFlow_NeedsAttentionToWorkingViaPreToolUse(t *testing.T) {
 		SessionID:       sessionID,
 		CWD:             "/tmp",
 	})
-	sessions := store.ListBySessionID(sessionID)
+	sessions := store.List()
 	require.Equal(t, StatusIdle, sessions[0].Status)
 
 	service.HandleHookEvent(ctx, &HookEventRequest{
@@ -124,7 +124,7 @@ func TestFullFlow_NeedsAttentionToWorkingViaPreToolUse(t *testing.T) {
 		SessionID:        sessionID,
 		NotificationType: "permission_prompt",
 	})
-	sessions = store.ListBySessionID(sessionID)
+	sessions = store.List()
 	require.Equal(t, StatusNeedsAttention, sessions[0].Status)
 
 	service.HandleHookEvent(ctx, &HookEventRequest{
@@ -132,7 +132,7 @@ func TestFullFlow_NeedsAttentionToWorkingViaPreToolUse(t *testing.T) {
 		ClaudeSessionID: "cs-1",
 		SessionID:       sessionID,
 	})
-	sessions = store.ListBySessionID(sessionID)
+	sessions = store.List()
 	require.Equal(t, StatusWorking, sessions[0].Status)
 
 	service.HandleHookEvent(ctx, &HookEventRequest{
@@ -140,6 +140,6 @@ func TestFullFlow_NeedsAttentionToWorkingViaPreToolUse(t *testing.T) {
 		ClaudeSessionID: "cs-1",
 		SessionID:       sessionID,
 	})
-	sessions = store.ListBySessionID(sessionID)
+	sessions = store.List()
 	require.Equal(t, StatusReadyForReview, sessions[0].Status)
 }

--- a/internal/claude/claudeservice_test.go
+++ b/internal/claude/claudeservice_test.go
@@ -4,192 +4,142 @@ import (
 	"context"
 	"testing"
 
-	"github.com/eleonorayaya/utena/internal/eventbus"
+	"github.com/eleonorayaya/utena/internal/db"
 	"github.com/stretchr/testify/require"
 )
 
-func setupService(t *testing.T) (*ClaudeService, *ClaudeStore) {
+func setupService(t *testing.T) (*ClaudeService, *ClaudeStore, db.Database) {
 	t.Helper()
 	database := setupTestDB(t)
 	store := NewClaudeStore(database)
-	bus := eventbus.NewEventBus()
-	service := NewClaudeService(store, bus)
-	service.OnAppStart(context.Background())
-	return service, store
+	service := NewClaudeService(store)
+	return service, store, database
 }
 
 func TestPreToolUse_ClearsNeedsAttention(t *testing.T) {
-	service, store := setupService(t)
-	store.Upsert(&ClaudeSession{
+	service, store, database := setupService(t)
+	sessionID := createTestSession(t, database)
+
+	store.Create(&ClaudeSession{
 		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
+		SessionID:       sessionID,
 		Status:          StatusNeedsAttention,
 	})
 
 	err := service.HandleHookEvent(context.Background(), &HookEventRequest{
 		Event:           "PreToolUse",
 		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
+		SessionID:       sessionID,
 	})
 	require.NoError(t, err)
 
-	sessions := store.ListBySessionID("sess-1")
+	sessions := store.ListBySessionID(sessionID)
 	require.Len(t, sessions, 1)
 	require.Equal(t, StatusWorking, sessions[0].Status)
 }
 
 func TestPreToolUse_NoOpWhenWorking(t *testing.T) {
-	service, store := setupService(t)
-	store.Upsert(&ClaudeSession{
+	service, store, database := setupService(t)
+	sessionID := createTestSession(t, database)
+
+	store.Create(&ClaudeSession{
 		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
+		SessionID:       sessionID,
 		Status:          StatusWorking,
 	})
 
 	err := service.HandleHookEvent(context.Background(), &HookEventRequest{
 		Event:           "PreToolUse",
 		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
+		SessionID:       sessionID,
 	})
 	require.NoError(t, err)
 
-	sessions := store.ListBySessionID("sess-1")
+	sessions := store.ListBySessionID(sessionID)
 	require.Len(t, sessions, 1)
 	require.Equal(t, StatusWorking, sessions[0].Status)
 }
 
 func TestPreToolUse_ClearsReadyForReview(t *testing.T) {
-	service, store := setupService(t)
-	store.Upsert(&ClaudeSession{
+	service, store, database := setupService(t)
+	sessionID := createTestSession(t, database)
+
+	store.Create(&ClaudeSession{
 		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
+		SessionID:       sessionID,
 		Status:          StatusReadyForReview,
 	})
 
 	err := service.HandleHookEvent(context.Background(), &HookEventRequest{
 		Event:           "PreToolUse",
 		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
+		SessionID:       sessionID,
 	})
 	require.NoError(t, err)
 
-	sessions := store.ListBySessionID("sess-1")
+	sessions := store.ListBySessionID(sessionID)
 	require.Len(t, sessions, 1)
 	require.Equal(t, StatusWorking, sessions[0].Status)
 }
 
-func TestPreToolUse_ClearsCompleted(t *testing.T) {
-	service, store := setupService(t)
-	store.Upsert(&ClaudeSession{
+func TestPreToolUse_ClearsDone(t *testing.T) {
+	service, store, database := setupService(t)
+	sessionID := createTestSession(t, database)
+
+	store.Create(&ClaudeSession{
 		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
-		Status:          StatusCompleted,
+		SessionID:       sessionID,
+		Status:          StatusDone,
 	})
 
 	err := service.HandleHookEvent(context.Background(), &HookEventRequest{
 		Event:           "PreToolUse",
 		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
+		SessionID:       sessionID,
 	})
 	require.NoError(t, err)
 
-	sessions := store.ListBySessionID("sess-1")
+	sessions := store.ListBySessionID(sessionID)
 	require.Len(t, sessions, 1)
 	require.Equal(t, StatusWorking, sessions[0].Status)
 }
 
 func TestFullFlow_NeedsAttentionToWorkingViaPreToolUse(t *testing.T) {
-	service, store := setupService(t)
+	service, store, database := setupService(t)
+	sessionID := createTestSession(t, database)
 	ctx := context.Background()
 
 	service.HandleHookEvent(ctx, &HookEventRequest{
 		Event:           "SessionStart",
 		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
+		SessionID:       sessionID,
 		CWD:             "/tmp",
 	})
-	sessions := store.ListBySessionID("sess-1")
-	require.Equal(t, StatusWorking, sessions[0].Status)
+	sessions := store.ListBySessionID(sessionID)
+	require.Equal(t, StatusIdle, sessions[0].Status)
 
 	service.HandleHookEvent(ctx, &HookEventRequest{
 		Event:            "Notification",
 		ClaudeSessionID:  "cs-1",
-		SessionID:        "sess-1",
+		SessionID:        sessionID,
 		NotificationType: "permission_prompt",
 	})
-	sessions = store.ListBySessionID("sess-1")
+	sessions = store.ListBySessionID(sessionID)
 	require.Equal(t, StatusNeedsAttention, sessions[0].Status)
 
 	service.HandleHookEvent(ctx, &HookEventRequest{
 		Event:           "PreToolUse",
 		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
+		SessionID:       sessionID,
 	})
-	sessions = store.ListBySessionID("sess-1")
+	sessions = store.ListBySessionID(sessionID)
 	require.Equal(t, StatusWorking, sessions[0].Status)
 
 	service.HandleHookEvent(ctx, &HookEventRequest{
 		Event:           "Stop",
 		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
+		SessionID:       sessionID,
 	})
-	sessions = store.ListBySessionID("sess-1")
+	sessions = store.ListBySessionID(sessionID)
 	require.Equal(t, StatusReadyForReview, sessions[0].Status)
-}
-
-func TestTmuxClientSessionChanged_ClearsReadyForReview(t *testing.T) {
-	service, store := setupService(t)
-	store.Upsert(&ClaudeSession{
-		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
-		Status:          StatusReadyForReview,
-	})
-
-	err := service.eventBus.Publish(context.Background(), eventbus.Event{
-		Type: eventbus.TmuxClientSessionChanged,
-		Data: eventbus.TmuxHookEvent{TmuxSessionName: "sess-1"},
-	})
-	require.NoError(t, err)
-
-	sessions := store.ListBySessionID("sess-1")
-	require.Len(t, sessions, 1)
-	require.Equal(t, StatusCompleted, sessions[0].Status)
-}
-
-func TestTmuxClientSessionChanged_DoesNotAffectWorking(t *testing.T) {
-	service, store := setupService(t)
-	store.Upsert(&ClaudeSession{
-		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
-		Status:          StatusWorking,
-	})
-
-	err := service.eventBus.Publish(context.Background(), eventbus.Event{
-		Type: eventbus.TmuxClientSessionChanged,
-		Data: eventbus.TmuxHookEvent{TmuxSessionName: "sess-1"},
-	})
-	require.NoError(t, err)
-
-	sessions := store.ListBySessionID("sess-1")
-	require.Len(t, sessions, 1)
-	require.Equal(t, StatusWorking, sessions[0].Status)
-}
-
-func TestTmuxClientSessionChanged_DoesNotAffectNeedsAttention(t *testing.T) {
-	service, store := setupService(t)
-	store.Upsert(&ClaudeSession{
-		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
-		Status:          StatusNeedsAttention,
-	})
-
-	err := service.eventBus.Publish(context.Background(), eventbus.Event{
-		Type: eventbus.TmuxClientSessionChanged,
-		Data: eventbus.TmuxHookEvent{TmuxSessionName: "sess-1"},
-	})
-	require.NoError(t, err)
-
-	sessions := store.ListBySessionID("sess-1")
-	require.Len(t, sessions, 1)
-	require.Equal(t, StatusNeedsAttention, sessions[0].Status)
 }

--- a/internal/claude/claudesession.go
+++ b/internal/claude/claudesession.go
@@ -11,16 +11,17 @@ var ErrClaudeSessionNotFound = errors.New("claude session not found")
 type ClaudeSessionStatus string
 
 const (
+	StatusIdle           ClaudeSessionStatus = "idle"
 	StatusWorking        ClaudeSessionStatus = "working"
 	StatusNeedsAttention ClaudeSessionStatus = "needs_attention"
 	StatusReadyForReview ClaudeSessionStatus = "ready_for_review"
-	StatusCompleted      ClaudeSessionStatus = "completed"
+	StatusDone           ClaudeSessionStatus = "done"
 )
 
 type ClaudeSession struct {
 	gorm.Model
 	ClaudeSessionID string              `json:"claude_session_id" gorm:"uniqueIndex"`
-	SessionID       string              `json:"session_id" gorm:"index"`
+	SessionID       uint                `json:"session_id" gorm:"index"`
 	Status          ClaudeSessionStatus `json:"status"`
 	CWD             string              `json:"cwd,omitempty"`
 }

--- a/internal/claude/claudesession.go
+++ b/internal/claude/claudesession.go
@@ -25,3 +25,44 @@ type ClaudeSession struct {
 	Status          ClaudeSessionStatus `json:"status"`
 	CWD             string              `json:"cwd,omitempty"`
 }
+
+func AggregateStatus(sessions []ClaudeSession) ClaudeSessionStatus {
+	if len(sessions) == 0 {
+		return ""
+	}
+	hasNeedsAttention := false
+	hasWorking := false
+	hasReadyForReview := false
+	hasDone := false
+	hasIdle := false
+	for _, cs := range sessions {
+		switch cs.Status {
+		case StatusNeedsAttention:
+			hasNeedsAttention = true
+		case StatusWorking:
+			hasWorking = true
+		case StatusReadyForReview:
+			hasReadyForReview = true
+		case StatusDone:
+			hasDone = true
+		case StatusIdle:
+			hasIdle = true
+		}
+	}
+	if hasNeedsAttention {
+		return StatusNeedsAttention
+	}
+	if hasWorking {
+		return StatusWorking
+	}
+	if hasReadyForReview {
+		return StatusReadyForReview
+	}
+	if hasDone {
+		return StatusDone
+	}
+	if hasIdle {
+		return StatusIdle
+	}
+	return ""
+}

--- a/internal/claude/claudestore.go
+++ b/internal/claude/claudestore.go
@@ -22,12 +22,6 @@ func (s *ClaudeStore) List() []ClaudeSession {
 	return sessions
 }
 
-func (s *ClaudeStore) ListBySessionID(sessionID uint) []ClaudeSession {
-	var sessions []ClaudeSession
-	s.db.Where("session_id = ?", sessionID).Order("updated_at DESC").Find(&sessions)
-	return sessions
-}
-
 func (s *ClaudeStore) Create(cs *ClaudeSession) error {
 	return s.db.Create(cs).Error
 }

--- a/internal/claude/claudestore.go
+++ b/internal/claude/claudestore.go
@@ -2,10 +2,8 @@ package claude
 
 import (
 	"context"
-	"errors"
 
 	"github.com/eleonorayaya/utena/internal/db"
-	"gorm.io/gorm"
 )
 
 type ClaudeStore struct {
@@ -24,61 +22,25 @@ func (s *ClaudeStore) List() []ClaudeSession {
 	return sessions
 }
 
-func (s *ClaudeStore) ListBySessionID(sessionID string) []ClaudeSession {
+func (s *ClaudeStore) ListBySessionID(sessionID uint) []ClaudeSession {
 	var sessions []ClaudeSession
 	s.db.Where("session_id = ?", sessionID).Order("updated_at DESC").Find(&sessions)
 	return sessions
 }
 
-func (s *ClaudeStore) Upsert(session *ClaudeSession) error {
-	if session == nil {
-		return errors.New("claude session cannot be nil")
-	}
-	if session.ClaudeSessionID == "" {
-		return errors.New("claude session ID cannot be empty")
-	}
-
-	var existing ClaudeSession
-	if err := s.db.First(&existing, "claude_session_id = ?", session.ClaudeSessionID).Error; err == nil {
-		existing.SessionID = session.SessionID
-		existing.Status = session.Status
-		existing.CWD = session.CWD
-		return s.db.Save(&existing).Error
-	}
-
-	return s.db.Create(session).Error
+func (s *ClaudeStore) Create(cs *ClaudeSession) error {
+	return s.db.Create(cs).Error
 }
 
-func (s *ClaudeStore) UpdateStatusBySessionID(sessionID string, from, to ClaudeSessionStatus) {
-	s.db.Model(&ClaudeSession{}).
-		Where("session_id = ? AND status = ?", sessionID, from).
-		Update("status", to)
-}
-
-func (s *ClaudeStore) UpdateStatusByClaudeSessionID(claudeSessionID string, status ClaudeSessionStatus) error {
+func (s *ClaudeStore) UpdateStatus(claudeSessionID string, status ClaudeSessionStatus) error {
 	return s.db.Model(&ClaudeSession{}).
 		Where("claude_session_id = ?", claudeSessionID).
 		Update("status", status).Error
 }
 
-func (s *ClaudeStore) DeleteByClaudeSessionID(claudeSessionID string) error {
-	if claudeSessionID == "" {
-		return errors.New("claude session ID cannot be empty")
-	}
-
-	var existing ClaudeSession
-	if err := s.db.First(&existing, "claude_session_id = ?", claudeSessionID).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return ErrClaudeSessionNotFound
-		}
-		return err
-	}
-
-	return s.db.Delete(&ClaudeSession{}, "id = ?", existing.ID).Error
-}
-
 func (s *ClaudeStore) OnAppStart(ctx context.Context) error {
-	return nil
+	s.db.Exec("DROP TABLE IF EXISTS claude_sessions")
+	return s.db.Migrate(&ClaudeSession{})
 }
 
 func (s *ClaudeStore) OnAppEnd(ctx context.Context) error {

--- a/internal/claude/claudestore.go
+++ b/internal/claude/claudestore.go
@@ -39,8 +39,7 @@ func (s *ClaudeStore) UpdateStatus(claudeSessionID string, status ClaudeSessionS
 }
 
 func (s *ClaudeStore) OnAppStart(ctx context.Context) error {
-	s.db.Exec("DROP TABLE IF EXISTS claude_sessions")
-	return s.db.Migrate(&ClaudeSession{})
+	return nil
 }
 
 func (s *ClaudeStore) OnAppEnd(ctx context.Context) error {

--- a/internal/claude/claudestore_test.go
+++ b/internal/claude/claudestore_test.go
@@ -51,7 +51,7 @@ func TestUpdateStatus(t *testing.T) {
 	err := store.UpdateStatus("cs-1", StatusWorking)
 	require.NoError(t, err)
 
-	sessions := store.ListBySessionID(sessionID)
+	sessions := store.List()
 	require.Len(t, sessions, 1)
 	require.Equal(t, StatusWorking, sessions[0].Status)
 }

--- a/internal/claude/claudestore_test.go
+++ b/internal/claude/claudestore_test.go
@@ -5,7 +5,14 @@ import (
 
 	"github.com/eleonorayaya/utena/internal/db"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
+
+type testSession struct {
+	gorm.Model
+}
+
+func (testSession) TableName() string { return "sessions" }
 
 func setupTestDB(t *testing.T) db.Database {
 	t.Helper()
@@ -13,35 +20,45 @@ func setupTestDB(t *testing.T) db.Database {
 	if err != nil {
 		t.Fatal(err)
 	}
-	database.Migrate(&ClaudeSession{})
+	database.Migrate(&testSession{}, &ClaudeSession{})
 	t.Cleanup(func() { database.Close() })
 	return database
 }
 
-func setupStore(t *testing.T) *ClaudeStore {
+func createTestSession(t *testing.T, database db.Database) uint {
 	t.Helper()
-	return NewClaudeStore(setupTestDB(t))
+	sess := &testSession{}
+	database.Create(sess)
+	return sess.ID
 }
 
-func TestUpdateStatusByClaudeSessionID(t *testing.T) {
-	store := setupStore(t)
-	store.Upsert(&ClaudeSession{
+func setupStore(t *testing.T) (*ClaudeStore, db.Database) {
+	t.Helper()
+	database := setupTestDB(t)
+	return NewClaudeStore(database), database
+}
+
+func TestUpdateStatus(t *testing.T) {
+	store, database := setupStore(t)
+	sessionID := createTestSession(t, database)
+
+	store.Create(&ClaudeSession{
 		ClaudeSessionID: "cs-1",
-		SessionID:       "sess-1",
+		SessionID:       sessionID,
 		Status:          StatusNeedsAttention,
 	})
 
-	err := store.UpdateStatusByClaudeSessionID("cs-1", StatusWorking)
+	err := store.UpdateStatus("cs-1", StatusWorking)
 	require.NoError(t, err)
 
-	sessions := store.ListBySessionID("sess-1")
+	sessions := store.ListBySessionID(sessionID)
 	require.Len(t, sessions, 1)
 	require.Equal(t, StatusWorking, sessions[0].Status)
 }
 
-func TestUpdateStatusByClaudeSessionID_NonExistentSession(t *testing.T) {
-	store := setupStore(t)
+func TestUpdateStatus_NonExistentSession(t *testing.T) {
+	store, _ := setupStore(t)
 
-	err := store.UpdateStatusByClaudeSessionID("nonexistent", StatusWorking)
+	err := store.UpdateStatus("nonexistent", StatusWorking)
 	require.NoError(t, err)
 }

--- a/internal/claude/types.go
+++ b/internal/claude/types.go
@@ -8,7 +8,7 @@ import (
 type HookEventRequest struct {
 	Event            string `json:"event"`
 	ClaudeSessionID  string `json:"claude_session_id"`
-	SessionID        string `json:"session_id"`
+	SessionID        uint   `json:"session_id,string"`
 	CWD              string `json:"cwd,omitempty"`
 	NotificationType string `json:"notification_type,omitempty"`
 }
@@ -19,9 +19,6 @@ func (h *HookEventRequest) Bind(r *http.Request) error {
 	}
 	if h.ClaudeSessionID == "" {
 		return errors.New("claude_session_id is required")
-	}
-	if h.SessionID == "" {
-		return errors.New("session_id is required")
 	}
 	return nil
 }

--- a/internal/db/dbservice.go
+++ b/internal/db/dbservice.go
@@ -17,6 +17,7 @@ type Database interface {
 	Order(value any) *gorm.DB
 	Joins(query string, args ...any) *gorm.DB
 	Omit(columns ...string) *gorm.DB
+	Exec(sql string, values ...any) *gorm.DB
 	Migrate(models ...any) error
 	Close() error
 }

--- a/internal/db/dbservice.go
+++ b/internal/db/dbservice.go
@@ -17,7 +17,6 @@ type Database interface {
 	Order(value any) *gorm.DB
 	Joins(query string, args ...any) *gorm.DB
 	Omit(columns ...string) *gorm.DB
-	Exec(sql string, values ...any) *gorm.DB
 	Migrate(models ...any) error
 	Close() error
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/eleonorayaya/utena/internal/claude"
 	"github.com/eleonorayaya/utena/internal/workspace"
 	"gorm.io/gorm"
 )
@@ -26,18 +27,19 @@ const (
 
 type Session struct {
 	gorm.Model
-	TmuxSessionName string               `json:"tmux_session_name,omitempty" gorm:"uniqueIndex"`
-	Name            string               `json:"name,omitempty"`
-	WorkspaceID     uint                 `json:"workspace_id" gorm:"index"`
-	TodoID          *uint                `json:"todo_id,omitempty" gorm:"index"`
-	Branch          string               `json:"branch,omitempty"`
-	BaseBranch      string               `json:"base_branch,omitempty"`
-	WorktreePath    string               `json:"worktree_path,omitempty"`
-	Status          SessionStatus        `json:"status"`
-	Resources       *Resources           `json:"resources,omitempty" gorm:"serializer:json"`
-	IsAttached      bool                 `json:"is_attached"`
-	LastUsedAt      time.Time            `json:"last_used_at"`
-	Workspace       *workspace.Workspace `json:"workspace,omitempty" gorm:"foreignKey:WorkspaceID"`
+	TmuxSessionName string                 `json:"tmux_session_name,omitempty" gorm:"uniqueIndex"`
+	Name            string                 `json:"name,omitempty"`
+	WorkspaceID     uint                   `json:"workspace_id" gorm:"index"`
+	TodoID          *uint                  `json:"todo_id,omitempty" gorm:"index"`
+	Branch          string                 `json:"branch,omitempty"`
+	BaseBranch      string                 `json:"base_branch,omitempty"`
+	WorktreePath    string                 `json:"worktree_path,omitempty"`
+	Status          SessionStatus          `json:"status"`
+	Resources       *Resources             `json:"resources,omitempty" gorm:"serializer:json"`
+	IsAttached      bool                   `json:"is_attached"`
+	LastUsedAt      time.Time              `json:"last_used_at"`
+	Workspace       *workspace.Workspace   `json:"workspace,omitempty" gorm:"foreignKey:WorkspaceID"`
+	ClaudeSessions  []claude.ClaudeSession `json:"claude_sessions,omitempty" gorm:"foreignKey:SessionID"`
 }
 
 func SanitizeTmuxName(name string) string {

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -260,6 +260,7 @@ func (s *SessionService) setupTmux(ctx context.Context, sess *Session) error {
 	if err := s.tmuxService.CreateSession(sess.TmuxSessionName, startDir); err != nil {
 		return fmt.Errorf("failed to create tmux session: %v", err)
 	}
+	s.tmuxService.SetSessionEnv(sess.TmuxSessionName, "UTENA_SESSION_ID", fmt.Sprintf("%d", sess.ID))
 	return nil
 }
 
@@ -430,6 +431,7 @@ func (s *SessionService) ActivateSession(ctx context.Context, id uint) (*Session
 		if err := s.tmuxService.CreateSession(session.TmuxSessionName, startDir); err != nil {
 			return nil, fmt.Errorf("failed to revive tmux session: %w", err)
 		}
+		s.tmuxService.SetSessionEnv(session.TmuxSessionName, "UTENA_SESSION_ID", fmt.Sprintf("%d", session.ID))
 		session.Status = StatusReady
 		if session.Resources != nil && session.Resources.Tmux != nil {
 			session.Resources.Tmux.Status = ResourceReady

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -257,10 +257,10 @@ func (s *SessionService) setupWorktree(ctx context.Context, sess *Session, ws *w
 
 func (s *SessionService) setupTmux(ctx context.Context, sess *Session) error {
 	startDir := s.resolveStartDir(ctx, sess)
-	if err := s.tmuxService.CreateSession(sess.TmuxSessionName, startDir); err != nil {
+	env := map[string]string{"UTENA_SESSION_ID": fmt.Sprintf("%d", sess.ID)}
+	if err := s.tmuxService.CreateSession(sess.TmuxSessionName, startDir, env); err != nil {
 		return fmt.Errorf("failed to create tmux session: %v", err)
 	}
-	s.tmuxService.SetSessionEnv(sess.TmuxSessionName, "UTENA_SESSION_ID", fmt.Sprintf("%d", sess.ID))
 	return nil
 }
 
@@ -428,10 +428,10 @@ func (s *SessionService) ActivateSession(ctx context.Context, id uint) (*Session
 
 	if !s.tmuxService.HasSession(session.TmuxSessionName) {
 		startDir := s.resolveStartDir(ctx, session)
-		if err := s.tmuxService.CreateSession(session.TmuxSessionName, startDir); err != nil {
+		env := map[string]string{"UTENA_SESSION_ID": fmt.Sprintf("%d", session.ID)}
+		if err := s.tmuxService.CreateSession(session.TmuxSessionName, startDir, env); err != nil {
 			return nil, fmt.Errorf("failed to revive tmux session: %w", err)
 		}
-		s.tmuxService.SetSessionEnv(session.TmuxSessionName, "UTENA_SESSION_ID", fmt.Sprintf("%d", session.ID))
 		session.Status = StatusReady
 		if session.Resources != nil && session.Resources.Tmux != nil {
 			session.Resources.Tmux.Status = ResourceReady

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -29,7 +29,7 @@ func newMockTmuxClient() *mockTmuxClient {
 	return &mockTmuxClient{sessions: make(map[string]bool)}
 }
 
-func (m *mockTmuxClient) CreateSession(name, startDir string) error {
+func (m *mockTmuxClient) CreateSession(name, startDir string, env map[string]string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.createErr != nil {

--- a/internal/session/sessionstore.go
+++ b/internal/session/sessionstore.go
@@ -22,7 +22,7 @@ func NewSessionStore(database db.Database) *SessionStore {
 
 func (s *SessionStore) GetByID(id uint) (*Session, error) {
 	var session Session
-	if err := s.db.Joins("Workspace").Preload("ClaudeSessions").First(&session, "sessions.id = ?", id).Error; err != nil {
+	if err := s.db.Joins("Workspace").First(&session, "sessions.id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrSessionNotFound
 		}
@@ -33,7 +33,7 @@ func (s *SessionStore) GetByID(id uint) (*Session, error) {
 
 func (s *SessionStore) GetByTmuxName(tmuxName string) (*Session, error) {
 	var session Session
-	if err := s.db.Joins("Workspace").Preload("ClaudeSessions").First(&session, "tmux_session_name = ?", tmuxName).Error; err != nil {
+	if err := s.db.Joins("Workspace").First(&session, "tmux_session_name = ?", tmuxName).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrSessionNotFound
 		}

--- a/internal/session/sessionstore.go
+++ b/internal/session/sessionstore.go
@@ -22,7 +22,7 @@ func NewSessionStore(database db.Database) *SessionStore {
 
 func (s *SessionStore) GetByID(id uint) (*Session, error) {
 	var session Session
-	if err := s.db.Joins("Workspace").First(&session, "sessions.id = ?", id).Error; err != nil {
+	if err := s.db.Joins("Workspace").Preload("ClaudeSessions").First(&session, "sessions.id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrSessionNotFound
 		}
@@ -33,7 +33,7 @@ func (s *SessionStore) GetByID(id uint) (*Session, error) {
 
 func (s *SessionStore) GetByTmuxName(tmuxName string) (*Session, error) {
 	var session Session
-	if err := s.db.Joins("Workspace").First(&session, "tmux_session_name = ?", tmuxName).Error; err != nil {
+	if err := s.db.Joins("Workspace").Preload("ClaudeSessions").First(&session, "tmux_session_name = ?", tmuxName).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrSessionNotFound
 		}
@@ -44,13 +44,13 @@ func (s *SessionStore) GetByTmuxName(tmuxName string) (*Session, error) {
 
 func (s *SessionStore) List() []Session {
 	var sessions []Session
-	s.db.Joins("Workspace").Order("sessions.last_used_at DESC").Find(&sessions)
+	s.db.Joins("Workspace").Preload("ClaudeSessions").Order("sessions.last_used_at DESC").Find(&sessions)
 	return sessions
 }
 
 func (s *SessionStore) ListByWorkspace(workspaceID uint) []Session {
 	var sessions []Session
-	s.db.Joins("Workspace").Where("sessions.workspace_id = ?", workspaceID).Order("sessions.last_used_at DESC").Find(&sessions)
+	s.db.Joins("Workspace").Preload("ClaudeSessions").Where("sessions.workspace_id = ?", workspaceID).Order("sessions.last_used_at DESC").Find(&sessions)
 	return sessions
 }
 
@@ -59,7 +59,7 @@ func (s *SessionStore) Add(session *Session) error {
 		return errors.New("session cannot be nil")
 	}
 
-	if err := s.db.Omit("Workspace").Create(session).Error; err != nil {
+	if err := s.db.Omit("Workspace", "ClaudeSessions").Create(session).Error; err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) || isUniqueConstraintError(err) {
 			return fmt.Errorf("session '%s' already exists: %w", session.TmuxSessionName, ErrSessionAlreadyExists)
 		}
@@ -84,7 +84,7 @@ func (s *SessionStore) Update(session *Session) error {
 		return err
 	}
 
-	return s.db.Omit("Workspace").Save(session).Error
+	return s.db.Omit("Workspace", "ClaudeSessions").Save(session).Error
 }
 
 func (s *SessionStore) Delete(id uint) error {

--- a/internal/session/sessionstore_test.go
+++ b/internal/session/sessionstore_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eleonorayaya/utena/internal/claude"
 	"github.com/eleonorayaya/utena/internal/db"
 	"github.com/eleonorayaya/utena/internal/workspace"
 	"github.com/stretchr/testify/require"
@@ -19,7 +20,7 @@ func setupTestDB(t *testing.T) db.Database {
 	if err != nil {
 		t.Fatal(err)
 	}
-	database.Migrate(&workspace.Workspace{}, &Session{})
+	database.Migrate(&workspace.Workspace{}, &Session{}, &claude.ClaudeSession{})
 	t.Cleanup(func() { database.Close() })
 	return database
 }

--- a/internal/shellinit/shellinit.go
+++ b/internal/shellinit/shellinit.go
@@ -2,7 +2,11 @@ package shellinit
 
 func Script() string {
 	return `if [ -n "$TMUX" ]; then
-  export UTENA_SESSION_ID="$(tmux display-message -p '#S')"
+  _utena_val=$(tmux show-environment UTENA_SESSION_ID 2>/dev/null)
+  if [ -n "$_utena_val" ] && [ "${_utena_val#-}" = "$_utena_val" ]; then
+    export "$_utena_val"
+  fi
+  unset _utena_val
 fi
 `
 }

--- a/internal/tmux/tmuxclient.go
+++ b/internal/tmux/tmuxclient.go
@@ -1,13 +1,14 @@
 package tmux
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/GianlucaP106/gotmux/gotmux"
 )
 
 type TmuxClient interface {
-	CreateSession(name, startDir string) error
+	CreateSession(name, startDir string, env map[string]string) error
 	KillSession(name string) error
 	HasSession(name string) bool
 	ListSessionNames() ([]string, error)
@@ -28,12 +29,20 @@ func NewGotmuxClient() TmuxClient {
 	return &gotmuxClient{tmux: t}
 }
 
-func (c *gotmuxClient) CreateSession(name, startDir string) error {
+func (c *gotmuxClient) CreateSession(name, startDir string, env map[string]string) error {
 	_, err := c.tmux.NewSession(&gotmux.SessionOptions{
 		Name:           name,
 		StartDirectory: startDir,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	for k, v := range env {
+		if _, err := c.tmux.Command("set-environment", "-t", name, k, v); err != nil {
+			return fmt.Errorf("failed to set environment %s: %w", k, err)
+		}
+	}
+	return nil
 }
 
 func (c *gotmuxClient) KillSession(name string) error {

--- a/internal/tmux/tmuxservice.go
+++ b/internal/tmux/tmuxservice.go
@@ -31,11 +31,11 @@ func (t *TmuxService) OnAppEnd(ctx context.Context) error {
 	return nil
 }
 
-func (t *TmuxService) CreateSession(name, startDir string) error {
+func (t *TmuxService) CreateSession(name, startDir string, env map[string]string) error {
 	if t.client == nil {
 		return ErrTmuxNotAvailable
 	}
-	return t.client.CreateSession(name, startDir)
+	return t.client.CreateSession(name, startDir, env)
 }
 
 func (t *TmuxService) KillSession(name string) error {
@@ -111,10 +111,6 @@ func (t *TmuxService) HandleClientDetached(ctx context.Context, tmuxName string)
 
 func (t *TmuxService) SyncWindows(ctx context.Context, tmuxName string, windows []Window) {
 	t.windowsBySession[tmuxName] = windows
-}
-
-func (t *TmuxService) SetSessionEnv(sessionName, key, value string) {
-	t.client.RunCommand("set-environment", "-t", sessionName, key, value)
 }
 
 func (t *TmuxService) GetWindows(ctx context.Context, tmuxName string) []Window {

--- a/internal/tmux/tmuxservice.go
+++ b/internal/tmux/tmuxservice.go
@@ -113,6 +113,10 @@ func (t *TmuxService) SyncWindows(ctx context.Context, tmuxName string, windows 
 	t.windowsBySession[tmuxName] = windows
 }
 
+func (t *TmuxService) SetSessionEnv(sessionName, key, value string) {
+	t.client.RunCommand("set-environment", "-t", sessionName, key, value)
+}
+
 func (t *TmuxService) GetWindows(ctx context.Context, tmuxName string) []Window {
 	return t.windowsBySession[tmuxName]
 }

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/GianlucaP106/gotmux/gotmux"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/eleonorayaya/utena/internal/claude"
 	"github.com/eleonorayaya/utena/internal/session"
 	"github.com/eleonorayaya/utena/internal/tmux"
 	"github.com/eleonorayaya/utena/internal/todo"
@@ -67,30 +66,6 @@ func (c *client) fetchSessions() tea.Cmd {
 			sessions[i] = *sr.Session
 		}
 		return sessionsLoadedMsg{sessions}
-	}
-}
-
-func (c *client) fetchClaudeSessions() tea.Cmd {
-	return func() tea.Msg {
-		res, err := c.httpClient.Get(c.baseURL + "/claude/sessions")
-		if err != nil {
-			log.Printf("[ERROR] fetch claude sessions: %v", err)
-			return claudeSessionsLoadedMsg{}
-		}
-		defer res.Body.Close()
-
-		if res.StatusCode != http.StatusOK {
-			log.Printf("[ERROR] fetch claude sessions: status %d", res.StatusCode)
-			return claudeSessionsLoadedMsg{}
-		}
-
-		var resp claude.ClaudeSessionListResponse
-		if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
-			log.Printf("[ERROR] decode claude sessions: %v", err)
-			return claudeSessionsLoadedMsg{}
-		}
-
-		return claudeSessionsLoadedMsg{claudeSessions: resp.ClaudeSessions}
 	}
 }
 

--- a/internal/tui/provider/sessionsprovider.go
+++ b/internal/tui/provider/sessionsprovider.go
@@ -2,14 +2,12 @@ package provider
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/eleonorayaya/utena/internal/claude"
 	"github.com/eleonorayaya/utena/internal/session"
 	"github.com/eleonorayaya/utena/internal/tmux"
 )
 
 type SessionsStateUpdatedMsg struct {
-	Sessions       []session.Session
-	ClaudeSessions map[string][]claude.ClaudeSession
+	Sessions []session.Session
 }
 
 type WindowsStateUpdatedMsg struct {
@@ -108,10 +106,6 @@ type sessionsLoadedMsg struct {
 	sessions []session.Session
 }
 
-type claudeSessionsLoadedMsg struct {
-	claudeSessions []claude.ClaudeSession
-}
-
 type sessionActivatedMsg struct {
 	tmuxSessionName string
 }
@@ -144,9 +138,8 @@ type SessionPolledMsg struct {
 type SessionSwitchedMsg struct{}
 
 type sessionsProvider struct {
-	client         *client
-	sessions       []session.Session
-	claudeSessions map[string][]claude.ClaudeSession
+	client   *client
+	sessions []session.Session
 }
 
 func newSessionsProvider(c *client) sessionsProvider {
@@ -155,11 +148,9 @@ func newSessionsProvider(c *client) sessionsProvider {
 
 func (p sessionsProvider) emitState() tea.Cmd {
 	sessions := p.sessions
-	claudeSessions := p.claudeSessions
 	return func() tea.Msg {
 		return SessionsStateUpdatedMsg{
-			Sessions:       sessions,
-			ClaudeSessions: claudeSessions,
+			Sessions: sessions,
 		}
 	}
 }
@@ -184,15 +175,8 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 		p.sessions = msg.sessions
 		return p, tea.Batch(p.emitState(), p.deriveActiveWorkspace())
 
-	case claudeSessionsLoadedMsg:
-		p.claudeSessions = make(map[string][]claude.ClaudeSession)
-		for _, cs := range msg.claudeSessions {
-			p.claudeSessions[cs.SessionID] = append(p.claudeSessions[cs.SessionID], cs)
-		}
-		return p, p.emitState()
-
 	case fetchSessionsIntentMsg:
-		return p, tea.Batch(p.client.fetchSessions(), p.client.fetchClaudeSessions())
+		return p, p.client.fetchSessions()
 
 	case fetchWindowsIntentMsg:
 		return p, p.client.fetchWindows(msg.sessionName)

--- a/internal/tui/sessionlist/sessionitem.go
+++ b/internal/tui/sessionlist/sessionitem.go
@@ -8,7 +8,7 @@ import (
 
 type sessionItem struct {
 	session      session.Session
-	claudeStatus string
+	claudeStatus claude.ClaudeSessionStatus
 }
 
 func (i sessionItem) displayName() string {
@@ -30,8 +30,17 @@ func (i sessionItem) Title() string {
 			title += " (attached)"
 		}
 	}
-	if i.claudeStatus != "" {
-		title += " " + i.claudeStatus
+	switch i.claudeStatus {
+	case claude.StatusNeedsAttention:
+		title += " [needs attention]"
+	case claude.StatusWorking:
+		title += " [working]"
+	case claude.StatusReadyForReview:
+		title += " [ready for review]"
+	case claude.StatusDone:
+		title += " [done]"
+	case claude.StatusIdle:
+		title += " [idle]"
 	}
 	return title
 }
@@ -52,33 +61,45 @@ func (i sessionItem) Description() string {
 
 func (i sessionItem) FilterValue() string { return i.displayName() }
 
-func aggregateClaudeStatus(sessions []claude.ClaudeSession) string {
+func aggregateClaudeStatus(sessions []claude.ClaudeSession) claude.ClaudeSessionStatus {
 	if len(sessions) == 0 {
 		return ""
 	}
 
 	hasNeedsAttention := false
-	hasReadyForReview := false
 	hasWorking := false
+	hasReadyForReview := false
+	hasDone := false
+	hasIdle := false
 	for _, cs := range sessions {
 		switch cs.Status {
 		case claude.StatusNeedsAttention:
 			hasNeedsAttention = true
-		case claude.StatusReadyForReview:
-			hasReadyForReview = true
 		case claude.StatusWorking:
 			hasWorking = true
+		case claude.StatusReadyForReview:
+			hasReadyForReview = true
+		case claude.StatusDone:
+			hasDone = true
+		case claude.StatusIdle:
+			hasIdle = true
 		}
 	}
 
 	if hasNeedsAttention {
-		return "[needs attention]"
+		return claude.StatusNeedsAttention
 	}
 	if hasWorking {
-		return "[working]"
+		return claude.StatusWorking
 	}
 	if hasReadyForReview {
-		return "[ready for review]"
+		return claude.StatusReadyForReview
 	}
-	return "[done]"
+	if hasDone {
+		return claude.StatusDone
+	}
+	if hasIdle {
+		return claude.StatusIdle
+	}
+	return ""
 }

--- a/internal/tui/sessionlist/sessionitem.go
+++ b/internal/tui/sessionlist/sessionitem.go
@@ -62,44 +62,5 @@ func (i sessionItem) Description() string {
 func (i sessionItem) FilterValue() string { return i.displayName() }
 
 func aggregateClaudeStatus(sessions []claude.ClaudeSession) claude.ClaudeSessionStatus {
-	if len(sessions) == 0 {
-		return ""
-	}
-
-	hasNeedsAttention := false
-	hasWorking := false
-	hasReadyForReview := false
-	hasDone := false
-	hasIdle := false
-	for _, cs := range sessions {
-		switch cs.Status {
-		case claude.StatusNeedsAttention:
-			hasNeedsAttention = true
-		case claude.StatusWorking:
-			hasWorking = true
-		case claude.StatusReadyForReview:
-			hasReadyForReview = true
-		case claude.StatusDone:
-			hasDone = true
-		case claude.StatusIdle:
-			hasIdle = true
-		}
-	}
-
-	if hasNeedsAttention {
-		return claude.StatusNeedsAttention
-	}
-	if hasWorking {
-		return claude.StatusWorking
-	}
-	if hasReadyForReview {
-		return claude.StatusReadyForReview
-	}
-	if hasDone {
-		return claude.StatusDone
-	}
-	if hasIdle {
-		return claude.StatusIdle
-	}
-	return ""
+	return claude.AggregateStatus(sessions)
 }

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -7,7 +7,6 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/eleonorayaya/utena/internal/claude"
 	"github.com/eleonorayaya/utena/internal/session"
 	ulist "github.com/eleonorayaya/utena/internal/tui/list"
 	"github.com/eleonorayaya/utena/internal/tui/provider"
@@ -18,7 +17,6 @@ import (
 type Model struct {
 	list            list.Model
 	sessions        []session.Session
-	claudeSessions  map[string][]claude.ClaudeSession
 	pendingDeleteID uint
 	pendingRepairID uint
 	showBroken      bool
@@ -51,7 +49,7 @@ func (m *Model) rebuildItems() tea.Cmd {
 		if s.Status == session.StatusBroken && !m.showBroken {
 			continue
 		}
-		status := aggregateClaudeStatus(m.claudeSessions[s.TmuxSessionName])
+		status := aggregateClaudeStatus(s.ClaudeSessions)
 		items = append(items, sessionItem{session: s, claudeStatus: status})
 	}
 	return m.list.SetItems(items)
@@ -63,7 +61,6 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m.OnWindowSizeMsg(msg)
 	case provider.SessionsStateUpdatedMsg:
 		m.sessions = msg.Sessions
-		m.claudeSessions = msg.ClaudeSessions
 		return m, m.rebuildItems()
 	case provider.ErrMsg:
 		return m, m.list.NewStatusMessage(msg.Err.Error())

--- a/internal/tui/statusview/model.go
+++ b/internal/tui/statusview/model.go
@@ -80,7 +80,6 @@ type tickMsg time.Time
 
 type Model struct {
 	sessions           []session.Session
-	claudeSessions     map[string][]claude.ClaudeSession
 	windowsBySession   map[string][]tmux.Window
 	expandedSessions   map[string]bool
 	currentTmuxSession string
@@ -177,7 +176,6 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 	case provider.SessionsStateUpdatedMsg:
 		m.sessions = msg.Sessions
-		m.claudeSessions = msg.ClaudeSessions
 		return m, nil
 
 	case provider.WindowsStateUpdatedMsg:
@@ -311,7 +309,7 @@ func (m Model) collapsedView() string {
 	for _, sess := range m.orderedActiveSessions() {
 		name := sessionDisplayName(sess)
 		name = truncate(name, maxNameLen)
-		dot := statusDot(m.claudeSessions[sess.TmuxSessionName], sess.IsAttached)
+		dot := statusDot(sess.ClaudeSessions, sess.IsAttached)
 		lines = append(lines, " "+dot+" "+name)
 	}
 
@@ -371,15 +369,15 @@ func (m Model) renderSessionRow(s session.Session, idx, innerWidth int, _ []sess
 		wsName = s.Workspace.Name
 	}
 
-	dotStyle := statusDotStyle(m.claudeSessions[s.TmuxSessionName], s.IsAttached)
-	dotChar := statusDotChar(m.claudeSessions[s.TmuxSessionName], s.IsAttached)
+	dotStyle := statusDotStyle(s.ClaudeSessions, s.IsAttached)
+	dotChar := statusDotChar(s.ClaudeSessions, s.IsAttached)
 
 	nStyle := sessionNameStyle
 	if s.IsAttached {
 		nStyle = sessionAttachedStyle
 	}
 	wsStyle := workspaceStyle
-	bStyle, badgeText := claudeBadgeParts(m.claudeSessions[s.TmuxSessionName])
+	bStyle, badgeText := claudeBadgeParts(s.ClaudeSessions)
 
 	if selected {
 		dotStyle = dotStyle.Background(bg)
@@ -444,7 +442,7 @@ func statusDotChar(claudeSessions []claude.ClaudeSession, attached bool) string 
 	switch status {
 	case claude.StatusNeedsAttention:
 		return "◆"
-	case claude.StatusWorking, claude.StatusReadyForReview, claude.StatusCompleted:
+	case claude.StatusWorking, claude.StatusReadyForReview, claude.StatusDone:
 		return "●"
 	default:
 		if attached {
@@ -463,7 +461,7 @@ func statusDotStyle(claudeSessions []claude.ClaudeSession, attached bool) lipglo
 		return workingDotStyle
 	case claude.StatusReadyForReview:
 		return reviewDotStyle
-	case claude.StatusCompleted:
+	case claude.StatusDone:
 		return completedDotStyle
 	default:
 		if attached {
@@ -485,7 +483,7 @@ func claudeBadgeParts(sessions []claude.ClaudeSession) (*lipgloss.Style, string)
 	case claude.StatusReadyForReview:
 		s := reviewBadgeStyle
 		return &s, " ✓ "
-	case claude.StatusCompleted:
+	case claude.StatusDone:
 		s := completedDotStyle
 		return &s, " ✓ "
 	default:
@@ -548,7 +546,7 @@ func statusDot(claudeSessions []claude.ClaudeSession, attached bool) string {
 		return workingDotStyle.Render("●")
 	case claude.StatusReadyForReview:
 		return reviewDotStyle.Render("●")
-	case claude.StatusCompleted:
+	case claude.StatusDone:
 		return completedDotStyle.Render("●")
 	default:
 		if attached {
@@ -567,7 +565,7 @@ func claudeBadge(sessions []claude.ClaudeSession) string {
 		return workingBadgeStyle.Render(" ~ ")
 	case claude.StatusReadyForReview:
 		return reviewBadgeStyle.Render(" ✓ ")
-	case claude.StatusCompleted:
+	case claude.StatusDone:
 		return completedDotStyle.Render(" ✓ ")
 	default:
 		return ""
@@ -581,7 +579,8 @@ func aggregateStatus(sessions []claude.ClaudeSession) claude.ClaudeSessionStatus
 	hasNeedsAttention := false
 	hasWorking := false
 	hasReadyForReview := false
-	hasCompleted := false
+	hasDone := false
+	hasIdle := false
 	for _, cs := range sessions {
 		switch cs.Status {
 		case claude.StatusNeedsAttention:
@@ -590,8 +589,10 @@ func aggregateStatus(sessions []claude.ClaudeSession) claude.ClaudeSessionStatus
 			hasWorking = true
 		case claude.StatusReadyForReview:
 			hasReadyForReview = true
-		case claude.StatusCompleted:
-			hasCompleted = true
+		case claude.StatusDone:
+			hasDone = true
+		case claude.StatusIdle:
+			hasIdle = true
 		}
 	}
 	if hasNeedsAttention {
@@ -603,8 +604,11 @@ func aggregateStatus(sessions []claude.ClaudeSession) claude.ClaudeSessionStatus
 	if hasReadyForReview {
 		return claude.StatusReadyForReview
 	}
-	if hasCompleted {
-		return claude.StatusCompleted
+	if hasDone {
+		return claude.StatusDone
+	}
+	if hasIdle {
+		return claude.StatusIdle
 	}
 	return ""
 }

--- a/internal/tui/statusview/model.go
+++ b/internal/tui/statusview/model.go
@@ -573,42 +573,5 @@ func claudeBadge(sessions []claude.ClaudeSession) string {
 }
 
 func aggregateStatus(sessions []claude.ClaudeSession) claude.ClaudeSessionStatus {
-	if len(sessions) == 0 {
-		return ""
-	}
-	hasNeedsAttention := false
-	hasWorking := false
-	hasReadyForReview := false
-	hasDone := false
-	hasIdle := false
-	for _, cs := range sessions {
-		switch cs.Status {
-		case claude.StatusNeedsAttention:
-			hasNeedsAttention = true
-		case claude.StatusWorking:
-			hasWorking = true
-		case claude.StatusReadyForReview:
-			hasReadyForReview = true
-		case claude.StatusDone:
-			hasDone = true
-		case claude.StatusIdle:
-			hasIdle = true
-		}
-	}
-	if hasNeedsAttention {
-		return claude.StatusNeedsAttention
-	}
-	if hasWorking {
-		return claude.StatusWorking
-	}
-	if hasReadyForReview {
-		return claude.StatusReadyForReview
-	}
-	if hasDone {
-		return claude.StatusDone
-	}
-	if hasIdle {
-		return claude.StatusIdle
-	}
-	return ""
+	return claude.AggregateStatus(sessions)
 }


### PR DESCRIPTION
## Summary
- Establish GORM has-many from `Session` → `ClaudeSession` via uint FK, replacing the string-based tmux name correlation
- Claude sessions now self-manage their lifecycle purely via hooks — removed eventbus coupling that auto-completed sessions on tmux switch
- New statuses: `idle` (SessionStart) and `done` (SessionEnd), replacing `completed`
- TUI reads `session.ClaudeSessions` directly from preloaded data — eliminated separate `/claude/sessions` fetch and client-side mapping
- `UTENA_SESSION_ID` env var now carries the DB uint ID, set via `tmux set-environment` at session creation

## Test plan
- [x] All existing tests pass (`task test`)
- [ ] Create a session via TUI, verify `echo $UTENA_SESSION_ID` shows a numeric DB ID
- [ ] Start Claude Code in a managed session, verify status indicators update in the TUI sidebar
- [ ] Verify session list shows correct claude status aggregation (idle, working, needs attention, etc.)