### PR TITLE
fix(tui): dismiss popup after session creation

### DIFF
--- a/internal/tui/sessionprogress/model.go
+++ b/internal/tui/sessionprogress/model.go
@@ -86,6 +86,9 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		}
 		return m, tea.Batch(provider.PollSession(m.sessionID), tick())
 
+	case provider.SessionSwitchedMsg:
+		return m, tea.Quit
+
 	case provider.SessionPolledMsg:
 		s := msg.Session
 		if s.ID != m.sessionID {


### PR DESCRIPTION
## Summary
- The session progress view didn't handle `SessionSwitchedMsg`, so after creating a session the tmux client switched but the TUI popup stayed open
- Added a `SessionSwitchedMsg` handler in `sessionprogress` that returns `tea.Quit`, matching the existing pattern in `sessionlist`

## Test plan
- [ ] `task test` passes
- [ ] Open TUI popup, create a new session, verify the popup dismisses once the session is ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)