### PR TITLE
fix(tmux): only kill sidebar when last non-sidebar pane closes

### DIFF
--- a/plugins/utena-tmux/scripts/cleanup-status-pane.sh
+++ b/plugins/utena-tmux/scripts/cleanup-status-pane.sh
@@ -11,7 +11,7 @@ if [ -z "$PANES" ]; then
 fi
 
 NON_STATUS_COUNT=$(echo "$PANES" | grep -v ' 1$' | grep -c . || true)
-if [ "$NON_STATUS_COUNT" -le 1 ]; then
+if [ "$NON_STATUS_COUNT" -eq 0 ]; then
     echo "$PANES" | grep ' 1$' | awk '{print $1}' | while read -r status_pane; do
         tmux kill-pane -t "$status_pane" 2>/dev/null
     done


### PR DESCRIPTION
## Summary
- The `cleanup-status-pane.sh` hook used `-le 1` to check non-status pane count, causing the sidebar to be killed whenever any pane closed in a window with two regular panes
- Changed to `-eq 0` so the sidebar is only removed when no non-status panes remain (i.e., the last regular pane was closed)

## Test plan
- [ ] Open a tmux window with the sidebar and 2+ regular panes
- [ ] Close a regular pane — sidebar should remain
- [ ] Close the last regular pane — sidebar should be cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)