### PR TITLE
fix(session): skip pull for local-only and dirty branches

### DIFF
--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -80,6 +80,24 @@ func (s *GitService) CurrentBranch(ctx context.Context, repoPath string) (string
 	return strings.TrimSpace(string(output)), nil
 }
 
+func (s *GitService) IsDirty(ctx context.Context, repoPath string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "status", "--porcelain")
+	output, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("git status failed: %w", err)
+	}
+	return strings.TrimSpace(string(output)) != "", nil
+}
+
+func (s *GitService) HasRemoteBranch(ctx context.Context, repoPath string, branch string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "ls-remote", "--heads", "origin", "refs/heads/"+branch)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("git ls-remote failed: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return strings.TrimSpace(string(output)) != "", nil
+}
+
 func (s *GitService) HasBranch(ctx context.Context, repoPath string, branch string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "--verify", "refs/heads/"+branch)
 	if err := cmd.Run(); err != nil {

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -201,9 +201,40 @@ func (s *SessionService) setupBranch(ctx context.Context, sess *Session, ws *wor
 		pullBranch = sess.BaseBranch
 	}
 
+	hasRemote, err := s.gitService.HasRemoteBranch(ctx, ws.Path, pullBranch)
+	if err != nil {
+		return fmt.Errorf("failed to check remote branch %q: %v", pullBranch, err)
+	}
+
+	if !hasRemote {
+		hasLocal, err := s.gitService.HasBranch(ctx, ws.Path, pullBranch)
+		if err != nil {
+			return fmt.Errorf("failed to check local branch %q: %v", pullBranch, err)
+		}
+		if !hasLocal {
+			return fmt.Errorf("branch %q does not exist locally or on remote", pullBranch)
+		}
+		return nil
+	}
+
+	checkPath := s.gitService.WorktreePath(ws.Path, pullBranch)
+	if _, err := os.Stat(checkPath); os.IsNotExist(err) {
+		checkPath = ws.Path
+	}
+
+	dirty, err := s.gitService.IsDirty(ctx, checkPath)
+	if err != nil {
+		return fmt.Errorf("failed to check dirty state for %q: %v", pullBranch, err)
+	}
+
+	if dirty {
+		return nil
+	}
+
 	if err := s.gitService.Pull(ctx, ws.Path, pullBranch); err != nil {
 		return fmt.Errorf("failed to pull branch %q: %v", pullBranch, err)
 	}
+
 	return nil
 }
 

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -477,6 +477,36 @@ func TestSessionService_CreateSession_WithWorktree_ReusesExistingBranch(t *testi
 	require.Equal(t, ResourceReady, retrieved.Resources.Worktree.Status)
 }
 
+func TestSessionService_CreateSession_WithWorktree_ReusesLocalOnlyBranch(t *testing.T) {
+	repoPath := initTestRepo(t)
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	ctx := context.Background()
+	branchName := "feature/local-only"
+	worktreePath := filepath.Join(repoPath, ".worktrees", "feature-local-only")
+	cmd := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branchName, worktreePath, "main")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "pre-create worktree failed: %s", string(out))
+
+	session := &Session{
+		Name:        branchName,
+		WorkspaceID: wsGitID,
+		Branch:      branchName,
+	}
+
+	err = service.CreateSession(ctx, session, true)
+	require.NoError(t, err)
+
+	waitForStatus(t, sessionStore, session.ID, StatusReady, 5*time.Second)
+
+	retrieved, err := sessionStore.GetByID(session.ID)
+	require.NoError(t, err)
+
+	require.Equal(t, worktreePath, retrieved.WorktreePath)
+	require.Equal(t, ResourceReady, retrieved.Resources.Branch.Status)
+	require.Equal(t, ResourceReady, retrieved.Resources.Worktree.Status)
+}
+
 func TestSessionService_CreateSession_WithWorktree_InvalidBranch(t *testing.T) {
 	repoPath := initTestRepo(t)
 	service, sessionStore, mock, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())


### PR DESCRIPTION
## Summary
- `setupBranch` now checks if the branch exists on remote before attempting to pull
- If the branch only exists locally (not pushed to remote), the pull is skipped and setup continues
- If the branch doesn't exist locally or on remote, setup fails early with a clear error
- If the branch's working tree has uncommitted changes, the pull is skipped to avoid conflicts

## Test plan
- [x] Existing tests pass (`task test`)
- [x] New test `TestSessionService_CreateSession_WithWorktree_ReusesLocalOnlyBranch` verifies session creation succeeds for a local-only branch with existing worktree