### PR TITLE
feat: workspace deletion and hide/show support

### DIFF
--- a/internal/git/gitcli_test.go
+++ b/internal/git/gitcli_test.go
@@ -13,7 +13,7 @@ import (
 func initTestRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	run(t, dir, "git", "init")
+	run(t, dir, "git", "init", "-b", "main")
 	run(t, dir, "git", "config", "user.email", "test@test.com")
 	run(t, dir, "git", "config", "user.name", "Test")
 	run(t, dir, "git", "commit", "--allow-empty", "-m", "init")

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -39,8 +39,8 @@ type Session struct {
 	Status         SessionStatus          `json:"status"`
 	IsAttached     bool                   `json:"is_attached"`
 	LastUsedAt     time.Time              `json:"last_used_at"`
-	Workspace      *workspace.Workspace   `json:"workspace,omitempty" gorm:"foreignKey:WorkspaceID"`
-	ClaudeSessions []claude.ClaudeSession `json:"claude_sessions,omitempty" gorm:"foreignKey:SessionID"`
+	Workspace      *workspace.Workspace   `json:"workspace,omitempty" gorm:"foreignKey:WorkspaceID;constraint:OnDelete:CASCADE"`
+	ClaudeSessions []claude.ClaudeSession `json:"claude_sessions,omitempty" gorm:"foreignKey:SessionID;constraint:OnDelete:CASCADE"`
 	BranchID       *uint                  `json:"branch_id,omitempty" gorm:"index"`
 	TmuxSessionID  *uint                  `json:"tmux_session_id,omitempty" gorm:"uniqueIndex"`
 	StatusError    string                 `json:"status_error,omitempty"`

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -307,7 +307,7 @@ func initTestRepo(t *testing.T) string {
 	dir := t.TempDir()
 
 	bareCmds := [][]string{
-		{"git", "init", "--bare"},
+		{"git", "init", "--bare", "-b", "main"},
 	}
 	for _, args := range bareCmds {
 		cmd := exec.Command(args[0], args[1:]...)
@@ -317,7 +317,7 @@ func initTestRepo(t *testing.T) string {
 	}
 
 	cmds := [][]string{
-		{"git", "init"},
+		{"git", "init", "-b", "main"},
 		{"git", "config", "user.email", "test@test.com"},
 		{"git", "config", "user.name", "Test"},
 		{"git", "remote", "add", "origin", bareDir},

--- a/internal/todo/todo.go
+++ b/internal/todo/todo.go
@@ -13,5 +13,5 @@ type Todo struct {
 	Name        string               `json:"name"`
 	Description string               `json:"description"`
 	WorkspaceID *uint                `json:"workspace_id,omitempty" gorm:"index"`
-	Workspace   *workspace.Workspace `json:"workspace,omitempty" gorm:"foreignKey:WorkspaceID"`
+	Workspace   *workspace.Workspace `json:"workspace,omitempty" gorm:"foreignKey:WorkspaceID;constraint:OnDelete:CASCADE"`
 }

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -289,6 +289,30 @@ func (c *client) deleteWorkspace(id uint) tea.Cmd {
 	}
 }
 
+func (c *client) setWorkspaceHidden(id uint, hidden bool) tea.Cmd {
+	return func() tea.Msg {
+		body, _ := json.Marshal(map[string]bool{"hidden": hidden})
+		req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/workspaces/%d/hidden", c.baseURL, id), bytes.NewReader(body))
+		if err != nil {
+			return ErrMsg{err}
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		res, err := c.httpClient.Do(req)
+		if err != nil {
+			log.Printf("[ERROR] set workspace hidden %d: %v", id, err)
+			return ErrMsg{err}
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusNoContent {
+			return parseAPIError(res, "set workspace hidden")
+		}
+
+		return workspaceHiddenToggledMsg{}
+	}
+}
+
 func (c *client) addWorkspace(path string, asRoot bool) tea.Cmd {
 	return func() tea.Msg {
 		body := map[string]interface{}{

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -267,6 +267,28 @@ func (c *client) deleteSession(id uint) tea.Cmd {
 	}
 }
 
+func (c *client) deleteWorkspace(id uint) tea.Cmd {
+	return func() tea.Msg {
+		req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/workspaces/%d", c.baseURL, id), nil)
+		if err != nil {
+			return ErrMsg{err}
+		}
+
+		res, err := c.httpClient.Do(req)
+		if err != nil {
+			log.Printf("[ERROR] delete workspace %d: %v", id, err)
+			return ErrMsg{err}
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusNoContent {
+			return parseAPIError(res, "delete workspace")
+		}
+
+		return workspaceDeletedMsg{}
+	}
+}
+
 func (c *client) addWorkspace(path string, asRoot bool) tea.Cmd {
 	return func() tea.Msg {
 		body := map[string]interface{}{

--- a/internal/tui/provider/workspacesprovider.go
+++ b/internal/tui/provider/workspacesprovider.go
@@ -36,6 +36,10 @@ func FetchPRs(workspaceID uint, state string) tea.Cmd {
 	return func() tea.Msg { return fetchPRsIntentMsg{workspaceID: workspaceID, state: state} }
 }
 
+func DeleteWorkspace(id uint) tea.Cmd {
+	return func() tea.Msg { return deleteWorkspaceIntentMsg{id: id} }
+}
+
 func AddWorkspace(path string, asRoot bool) tea.Cmd {
 	return func() tea.Msg { return addWorkspaceIntentMsg{path: path, asRoot: asRoot} }
 }
@@ -45,6 +49,10 @@ type requestWorkspacesStateMsg struct{}
 
 type requestBranchesMsg struct {
 	workspaceID uint
+}
+
+type deleteWorkspaceIntentMsg struct {
+	id uint
 }
 
 type addWorkspaceIntentMsg struct {
@@ -70,6 +78,7 @@ type branchesLoadedMsg struct {
 	branches []string
 }
 
+type workspaceDeletedMsg struct{}
 type workspaceAddedMsg struct{}
 
 type workspacesProvider struct {
@@ -125,6 +134,12 @@ func (p workspacesProvider) Update(msg tea.Msg) (workspacesProvider, tea.Cmd) {
 	case setActiveWorkspaceMsg:
 		p.activeWorkspaceID = msg.workspaceID
 		return p, p.emitState()
+
+	case deleteWorkspaceIntentMsg:
+		return p, p.client.deleteWorkspace(msg.id)
+
+	case workspaceDeletedMsg:
+		return p, p.client.fetchWorkspaces()
 
 	case addWorkspaceIntentMsg:
 		return p, p.client.addWorkspace(msg.path, msg.asRoot)

--- a/internal/tui/provider/workspacesprovider.go
+++ b/internal/tui/provider/workspacesprovider.go
@@ -40,6 +40,10 @@ func DeleteWorkspace(id uint) tea.Cmd {
 	return func() tea.Msg { return deleteWorkspaceIntentMsg{id: id} }
 }
 
+func SetWorkspaceHidden(id uint, hidden bool) tea.Cmd {
+	return func() tea.Msg { return setWorkspaceHiddenIntentMsg{id: id, hidden: hidden} }
+}
+
 func AddWorkspace(path string, asRoot bool) tea.Cmd {
 	return func() tea.Msg { return addWorkspaceIntentMsg{path: path, asRoot: asRoot} }
 }
@@ -53,6 +57,11 @@ type requestBranchesMsg struct {
 
 type deleteWorkspaceIntentMsg struct {
 	id uint
+}
+
+type setWorkspaceHiddenIntentMsg struct {
+	id     uint
+	hidden bool
 }
 
 type addWorkspaceIntentMsg struct {
@@ -79,6 +88,7 @@ type branchesLoadedMsg struct {
 }
 
 type workspaceDeletedMsg struct{}
+type workspaceHiddenToggledMsg struct{}
 type workspaceAddedMsg struct{}
 
 type workspacesProvider struct {
@@ -139,6 +149,12 @@ func (p workspacesProvider) Update(msg tea.Msg) (workspacesProvider, tea.Cmd) {
 		return p, p.client.deleteWorkspace(msg.id)
 
 	case workspaceDeletedMsg:
+		return p, p.client.fetchWorkspaces()
+
+	case setWorkspaceHiddenIntentMsg:
+		return p, p.client.setWorkspaceHidden(msg.id, msg.hidden)
+
+	case workspaceHiddenToggledMsg:
 		return p, p.client.fetchWorkspaces()
 
 	case addWorkspaceIntentMsg:

--- a/internal/tui/workspacelist/keys.go
+++ b/internal/tui/workspacelist/keys.go
@@ -7,19 +7,21 @@ import (
 
 type keyMap struct {
 	Select key.Binding
+	Delete key.Binding
 	Back   key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Select, k.Back}
+	return []key.Binding{k.Select, k.Delete, k.Back}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.Select, k.Back}}
+	return [][]key.Binding{{k.Select, k.Delete, k.Back}}
 }
 
 var keys = keyMap{
 	Select: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+	Delete: key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
 	Back:   key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
 }
 

--- a/internal/tui/workspacelist/keys.go
+++ b/internal/tui/workspacelist/keys.go
@@ -6,23 +6,27 @@ import (
 )
 
 type keyMap struct {
-	Select key.Binding
-	Delete key.Binding
-	Back   key.Binding
+	Select       key.Binding
+	Delete       key.Binding
+	Hide         key.Binding
+	ToggleHidden key.Binding
+	Back         key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Select, k.Delete, k.Back}
+	return []key.Binding{k.Select, k.Hide, k.Delete, k.Back}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.Select, k.Delete, k.Back}}
+	return [][]key.Binding{{k.Select, k.Hide, k.ToggleHidden, k.Delete, k.Back}}
 }
 
 var keys = keyMap{
-	Select: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
-	Delete: key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
-	Back:   key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+	Select:       key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+	Delete:       key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
+	Hide:         key.NewBinding(key.WithKeys("h"), key.WithHelp("h", "hide")),
+	ToggleHidden: key.NewBinding(key.WithKeys("H"), key.WithHelp("H", "show hidden")),
+	Back:         key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
 }
 
 var _ help.KeyMap = keys

--- a/internal/tui/workspacelist/workspaceitem.go
+++ b/internal/tui/workspacelist/workspaceitem.go
@@ -14,6 +14,9 @@ func (i workspaceItem) Title() string {
 	if i.workspace.IsGitRepo {
 		title += " (git)"
 	}
+	if i.workspace.IsHidden {
+		title += " [hidden]"
+	}
 	return title
 }
 

--- a/internal/tui/workspacelist/workspacelist.go
+++ b/internal/tui/workspacelist/workspacelist.go
@@ -18,6 +18,7 @@ type Model struct {
 	list            list.Model
 	workspaces      []workspace.Workspace
 	pendingDeleteID uint
+	showHidden      bool
 }
 
 func New() Model {
@@ -39,6 +40,9 @@ func (m Model) Keys() help.KeyMap {
 func (m *Model) rebuildItems() tea.Cmd {
 	var items []list.Item
 	for _, ws := range m.workspaces {
+		if !m.showHidden && ws.IsHidden {
+			continue
+		}
 		items = append(items, workspaceItem{workspace: ws})
 	}
 	return m.list.SetItems(items)
@@ -86,6 +90,27 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 			router.NavigateTo(router.WorkspaceDetailView),
 			workspacedetail.Select(item.workspace),
 		), true
+	case key.Matches(msg, keys.Hide):
+		item, ok := m.list.SelectedItem().(workspaceItem)
+		if !ok {
+			return m, nil, false
+		}
+		newHidden := !item.workspace.IsHidden
+		verb := "hidden"
+		if !newHidden {
+			verb = "unhidden"
+		}
+		return m, tea.Batch(
+			provider.SetWorkspaceHidden(item.workspace.ID, newHidden),
+			m.list.NewStatusMessage(fmt.Sprintf("%s %s", item.workspace.Name, verb)),
+		), true
+	case key.Matches(msg, keys.ToggleHidden):
+		m.showHidden = !m.showHidden
+		msg := "showing all workspaces"
+		if !m.showHidden {
+			msg = "hiding hidden workspaces"
+		}
+		return m, tea.Batch(m.rebuildItems(), m.list.NewStatusMessage(msg)), true
 	case key.Matches(msg, keys.Delete):
 		item, ok := m.list.SelectedItem().(workspaceItem)
 		if !ok {

--- a/internal/tui/workspacelist/workspacelist.go
+++ b/internal/tui/workspacelist/workspacelist.go
@@ -1,6 +1,8 @@
 package workspacelist
 
 import (
+	"fmt"
+
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
@@ -13,8 +15,9 @@ import (
 )
 
 type Model struct {
-	list       list.Model
-	workspaces []workspace.Workspace
+	list            list.Model
+	workspaces      []workspace.Workspace
+	pendingDeleteID uint
 }
 
 func New() Model {
@@ -70,6 +73,9 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 	if m.list.FilterState() == list.Filtering {
 		return m, nil, false
 	}
+	if !key.Matches(msg, keys.Delete) {
+		m.pendingDeleteID = 0
+	}
 	switch {
 	case key.Matches(msg, keys.Select):
 		item, ok := m.list.SelectedItem().(workspaceItem)
@@ -80,6 +86,17 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 			router.NavigateTo(router.WorkspaceDetailView),
 			workspacedetail.Select(item.workspace),
 		), true
+	case key.Matches(msg, keys.Delete):
+		item, ok := m.list.SelectedItem().(workspaceItem)
+		if !ok {
+			return m, nil, false
+		}
+		if m.pendingDeleteID == item.workspace.ID {
+			m.pendingDeleteID = 0
+			return m, provider.DeleteWorkspace(item.workspace.ID), true
+		}
+		m.pendingDeleteID = item.workspace.ID
+		return m, m.list.NewStatusMessage(fmt.Sprintf("press d again to delete %s", item.workspace.Name)), true
 	case key.Matches(msg, keys.Back):
 		return m, router.Back(), true
 	}

--- a/internal/tui/workspacepicker/keys.go
+++ b/internal/tui/workspacepicker/keys.go
@@ -6,9 +6,10 @@ import (
 )
 
 type keyMap struct {
-	Select key.Binding
-	AddDir key.Binding
-	Back   key.Binding
+	Select       key.Binding
+	ToggleHidden key.Binding
+	AddDir       key.Binding
+	Back         key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
@@ -16,13 +17,14 @@ func (k keyMap) ShortHelp() []key.Binding {
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.Select, k.AddDir, k.Back}}
+	return [][]key.Binding{{k.Select, k.ToggleHidden, k.AddDir, k.Back}}
 }
 
 var Keys = keyMap{
-	Select: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
-	AddDir: key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "add dir")),
-	Back:   key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+	Select:       key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+	ToggleHidden: key.NewBinding(key.WithKeys("H"), key.WithHelp("H", "show hidden")),
+	AddDir:       key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "add dir")),
+	Back:         key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
 }
 
 var _ help.KeyMap = Keys

--- a/internal/tui/workspacepicker/workspaceitem.go
+++ b/internal/tui/workspacepicker/workspaceitem.go
@@ -11,7 +11,13 @@ type workspaceItem struct {
 	workspace workspace.Workspace
 }
 
-func (i workspaceItem) Title() string       { return i.workspace.Name }
+func (i workspaceItem) Title() string {
+	title := i.workspace.Name
+	if i.workspace.IsHidden {
+		title += " [hidden]"
+	}
+	return title
+}
 func (i workspaceItem) Description() string { return AbbreviatePath(i.workspace.Path) }
 func (i workspaceItem) FilterValue() string { return i.workspace.Name }
 

--- a/internal/tui/workspacepicker/workspacepicker.go
+++ b/internal/tui/workspacepicker/workspacepicker.go
@@ -12,7 +12,9 @@ import (
 
 type Model struct {
 	list              list.Model
+	workspaces        []workspace.Workspace
 	sortActiveFirst   bool
+	showHidden        bool
 	activeWorkspaceID uint
 }
 
@@ -42,30 +44,38 @@ func (m Model) Keys() help.KeyMap {
 	return Keys
 }
 
+func (m *Model) rebuildItems() tea.Cmd {
+	workspaces := m.workspaces
+
+	if m.sortActiveFirst && m.activeWorkspaceID != 0 {
+		sorted := make([]workspace.Workspace, 0, len(workspaces))
+		var rest []workspace.Workspace
+		for _, ws := range workspaces {
+			if ws.ID == m.activeWorkspaceID {
+				sorted = append(sorted, ws)
+			} else {
+				rest = append(rest, ws)
+			}
+		}
+		workspaces = append(sorted, rest...)
+	}
+
+	var items []list.Item
+	for _, ws := range workspaces {
+		if !m.showHidden && ws.IsHidden {
+			continue
+		}
+		items = append(items, workspaceItem{workspace: ws})
+	}
+	return m.list.SetItems(items)
+}
+
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case provider.WorkspacesStateUpdatedMsg:
 		m.activeWorkspaceID = msg.ActiveWorkspaceID
-		workspaces := msg.Workspaces
-
-		if m.sortActiveFirst && m.activeWorkspaceID != 0 {
-			sorted := make([]workspace.Workspace, 0, len(workspaces))
-			var rest []workspace.Workspace
-			for _, ws := range workspaces {
-				if ws.ID == m.activeWorkspaceID {
-					sorted = append(sorted, ws)
-				} else {
-					rest = append(rest, ws)
-				}
-			}
-			workspaces = append(sorted, rest...)
-		}
-
-		items := make([]list.Item, len(workspaces))
-		for i, ws := range workspaces {
-			items[i] = workspaceItem{workspace: ws}
-		}
-		return m, m.list.SetItems(items)
+		m.workspaces = msg.Workspaces
+		return m, m.rebuildItems()
 
 	case tea.KeyMsg:
 		var cmd tea.Cmd
@@ -93,6 +103,13 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 				return SelectedMsg{Workspace: ws}
 			}, true
 		}
+	case key.Matches(msg, Keys.ToggleHidden):
+		m.showHidden = !m.showHidden
+		statusMsg := "showing all workspaces"
+		if !m.showHidden {
+			statusMsg = "hiding hidden workspaces"
+		}
+		return m, tea.Batch(m.rebuildItems(), m.list.NewStatusMessage(statusMsg)), true
 	case key.Matches(msg, Keys.AddDir):
 		return m, func() tea.Msg { return AddDirectoryMsg{} }, true
 	}

--- a/internal/workspace/types.go
+++ b/internal/workspace/types.go
@@ -55,6 +55,14 @@ func (a *AddWorkspaceRequest) Bind(r *http.Request) error {
 	return nil
 }
 
+type SetHiddenRequest struct {
+	Hidden bool `json:"hidden"`
+}
+
+func (s *SetHiddenRequest) Bind(r *http.Request) error {
+	return nil
+}
+
 type BranchListResponse struct {
 	Branches      []string `json:"branches"`
 	CurrentBranch string   `json:"current_branch"`

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -12,6 +12,7 @@ type Workspace struct {
 	Name       string    `json:"name"`
 	Path       string    `json:"path" gorm:"uniqueIndex"`
 	IsGitRepo  bool      `json:"is_git_repo"`
+	IsHidden   bool      `json:"is_hidden" gorm:"default:false"`
 	RepoID     *uint     `json:"repo_id,omitempty" gorm:"index"`
 	Repo       *git.Repo `json:"repo,omitempty" gorm:"foreignKey:RepoID"`
 	LastUsedAt time.Time `json:"last_used_at,omitempty"`

--- a/internal/workspace/workspacecontroller.go
+++ b/internal/workspace/workspacecontroller.go
@@ -79,6 +79,29 @@ func (c *WorkspaceController) AddWorkspace(w http.ResponseWriter, r *http.Reques
 	}
 }
 
+func (c *WorkspaceController) SetWorkspaceHidden(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		common.RenderError(w, r, common.NewInvalidRequest(err.Error()))
+		return
+	}
+
+	var req SetHiddenRequest
+	if err := render.Bind(r, &req); err != nil {
+		common.RenderError(w, r, common.NewInvalidRequest(err.Error()))
+		return
+	}
+
+	if err := c.service.SetWorkspaceHidden(ctx, uint(id), req.Hidden); err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	render.NoContent(w, r)
+}
+
 func (c *WorkspaceController) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	raw := chi.URLParam(r, "id")

--- a/internal/workspace/workspacecontroller.go
+++ b/internal/workspace/workspacecontroller.go
@@ -79,6 +79,23 @@ func (c *WorkspaceController) AddWorkspace(w http.ResponseWriter, r *http.Reques
 	}
 }
 
+func (c *WorkspaceController) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		common.RenderError(w, r, common.NewInvalidRequest(err.Error()))
+		return
+	}
+
+	if err := c.service.DeleteWorkspace(ctx, uint(id)); err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	render.NoContent(w, r)
+}
+
 func (c *WorkspaceController) ListBranches(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	raw := chi.URLParam(r, "id")

--- a/internal/workspace/workspacerouter.go
+++ b/internal/workspace/workspacerouter.go
@@ -22,6 +22,7 @@ func (wr *WorkspaceRouter) Routes() chi.Router {
 	r.Get("/{id}/branches", wr.controller.ListBranches)
 	r.Get("/{id}/prs", wr.controller.ListPRs)
 	r.Get("/{id}", wr.controller.GetWorkspaceByID)
+	r.Put("/{id}/hidden", wr.controller.SetWorkspaceHidden)
 	r.Delete("/{id}", wr.controller.DeleteWorkspace)
 
 	return r

--- a/internal/workspace/workspacerouter.go
+++ b/internal/workspace/workspacerouter.go
@@ -22,6 +22,7 @@ func (wr *WorkspaceRouter) Routes() chi.Router {
 	r.Get("/{id}/branches", wr.controller.ListBranches)
 	r.Get("/{id}/prs", wr.controller.ListPRs)
 	r.Get("/{id}", wr.controller.GetWorkspaceByID)
+	r.Delete("/{id}", wr.controller.DeleteWorkspace)
 
 	return r
 }

--- a/internal/workspace/workspacerouter_test.go
+++ b/internal/workspace/workspacerouter_test.go
@@ -138,7 +138,7 @@ func initTestRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	cmds := [][]string{
-		{"git", "init"},
+		{"git", "init", "-b", "main"},
 		{"git", "config", "user.email", "test@test.com"},
 		{"git", "config", "user.name", "Test"},
 		{"git", "commit", "--allow-empty", "-m", "init"},
@@ -183,6 +183,34 @@ func TestWorkspaceRouter_ListBranches(t *testing.T) {
 	require.Contains(t, response.Branches, "main")
 	require.Contains(t, response.Branches, "develop")
 	require.Equal(t, "main", response.Branches[0])
+}
+
+func TestWorkspaceRouter_DeleteWorkspace(t *testing.T) {
+	router, store := setupWorkspaceRouter(t)
+
+	ws, err := store.GetByPath("/path/to/utena")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("DELETE", fmt.Sprintf("/%d", ws.ID), nil)
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+
+	_, err = store.GetByID(ws.ID)
+	require.Error(t, err)
+}
+
+func TestWorkspaceRouter_DeleteWorkspace_NotFound(t *testing.T) {
+	router, _ := setupWorkspaceRouter(t)
+
+	req := httptest.NewRequest("DELETE", "/99999", nil)
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestWorkspaceRouter_ListBranches_NotGitRepo(t *testing.T) {

--- a/internal/workspace/workspacerouter_test.go
+++ b/internal/workspace/workspacerouter_test.go
@@ -185,6 +185,40 @@ func TestWorkspaceRouter_ListBranches(t *testing.T) {
 	require.Equal(t, "main", response.Branches[0])
 }
 
+func TestWorkspaceRouter_SetWorkspaceHidden(t *testing.T) {
+	router, store := setupWorkspaceRouter(t)
+
+	ws, err := store.GetByPath("/path/to/utena")
+	require.NoError(t, err)
+	require.False(t, ws.IsHidden)
+
+	body := `{"hidden": true}`
+	req := httptest.NewRequest("PUT", fmt.Sprintf("/%d/hidden", ws.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+
+	updated, err := store.GetByID(ws.ID)
+	require.NoError(t, err)
+	require.True(t, updated.IsHidden)
+}
+
+func TestWorkspaceRouter_SetWorkspaceHidden_NotFound(t *testing.T) {
+	router, _ := setupWorkspaceRouter(t)
+
+	body := `{"hidden": true}`
+	req := httptest.NewRequest("PUT", "/99999/hidden", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestWorkspaceRouter_DeleteWorkspace(t *testing.T) {
 	router, store := setupWorkspaceRouter(t)
 

--- a/internal/workspace/workspaceservice.go
+++ b/internal/workspace/workspaceservice.go
@@ -51,6 +51,20 @@ func (s *WorkspaceService) Touch(ctx context.Context, id uint) error {
 	return s.store.Update(ws)
 }
 
+func (s *WorkspaceService) DeleteWorkspace(ctx context.Context, id uint) error {
+	ws, err := s.store.GetByID(id)
+	if err != nil {
+		return err
+	}
+
+	if err := s.store.Delete(id); err != nil {
+		return err
+	}
+
+	s.store.RemoveWorkspaceFromConfig(ws.Path)
+	return nil
+}
+
 func (s *WorkspaceService) AddWorkspace(ctx context.Context, path string, asRoot bool) (*Workspace, error) {
 	if asRoot {
 		_, err := s.store.AddWorkspaceRoot(path)

--- a/internal/workspace/workspaceservice.go
+++ b/internal/workspace/workspaceservice.go
@@ -51,6 +51,10 @@ func (s *WorkspaceService) Touch(ctx context.Context, id uint) error {
 	return s.store.Update(ws)
 }
 
+func (s *WorkspaceService) SetWorkspaceHidden(ctx context.Context, id uint, hidden bool) error {
+	return s.store.SetHidden(id, hidden)
+}
+
 func (s *WorkspaceService) DeleteWorkspace(ctx context.Context, id uint) error {
 	ws, err := s.store.GetByID(id)
 	if err != nil {

--- a/internal/workspace/workspaceservice_test.go
+++ b/internal/workspace/workspaceservice_test.go
@@ -156,6 +156,30 @@ func TestWorkspaceService_AddWorkspaceAsRoot(t *testing.T) {
 	require.Len(t, workspaces, 1)
 }
 
+func TestWorkspaceService_DeleteWorkspace(t *testing.T) {
+	service, store := setupWorkspaceService(t)
+
+	ws := &Workspace{Name: "test", Path: "/path"}
+	store.Add(ws)
+
+	ctx := context.Background()
+	err := service.DeleteWorkspace(ctx, ws.ID)
+	require.NoError(t, err)
+
+	_, err = store.GetByID(ws.ID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestWorkspaceService_DeleteWorkspace_NotFound(t *testing.T) {
+	service, _ := setupWorkspaceService(t)
+
+	ctx := context.Background()
+	err := service.DeleteWorkspace(ctx, 99999)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
 func TestWorkspaceService_Touch(t *testing.T) {
 	service, store := setupWorkspaceService(t)
 

--- a/internal/workspace/workspaceservice_test.go
+++ b/internal/workspace/workspaceservice_test.go
@@ -156,6 +156,30 @@ func TestWorkspaceService_AddWorkspaceAsRoot(t *testing.T) {
 	require.Len(t, workspaces, 1)
 }
 
+func TestWorkspaceService_SetWorkspaceHidden(t *testing.T) {
+	service, store := setupWorkspaceService(t)
+
+	ws := &Workspace{Name: "test", Path: "/path"}
+	store.Add(ws)
+
+	ctx := context.Background()
+	err := service.SetWorkspaceHidden(ctx, ws.ID, true)
+	require.NoError(t, err)
+
+	retrieved, err := store.GetByID(ws.ID)
+	require.NoError(t, err)
+	require.True(t, retrieved.IsHidden)
+}
+
+func TestWorkspaceService_SetWorkspaceHidden_NotFound(t *testing.T) {
+	service, _ := setupWorkspaceService(t)
+
+	ctx := context.Background()
+	err := service.SetWorkspaceHidden(ctx, 99999, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
 func TestWorkspaceService_DeleteWorkspace(t *testing.T) {
 	service, store := setupWorkspaceService(t)
 

--- a/internal/workspace/workspacestore.go
+++ b/internal/workspace/workspacestore.go
@@ -126,6 +126,41 @@ func (s *WorkspaceStore) Update(ws *Workspace) error {
 	return s.db.Omit("Repo").Save(ws).Error
 }
 
+func (s *WorkspaceStore) Delete(id uint) error {
+	if id == 0 {
+		return errors.New("workspace ID cannot be zero")
+	}
+
+	var existing Workspace
+	if err := s.db.First(&existing, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return common.NewNotFound(fmt.Sprintf("workspace not found: %d", id))
+		}
+		return err
+	}
+
+	return s.db.Where("id = ?", id).Unscoped().Delete(&Workspace{}).Error
+}
+
+func (s *WorkspaceStore) RemoveWorkspaceFromConfig(path string) {
+	cfg, err := s.loadConfig()
+	if err != nil {
+		return
+	}
+
+	filtered := make([]string, 0, len(cfg.Workspaces))
+	for _, ws := range cfg.Workspaces {
+		if expandHome(ws) != expandHome(path) {
+			filtered = append(filtered, ws)
+		}
+	}
+
+	if len(filtered) != len(cfg.Workspaces) {
+		cfg.Workspaces = filtered
+		s.saveConfig(cfg)
+	}
+}
+
 func (s *WorkspaceStore) AddWorkspace(path string) (*Workspace, error) {
 	info, err := s.fs.Stat(path)
 	if err != nil {

--- a/internal/workspace/workspacestore.go
+++ b/internal/workspace/workspacestore.go
@@ -126,6 +126,18 @@ func (s *WorkspaceStore) Update(ws *Workspace) error {
 	return s.db.Omit("Repo").Save(ws).Error
 }
 
+func (s *WorkspaceStore) SetHidden(id uint, hidden bool) error {
+	var ws Workspace
+	if err := s.db.First(&ws, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return common.NewNotFound(fmt.Sprintf("workspace not found: %d", id))
+		}
+		return err
+	}
+
+	return s.db.Model(&ws).Update("is_hidden", hidden).Error
+}
+
 func (s *WorkspaceStore) Delete(id uint) error {
 	if id == 0 {
 		return errors.New("workspace ID cannot be zero")

--- a/internal/workspace/workspacestore_test.go
+++ b/internal/workspace/workspacestore_test.go
@@ -617,6 +617,55 @@ func TestWorkspaceStore_GetByRepoID_NotFound(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestWorkspaceStore_Delete(t *testing.T) {
+	store := setupWorkspaceStore(t)
+
+	ws := &Workspace{Name: "test", Path: "/path/to/test"}
+	store.Add(ws)
+
+	err := store.Delete(ws.ID)
+	require.NoError(t, err)
+
+	_, err = store.GetByID(ws.ID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestWorkspaceStore_Delete_NotFound(t *testing.T) {
+	store := setupWorkspaceStore(t)
+
+	err := store.Delete(99999)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestWorkspaceStore_Delete_ZeroID(t *testing.T) {
+	store := setupWorkspaceStore(t)
+
+	err := store.Delete(0)
+	require.Error(t, err)
+}
+
+func TestWorkspaceStore_RemoveWorkspaceFromConfig(t *testing.T) {
+	store, _ := setupWorkspaceStoreWithFullConfig(t, nil, []string{"/some/path", "/other/path"})
+
+	store.RemoveWorkspaceFromConfig("/some/path")
+
+	cfg, err := store.loadConfig()
+	require.NoError(t, err)
+	require.Equal(t, []string{"/other/path"}, cfg.Workspaces)
+}
+
+func TestWorkspaceStore_RemoveWorkspaceFromConfig_NotInConfig(t *testing.T) {
+	store, _ := setupWorkspaceStoreWithFullConfig(t, nil, []string{"/some/path"})
+
+	store.RemoveWorkspaceFromConfig("/nonexistent/path")
+
+	cfg, err := store.loadConfig()
+	require.NoError(t, err)
+	require.Equal(t, []string{"/some/path"}, cfg.Workspaces)
+}
+
 func TestWorkspaceStore_OnAppStart_MergesDiscoveredWithPersisted(t *testing.T) {
 	rootDir := t.TempDir()
 	os.MkdirAll(filepath.Join(rootDir, "project-alpha"), 0755)

--- a/internal/workspace/workspacestore_test.go
+++ b/internal/workspace/workspacestore_test.go
@@ -646,6 +646,36 @@ func TestWorkspaceStore_Delete_ZeroID(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestWorkspaceStore_SetHidden(t *testing.T) {
+	store := setupWorkspaceStore(t)
+
+	ws := &Workspace{Name: "test", Path: "/path/to/test"}
+	store.Add(ws)
+	require.False(t, ws.IsHidden)
+
+	err := store.SetHidden(ws.ID, true)
+	require.NoError(t, err)
+
+	retrieved, err := store.GetByID(ws.ID)
+	require.NoError(t, err)
+	require.True(t, retrieved.IsHidden)
+
+	err = store.SetHidden(ws.ID, false)
+	require.NoError(t, err)
+
+	retrieved, err = store.GetByID(ws.ID)
+	require.NoError(t, err)
+	require.False(t, retrieved.IsHidden)
+}
+
+func TestWorkspaceStore_SetHidden_NotFound(t *testing.T) {
+	store := setupWorkspaceStore(t)
+
+	err := store.SetHidden(99999, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
 func TestWorkspaceStore_RemoveWorkspaceFromConfig(t *testing.T) {
 	store, _ := setupWorkspaceStoreWithFullConfig(t, nil, []string{"/some/path", "/other/path"})
 


### PR DESCRIPTION
## Summary
- Add `DELETE /workspaces/{id}` endpoint with DB-level `ON DELETE CASCADE` to clean up related sessions, todos, and claude sessions
- Add `IsHidden` boolean field to workspaces with `PUT /workspaces/{id}/hidden` toggle endpoint
- TUI workspace list: **d** to delete (two-press confirm), **h** to hide/unhide, **H** to toggle showing hidden
- TUI workspace picker (session/todo forms): filters hidden workspaces by default, **H** to toggle
- Fix pre-existing test failures from git defaulting to `master` instead of `main`

## Test plan
- [ ] Verify workspace deletion cascades to sessions/todos in a fresh DB
- [ ] Verify hiding a workspace removes it from list and picker views
- [ ] Verify "H" toggle shows hidden workspaces with `[hidden]` indicator
- [ ] Verify unhiding a workspace restores it to default views

🤖 Generated with [Claude Code](https://claude.com/claude-code)