### PR TITLE
fix(session): gracefully handle rebase state and existing tmux sessions during repair

### DIFF
--- a/internal/git/gitcli.go
+++ b/internal/git/gitcli.go
@@ -125,6 +125,9 @@ func (s *gitCLI) validateWorktree(ctx context.Context, worktreePath string, expe
 	if err != nil {
 		return false, fmt.Errorf("worktree exists at %s but failed to read branch: %w", worktreePath, err)
 	}
+	if currentBranch == "" {
+		return true, nil
+	}
 	if currentBranch != expectedBranch {
 		return false, fmt.Errorf("worktree at %s has branch %q, expected %q", worktreePath, currentBranch, expectedBranch)
 	}

--- a/internal/git/gitcli_test.go
+++ b/internal/git/gitcli_test.go
@@ -139,6 +139,20 @@ func TestGitCLI_CreateWorktree_InvalidBaseBranch(t *testing.T) {
 	require.Contains(t, err.Error(), "git worktree add failed")
 }
 
+func TestGitCLI_ValidateWorktree_DetachedHead(t *testing.T) {
+	repo := initTestRepo(t)
+
+	svc := newGitCLI()
+	worktreePath, err := svc.createWorktree(context.Background(), repo, "eqt/my-feature", "main")
+	require.NoError(t, err)
+
+	run(t, worktreePath, "git", "checkout", "--detach")
+
+	exists, err := svc.validateWorktree(context.Background(), worktreePath, "eqt/my-feature")
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
 func TestGitCLI_Pull_NoRemote(t *testing.T) {
 	repo := initTestRepo(t)
 

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -317,6 +317,14 @@ func (s *SessionService) setupTmux(ctx context.Context, sess *Session, tmuxName 
 		startDir = s.resolveStartDir(ctx, sess)
 	}
 	env := map[string]string{"UTENA_SESSION_ID": fmt.Sprintf("%d", sess.ID)}
+	if s.tmuxService.HasSession(tmuxName) {
+		ts, err := s.tmuxService.GetOrTrackSession(tmuxName, startDir, env)
+		if err != nil {
+			return fmt.Errorf("failed to attach to existing tmux session: %v", err)
+		}
+		sess.TmuxSessionID = &ts.ID
+		return nil
+	}
 	ts, err := s.tmuxService.CreateSession(tmuxName, startDir, env)
 	if err != nil {
 		return fmt.Errorf("failed to create tmux session: %v", err)

--- a/internal/tmux/testing.go
+++ b/internal/tmux/testing.go
@@ -1,6 +1,9 @@
 package tmux
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 type MockRunner struct {
 	mu        sync.Mutex
@@ -18,6 +21,9 @@ func (m *MockRunner) newSession(name, startDir string, env map[string]string) er
 	defer m.mu.Unlock()
 	if m.CreateErr != nil {
 		return m.CreateErr
+	}
+	if m.Sessions[name] {
+		return fmt.Errorf("duplicate session: %s", name)
 	}
 	m.Sessions[name] = true
 	return nil

--- a/internal/tmux/tmuxservice.go
+++ b/internal/tmux/tmuxservice.go
@@ -139,6 +139,21 @@ func (t *TmuxService) GetSessionByName(name string) (*TmuxSession, error) {
 	return ts, nil
 }
 
+func (t *TmuxService) GetOrTrackSession(name, startDir string, env map[string]string) (*TmuxSession, error) {
+	ts, err := t.store.GetByName(name)
+	if err == nil {
+		return ts, nil
+	}
+	if !errors.Is(err, ErrTmuxSessionNotFound) {
+		return nil, err
+	}
+	ts = &TmuxSession{Name: name, StartDir: startDir, Env: env, IsAlive: true}
+	if err := t.store.Add(ts); err != nil {
+		return nil, err
+	}
+	return ts, nil
+}
+
 func (t *TmuxService) ListSessionNames() ([]string, error) {
 	if t.runner == nil {
 		return nil, ErrTmuxNotAvailable


### PR DESCRIPTION
## Summary
- During session repair, `validateWorktree` now treats a detached HEAD (empty output from `git branch --show-current`, which happens mid-rebase) as a valid existing worktree instead of erroring — allowing repair to proceed to tmux setup
- `setupTmux` now checks whether the tmux session is already alive before attempting to create it; if it is, it reuses the existing session record (or tracks it in the DB if missing) rather than failing with a duplicate-session error
- `MockRunner` updated to enforce session uniqueness, matching real gotmux behaviour

## Test plan
- [ ] `task test` passes
- [ ] Repair a session whose worktree branch is mid-rebase — session becomes active
- [ ] Repair a session whose tmux session is still alive — session becomes active without creating a duplicate