### PR TITLE
feat(tui): restyle session list to match statusbar tab appearance

### DIFF
--- a/internal/tui/list/list.go
+++ b/internal/tui/list/list.go
@@ -22,3 +22,11 @@ func New(title string) bubblelist.Model {
 	l.SetShowHelp(false)
 	return l
 }
+
+func NewWithDelegate(title string, d bubblelist.ItemDelegate) bubblelist.Model {
+	l := bubblelist.New(nil, d, 0, 0)
+	l.Title = title
+	l.KeyMap.Quit.SetEnabled(false)
+	l.SetShowHelp(false)
+	return l
+}

--- a/internal/tui/sessionlist/delegate.go
+++ b/internal/tui/sessionlist/delegate.go
@@ -1,0 +1,35 @@
+package sessionlist
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/eleonorayaya/utena/internal/tui/statusview"
+)
+
+var _ list.ItemDelegate = sessionItemDelegate{}
+
+type sessionItemDelegate struct{}
+
+func (d sessionItemDelegate) Height() int                             { return 4 }
+func (d sessionItemDelegate) Spacing() int                            { return 0 }
+func (d sessionItemDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (d sessionItemDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	si, ok := item.(sessionItem)
+	if !ok {
+		return
+	}
+	width := m.Width()
+	if width < 1 {
+		return
+	}
+	isSelected := index == m.Index()
+	tab := statusview.NewSessionTab(si.session).
+		WithWidth(width).
+		WithoutWindows().
+		WithSelected(isSelected)
+	fmt.Fprint(w, tab.View())
+}

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -23,7 +23,7 @@ type Model struct {
 }
 
 func New() Model {
-	l := ulist.New("Sessions")
+	l := ulist.NewWithDelegate("Sessions", sessionItemDelegate{})
 	l.KeyMap.Quit.SetEnabled(true)
 	return Model{list: l}
 }
@@ -52,7 +52,11 @@ func (m *Model) rebuildItems() tea.Cmd {
 		status := aggregateClaudeStatus(s.ClaudeSessions)
 		items = append(items, sessionItem{session: s, claudeStatus: status})
 	}
-	return m.list.SetItems(items)
+	cmd := m.list.SetItems(items)
+	if len(items) > 1 {
+		m.list.Select(1)
+	}
+	return cmd
 }
 
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {

--- a/internal/tui/statusview/sessiontab.go
+++ b/internal/tui/statusview/sessiontab.go
@@ -13,11 +13,32 @@ import (
 )
 
 type SessionTab struct {
-	session  session.Session
-	windows  []tmux.Window
-	badge    StatusBadge
-	selected bool
-	width    int
+	session     session.Session
+	windows     []tmux.Window
+	badge       StatusBadge
+	selected    bool
+	width       int
+	hideWindows bool
+}
+
+func (t SessionTab) WithWidth(w int) SessionTab {
+	t.width = w
+	return t
+}
+
+func (t SessionTab) WithoutWindows() SessionTab {
+	t.hideWindows = true
+	return t
+}
+
+func (t SessionTab) WithSelected(selected bool) SessionTab {
+	t.selected = selected
+	t.badge, _ = t.badge.Update(statusBadgeMsg{
+		ClaudeSessions: t.session.ClaudeSessions,
+		Selected:       selected,
+		IsAttached:     t.session.IsAttached,
+	})
+	return t
 }
 
 func NewSessionTab(s session.Session) SessionTab {
@@ -145,13 +166,15 @@ func (t SessionTab) renderHeader(bg lipgloss.TerminalColor) []string {
 		wsLine := accent + wsStyle.Render(wsName) + timeStr
 		wsLine = t.padLine(wsLine, bg)
 		result = append(result, wsLine)
+	} else if t.hideWindows {
+		result = append(result, t.padLine(accent, bg))
 	}
 
 	return result
 }
 
 func (t SessionTab) renderWindows(bg lipgloss.TerminalColor) []string {
-	if len(t.windows) == 0 {
+	if t.hideWindows || len(t.windows) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

- Adds `WithWidth`, `WithoutWindows`, and `WithSelected` configuration methods to `SessionTab` so it can be used statelessly outside the statusbar
- Replaces the default bubbles list delegate in the session list with a custom `sessionItemDelegate` that renders each item via `SessionTab` — same accent bars, background fills, and inline badges as the sidebar
- Pre-selects the second session on load since the first is always the current one

## Test Plan

- [ ] Open TUI — session list items should show colored `▐` accent bars on the left
- [ ] Selected item has pink background spanning full width
- [ ] Attached session has beige background + bold name
- [ ] Claude status badges render inline (`!`, `~`, `✓`)
- [ ] Workspace name in purple, time in muted brown
- [ ] Second session is pre-selected on open
- [ ] Statusbar sidebar appearance is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)