### PR TITLE
fix(tmux): guard killSession with HasSession to prevent nil dereference

### DIFF
--- a/internal/tmux/tmuxclient.go
+++ b/internal/tmux/tmuxclient.go
@@ -46,6 +46,9 @@ func (r *gotmuxRunner) newSession(name, startDir string, env map[string]string) 
 }
 
 func (r *gotmuxRunner) killSession(name string) error {
+	if !r.tmux.HasSession(name) {
+		return nil
+	}
 	sess, err := r.tmux.GetSessionByName(name)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- Fix nil pointer dereference panic in `killSession` when the tmux session no longer exists
- `gotmux.GetSessionByName` can return a stale session object for a dead session, and calling `Kill()` on it dereferences a nil internal pointer
- Added a `HasSession` guard to short-circuit before attempting the lookup

## Test plan
- [ ] Delete a session whose tmux session has already been killed — no panic
- [ ] Delete a session with a live tmux session — session is killed normally
- [ ] `task test` passes
