### PR TITLE
fix(tui,session): workspace hidden toggle + existing-branch worktree/name

### DIFF
--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -120,6 +120,10 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, br
 		createWorktree = true
 	}
 
+	if ws != nil && ws.IsGitRepo && branchName != "" && baseBranchName == "" && branchName != "main" {
+		createWorktree = true
+	}
+
 	var tmuxName string
 	switch {
 	case session.Name != "":
@@ -130,7 +134,7 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, br
 		}
 	case branchName != "":
 		if session.Name == "" {
-			session.Name = branchName
+			session.Name = s.nameFromBranch(branchName)
 		}
 		if ws != nil {
 			tmuxName = BuildTmuxSessionName(ws.Name, session.Name)
@@ -584,6 +588,17 @@ func (s *SessionService) computeTmuxName(sess *Session, ws *workspace.Workspace)
 	return SanitizeTmuxName(sess.Name)
 }
 
+func (s *SessionService) nameFromBranch(branchName string) string {
+	if s.branchPrefix == "" {
+		return branchName
+	}
+	stripped := strings.TrimPrefix(branchName, s.branchPrefix)
+	if stripped == "" {
+		return branchName
+	}
+	return stripped
+}
+
 func (s *SessionService) resolveStartDir(ctx context.Context, session *Session) string {
 	if session.BranchID != nil && session.GitBranch != nil {
 		ws, _ := s.workspaceService.GetWorkspace(ctx, session.WorkspaceID)
@@ -850,7 +865,7 @@ func (s *SessionService) maybeCreatePendingSession(ctx context.Context, data git
 	}
 
 	sess := &Session{
-		Name:        branch.Name,
+		Name:        s.nameFromBranch(branch.Name),
 		WorkspaceID: ws.ID,
 		BranchID:    pr.HeadBranchID,
 		Status:      StatusPending,

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -508,6 +508,52 @@ func TestSessionService_CreateSession_NoBranch_SkipsWorktree(t *testing.T) {
 	waitForStatus(t, sessionStore, session.ID, StatusActive, 2*time.Second)
 }
 
+func TestSessionService_CreateSession_ExistingBranch_AutoCreatesWorktree(t *testing.T) {
+	repoPath := initTestRepo(t)
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	ctx := context.Background()
+	branchName := "eqt/auto-worktree"
+	worktreePath := filepath.Join(repoPath, ".worktrees", "eqt-auto-worktree")
+	cmd := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branchName, worktreePath, "main")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "pre-create worktree failed: %s", string(out))
+
+	pushCmd := exec.Command("git", "-C", worktreePath, "push", "-u", "origin", branchName)
+	out, err = pushCmd.CombinedOutput()
+	require.NoError(t, err, "push branch failed: %s", string(out))
+
+	session := &Session{WorkspaceID: wsGitID}
+
+	err = service.CreateSession(ctx, session, branchName, "", false)
+	require.NoError(t, err)
+
+	waitForStatus(t, sessionStore, session.ID, StatusActive, 5*time.Second)
+
+	_, err = os.Stat(worktreePath)
+	require.NoError(t, err, "worktree should exist")
+
+	retrieved, err := sessionStore.GetByID(session.ID)
+	require.NoError(t, err)
+	require.Equal(t, "auto-worktree", retrieved.Name, "branch prefix should be stripped from session name")
+}
+
+func TestSessionService_CreateSession_ExistingMainBranch_SkipsWorktree(t *testing.T) {
+	repoPath := initTestRepo(t)
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	session := &Session{WorkspaceID: wsGitID}
+
+	ctx := context.Background()
+	err := service.CreateSession(ctx, session, "main", "", false)
+	require.NoError(t, err)
+
+	waitForStatus(t, sessionStore, session.ID, StatusActive, 5*time.Second)
+
+	_, err = os.Stat(filepath.Join(repoPath, ".worktrees", "main"))
+	require.True(t, os.IsNotExist(err), "no worktree should be created for main")
+}
+
 func TestSessionService_CreateSession_NonGitWorkspace_SkipsWorktree(t *testing.T) {
 	database := setupTestDB(t)
 	bus := eventbus.NewEventBus()

--- a/internal/tui/workspacelist/keys.go
+++ b/internal/tui/workspacelist/keys.go
@@ -14,7 +14,7 @@ type keyMap struct {
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Select, k.Hide, k.Delete, k.Back}
+	return []key.Binding{k.Select, k.Hide, k.ToggleHidden, k.Delete, k.Back}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
@@ -25,7 +25,7 @@ var keys = keyMap{
 	Select:       key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
 	Delete:       key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
 	Hide:         key.NewBinding(key.WithKeys("h"), key.WithHelp("h", "hide")),
-	ToggleHidden: key.NewBinding(key.WithKeys("H"), key.WithHelp("H", "show hidden")),
+	ToggleHidden: key.NewBinding(key.WithKeys("."), key.WithHelp(".", "show hidden")),
 	Back:         key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
 }
 


### PR DESCRIPTION
## Summary

- **tui**: rebind the workspace-list "show hidden" toggle from `H` to `.` and include it in `ShortHelp` so it renders in the bottom help bar (was only in `FullHelp`).
- **session**: when creating a session from an existing non-main branch, force `createWorktree=true`. The TUI's "use existing branch" flow was submitting `create_worktree=false`, so the tmux session was starting in the workspace root instead of the worktree.
- **session**: strip the configured branch prefix (e.g. `eqt/`) when deriving a session name from a branch — both manual create and PR-driven pending sessions. A session from `eqt/foo-bar` is now named `foo-bar` and produces a clean tmux name like `workspace-foo-bar`. The underlying branch still uses the full name.

## Test plan

- [ ] In the workspace list view, bottom help bar shows `. show hidden` alongside existing entries.
- [ ] `h` hides a workspace, `.` toggles visibility of hidden workspaces.
- [ ] Create a session from an existing non-main branch (e.g. `eqt/foo`) → a worktree is created under `.worktrees/` and the session starts there.
- [ ] The resulting session is named `foo` (prefix stripped) with tmux name `workspace-foo`.
- [ ] Create a session from `main` (existing branch) → no worktree, session runs in workspace root.
- [ ] `go test ./...` green.
