### PR TITLE
feat(tui): fetch-from-remote and manual branch entry in branch picker

### DIFF
--- a/internal/git/gitcli.go
+++ b/internal/git/gitcli.go
@@ -17,6 +17,11 @@ func newGitCLI() *gitCLI {
 	return &gitCLI{}
 }
 
+type BranchRef struct {
+	Name   string `json:"name"`
+	Remote bool   `json:"remote"`
+}
+
 func (s *gitCLI) listBranches(ctx context.Context, repoPath string) ([]string, error) {
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "branch", "--format=%(refname:short)")
 	output, err := cmd.Output()
@@ -42,6 +47,56 @@ func (s *gitCLI) listBranches(ctx context.Context, repoPath string) ([]string, e
 	}
 
 	return branches, nil
+}
+
+func (s *gitCLI) listAllBranches(ctx context.Context, repoPath string) ([]BranchRef, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "for-each-ref", "--format=%(refname:short)", "refs/heads", "refs/remotes/origin")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list branches: %w", err)
+	}
+
+	refs := []BranchRef{}
+	seen := map[string]bool{}
+
+	for line := range strings.SplitSeq(strings.TrimSpace(string(output)), "\n") {
+		ref := strings.TrimSpace(line)
+		if ref == "" {
+			continue
+		}
+		name := ref
+		remote := false
+		if stripped, ok := strings.CutPrefix(ref, "origin/"); ok {
+			if stripped == "HEAD" {
+				continue
+			}
+			name = stripped
+			remote = true
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		refs = append(refs, BranchRef{Name: name, Remote: remote})
+	}
+
+	for i, r := range refs {
+		if r.Name == "main" {
+			refs = append(refs[:i], refs[i+1:]...)
+			refs = append([]BranchRef{r}, refs...)
+			break
+		}
+	}
+
+	return refs, nil
+}
+
+func (s *gitCLI) fetchOrigin(ctx context.Context, repoPath string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "fetch", "--prune", "origin")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git fetch failed: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
 }
 
 func (s *gitCLI) pull(ctx context.Context, repoPath string, branch string) error {

--- a/internal/git/gitcli_test.go
+++ b/internal/git/gitcli_test.go
@@ -162,6 +162,96 @@ func TestGitCLI_Pull_NoRemote(t *testing.T) {
 	require.Contains(t, err.Error(), "git pull failed")
 }
 
+func TestGitCLI_FetchOrigin_NoRemote(t *testing.T) {
+	repo := initTestRepo(t)
+
+	svc := newGitCLI()
+	err := svc.fetchOrigin(context.Background(), repo)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "git fetch failed")
+}
+
+func initTestRepoWithOrigin(t *testing.T) (string, string) {
+	t.Helper()
+	origin := t.TempDir()
+	run(t, origin, "git", "init", "--bare", "-b", "main")
+
+	upstream := t.TempDir()
+	run(t, upstream, "git", "init", "-b", "main")
+	run(t, upstream, "git", "config", "user.email", "test@test.com")
+	run(t, upstream, "git", "config", "user.name", "Test")
+	run(t, upstream, "git", "commit", "--allow-empty", "-m", "init")
+	run(t, upstream, "git", "remote", "add", "origin", origin)
+	run(t, upstream, "git", "push", "origin", "main")
+
+	clone := t.TempDir()
+	run(t, clone, "git", "clone", origin, ".")
+	run(t, clone, "git", "config", "user.email", "test@test.com")
+	run(t, clone, "git", "config", "user.name", "Test")
+	return clone, upstream
+}
+
+func TestGitCLI_ListAllBranches_DedupesLocalAndRemote(t *testing.T) {
+	clone, upstream := initTestRepoWithOrigin(t)
+
+	run(t, upstream, "git", "checkout", "-b", "feature-remote")
+	run(t, upstream, "git", "commit", "--allow-empty", "-m", "feature commit")
+	run(t, upstream, "git", "push", "origin", "feature-remote")
+
+	run(t, clone, "git", "fetch", "origin")
+	run(t, clone, "git", "branch", "local-only")
+
+	svc := newGitCLI()
+	refs, err := svc.listAllBranches(context.Background(), clone)
+	require.NoError(t, err)
+
+	byName := map[string]BranchRef{}
+	for _, r := range refs {
+		byName[r.Name] = r
+	}
+	require.Contains(t, byName, "main")
+	require.False(t, byName["main"].Remote, "main exists locally")
+	require.Contains(t, byName, "local-only")
+	require.False(t, byName["local-only"].Remote)
+	require.Contains(t, byName, "feature-remote")
+	require.True(t, byName["feature-remote"].Remote, "feature-remote should be remote-only")
+	require.Equal(t, "main", refs[0].Name, "main should be first")
+}
+
+func TestGitCLI_ListAllBranches_SkipsOriginHEAD(t *testing.T) {
+	clone, _ := initTestRepoWithOrigin(t)
+
+	svc := newGitCLI()
+	refs, err := svc.listAllBranches(context.Background(), clone)
+	require.NoError(t, err)
+	for _, r := range refs {
+		require.NotEqual(t, "HEAD", r.Name)
+	}
+}
+
+func TestGitCLI_FetchOrigin_Succeeds(t *testing.T) {
+	clone, upstream := initTestRepoWithOrigin(t)
+
+	run(t, upstream, "git", "checkout", "-b", "new-from-upstream")
+	run(t, upstream, "git", "commit", "--allow-empty", "-m", "upstream commit")
+	run(t, upstream, "git", "push", "origin", "new-from-upstream")
+
+	svc := newGitCLI()
+	err := svc.fetchOrigin(context.Background(), clone)
+	require.NoError(t, err)
+
+	refs, err := svc.listAllBranches(context.Background(), clone)
+	require.NoError(t, err)
+	found := false
+	for _, r := range refs {
+		if r.Name == "new-from-upstream" {
+			found = true
+			require.True(t, r.Remote)
+		}
+	}
+	require.True(t, found, "expected new-from-upstream after fetch")
+}
+
 func TestGitCLI_WorktreePath(t *testing.T) {
 	svc := newGitCLI()
 	require.Equal(t, "/repo/.worktrees/eqt-my-feature", svc.worktreePath("/repo", "eqt/my-feature"))

--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -60,6 +60,14 @@ func (s *GitService) ListBranches(ctx context.Context, repoPath string) ([]strin
 	return s.cli.listBranches(ctx, repoPath)
 }
 
+func (s *GitService) ListAllBranches(ctx context.Context, repoPath string) ([]BranchRef, error) {
+	return s.cli.listAllBranches(ctx, repoPath)
+}
+
+func (s *GitService) FetchOrigin(ctx context.Context, repoPath string) error {
+	return s.cli.fetchOrigin(ctx, repoPath)
+}
+
 func (s *GitService) Pull(ctx context.Context, repoPath string, branch string) error {
 	return s.cli.pull(ctx, repoPath, branch)
 }

--- a/internal/tui/branchpicker/branchitem.go
+++ b/internal/tui/branchpicker/branchitem.go
@@ -1,9 +1,15 @@
 package branchpicker
 
 type branchItem struct {
-	name string
+	name   string
+	remote bool
 }
 
-func (i branchItem) Title() string       { return i.name }
-func (i branchItem) Description() string { return "" }
+func (i branchItem) Title() string { return i.name }
+func (i branchItem) Description() string {
+	if i.remote {
+		return "remote"
+	}
+	return ""
+}
 func (i branchItem) FilterValue() string { return i.name }

--- a/internal/tui/branchpicker/branchpicker.go
+++ b/internal/tui/branchpicker/branchpicker.go
@@ -10,7 +10,8 @@ import (
 )
 
 type Model struct {
-	list list.Model
+	list       list.Model
+	isFetching bool
 }
 
 func New() Model {
@@ -45,6 +46,17 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		}
 		return m, m.list.SetItems(items)
 
+	case provider.BranchesFetchedMsg:
+		m.isFetching = false
+		if msg.Err != nil {
+			return m, m.list.NewStatusMessage("fetch failed: " + msg.Err.Error())
+		}
+		items := make([]list.Item, len(msg.Branches))
+		for i, b := range msg.Branches {
+			items[i] = branchItem{name: b.Name, remote: b.Remote}
+		}
+		return m, tea.Batch(m.list.SetItems(items), m.list.NewStatusMessage("fetched"))
+
 	case tea.KeyMsg:
 		var cmd tea.Cmd
 		var handled bool
@@ -70,6 +82,19 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 				return SelectedMsg{Branch: branch}
 			}, true
 		}
+	}
+	if key.Matches(msg, Keys.Fetch) {
+		if m.isFetching {
+			return m, nil, true
+		}
+		m.isFetching = true
+		return m, tea.Batch(
+			m.list.NewStatusMessage("fetching origin…"),
+			func() tea.Msg { return FetchRequestedMsg{} },
+		), true
+	}
+	if key.Matches(msg, Keys.Manual) {
+		return m, func() tea.Msg { return ManualEntryRequestedMsg{} }, true
 	}
 	return m, nil, false
 }

--- a/internal/tui/branchpicker/keys.go
+++ b/internal/tui/branchpicker/keys.go
@@ -4,18 +4,22 @@ import "github.com/charmbracelet/bubbles/key"
 
 type keyMap struct {
 	Select key.Binding
+	Fetch  key.Binding
+	Manual key.Binding
 	Back   key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Select, k.Back}
+	return []key.Binding{k.Select, k.Fetch, k.Manual, k.Back}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.Select, k.Back}}
+	return [][]key.Binding{{k.Select, k.Fetch, k.Manual, k.Back}}
 }
 
 var Keys = keyMap{
 	Select: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+	Fetch:  key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh")),
+	Manual: key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new name")),
 	Back:   key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
 }

--- a/internal/tui/branchpicker/messages.go
+++ b/internal/tui/branchpicker/messages.go
@@ -3,3 +3,7 @@ package branchpicker
 type SelectedMsg struct {
 	Branch string
 }
+
+type FetchRequestedMsg struct{}
+
+type ManualEntryRequestedMsg struct{}

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/GianlucaP106/gotmux/gotmux"
@@ -96,6 +97,21 @@ type branchListResponse struct {
 	CurrentBranch string   `json:"current_branch"`
 }
 
+type branchRefListResponse struct {
+	Branches      []branchRefEntry `json:"branches"`
+	CurrentBranch string           `json:"current_branch"`
+}
+
+type branchRefEntry struct {
+	Name   string `json:"name"`
+	Remote bool   `json:"remote"`
+}
+
+type branchExistsResponse struct {
+	ExistsLocal  bool `json:"exists_local"`
+	ExistsRemote bool `json:"exists_remote"`
+}
+
 func (c *client) fetchBranches(workspaceID uint) tea.Cmd {
 	return func() tea.Msg {
 		res, err := c.httpClient.Get(fmt.Sprintf("%s/workspaces/%d/branches", c.baseURL, workspaceID))
@@ -115,6 +131,66 @@ func (c *client) fetchBranches(workspaceID uint) tea.Cmd {
 		}
 
 		return branchesLoadedMsg{branches: resp.Branches}
+	}
+}
+
+func (c *client) fetchOriginBranches(workspaceID uint) tea.Cmd {
+	return func() tea.Msg {
+		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/workspaces/%d/branches/fetch", c.baseURL, workspaceID), nil)
+		if err != nil {
+			return branchesFetchedLoadedMsg{err: err}
+		}
+
+		res, err := c.httpClient.Do(req)
+		if err != nil {
+			log.Printf("[ERROR] fetch origin branches: %v", err)
+			return branchesFetchedLoadedMsg{err: err}
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			apiErr := parseAPIError(res, "fetch origin branches")
+			return branchesFetchedLoadedMsg{err: apiErr.Err}
+		}
+
+		var resp branchRefListResponse
+		if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+			return branchesFetchedLoadedMsg{err: err}
+		}
+
+		branches := make([]BranchRef, len(resp.Branches))
+		for i, b := range resp.Branches {
+			branches[i] = BranchRef{Name: b.Name, Remote: b.Remote}
+		}
+		return branchesFetchedLoadedMsg{branches: branches}
+	}
+}
+
+func (c *client) checkBranchExists(workspaceID uint, name string) tea.Cmd {
+	return func() tea.Msg {
+		u := fmt.Sprintf("%s/workspaces/%d/branches/exists?name=%s", c.baseURL, workspaceID, url.QueryEscape(name))
+		res, err := c.httpClient.Get(u)
+		if err != nil {
+			log.Printf("[ERROR] check branch exists %q: %v", name, err)
+			return branchExistsCheckedLoadedMsg{name: name, err: err}
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			apiErr := parseAPIError(res, "check branch exists")
+			return branchExistsCheckedLoadedMsg{name: name, err: apiErr.Err}
+		}
+
+		var resp branchExistsResponse
+		if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+			return branchExistsCheckedLoadedMsg{name: name, err: err}
+		}
+
+		return branchExistsCheckedLoadedMsg{
+			name:         name,
+			existsLocal:  resp.ExistsLocal,
+			existsRemote: resp.ExistsRemote,
+		}
 	}
 }
 

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -98,13 +98,8 @@ type branchListResponse struct {
 }
 
 type branchRefListResponse struct {
-	Branches      []branchRefEntry `json:"branches"`
-	CurrentBranch string           `json:"current_branch"`
-}
-
-type branchRefEntry struct {
-	Name   string `json:"name"`
-	Remote bool   `json:"remote"`
+	Branches      []git.BranchRef `json:"branches"`
+	CurrentBranch string          `json:"current_branch"`
 }
 
 type branchExistsResponse struct {
@@ -158,11 +153,7 @@ func (c *client) fetchOriginBranches(workspaceID uint) tea.Cmd {
 			return branchesFetchedLoadedMsg{err: err}
 		}
 
-		branches := make([]BranchRef, len(resp.Branches))
-		for i, b := range resp.Branches {
-			branches[i] = BranchRef{Name: b.Name, Remote: b.Remote}
-		}
-		return branchesFetchedLoadedMsg{branches: branches}
+		return branchesFetchedLoadedMsg{branches: resp.Branches}
 	}
 }
 

--- a/internal/tui/provider/workspacesprovider.go
+++ b/internal/tui/provider/workspacesprovider.go
@@ -15,10 +15,7 @@ type BranchesLoadedMsg struct {
 	Branches []string
 }
 
-type BranchRef struct {
-	Name   string
-	Remote bool
-}
+type BranchRef = git.BranchRef
 
 type BranchesFetchedMsg struct {
 	Branches []BranchRef

--- a/internal/tui/provider/workspacesprovider.go
+++ b/internal/tui/provider/workspacesprovider.go
@@ -15,6 +15,23 @@ type BranchesLoadedMsg struct {
 	Branches []string
 }
 
+type BranchRef struct {
+	Name   string
+	Remote bool
+}
+
+type BranchesFetchedMsg struct {
+	Branches []BranchRef
+	Err      error
+}
+
+type BranchExistsCheckedMsg struct {
+	Name         string
+	ExistsLocal  bool
+	ExistsRemote bool
+	Err          error
+}
+
 func FetchWorkspaces() tea.Cmd {
 	return func() tea.Msg { return fetchWorkspacesIntentMsg{} }
 }
@@ -25,6 +42,14 @@ func RequestWorkspacesState() tea.Cmd {
 
 func RequestBranches(workspaceID uint) tea.Cmd {
 	return func() tea.Msg { return requestBranchesMsg{workspaceID: workspaceID} }
+}
+
+func FetchOriginBranches(workspaceID uint) tea.Cmd {
+	return func() tea.Msg { return fetchOriginBranchesIntentMsg{workspaceID: workspaceID} }
+}
+
+func CheckBranchExists(workspaceID uint, name string) tea.Cmd {
+	return func() tea.Msg { return checkBranchExistsIntentMsg{workspaceID: workspaceID, name: name} }
 }
 
 type PRsStateUpdatedMsg struct {
@@ -53,6 +78,27 @@ type requestWorkspacesStateMsg struct{}
 
 type requestBranchesMsg struct {
 	workspaceID uint
+}
+
+type fetchOriginBranchesIntentMsg struct {
+	workspaceID uint
+}
+
+type checkBranchExistsIntentMsg struct {
+	workspaceID uint
+	name        string
+}
+
+type branchesFetchedLoadedMsg struct {
+	branches []BranchRef
+	err      error
+}
+
+type branchExistsCheckedLoadedMsg struct {
+	name         string
+	existsLocal  bool
+	existsRemote bool
+	err          error
 }
 
 type deleteWorkspaceIntentMsg struct {
@@ -132,6 +178,26 @@ func (p workspacesProvider) Update(msg tea.Msg) (workspacesProvider, tea.Cmd) {
 
 	case requestBranchesMsg:
 		return p, p.client.fetchBranches(msg.workspaceID)
+
+	case fetchOriginBranchesIntentMsg:
+		return p, p.client.fetchOriginBranches(msg.workspaceID)
+
+	case branchesFetchedLoadedMsg:
+		branches := msg.branches
+		err := msg.err
+		return p, func() tea.Msg { return BranchesFetchedMsg{Branches: branches, Err: err} }
+
+	case checkBranchExistsIntentMsg:
+		return p, p.client.checkBranchExists(msg.workspaceID, msg.name)
+
+	case branchExistsCheckedLoadedMsg:
+		name := msg.name
+		existsLocal := msg.existsLocal
+		existsRemote := msg.existsRemote
+		err := msg.err
+		return p, func() tea.Msg {
+			return BranchExistsCheckedMsg{Name: name, ExistsLocal: existsLocal, ExistsRemote: existsRemote, Err: err}
+		}
 
 	case fetchPRsIntentMsg:
 		return p, p.client.fetchPRs(msg.workspaceID, msg.state)

--- a/internal/tui/sessionform/sessionform.go
+++ b/internal/tui/sessionform/sessionform.go
@@ -31,29 +31,34 @@ const (
 	filePickerStep
 	dirTypeChoiceStep
 	branchPickerStep
+	branchManualInputStep
 	branchModeStep
 	nameInputStep
 )
 
 type Model struct {
-	activeStep        step
-	workspacePicker   workspacepicker.Model
-	filePicker        filepicker.Model
-	branchPicker      branchpicker.Model
-	nameInput         textinput.Model
-	selectedWorkspace workspace.Workspace
-	selectedBranch    string
-	selectedDirPath   string
-	nameErr           string
-	width, height     int
+	activeStep         step
+	workspacePicker    workspacepicker.Model
+	filePicker         filepicker.Model
+	branchPicker       branchpicker.Model
+	nameInput          textinput.Model
+	manualBranchInput  textinput.Model
+	selectedWorkspace  workspace.Workspace
+	selectedBranch     string
+	selectedDirPath    string
+	nameErr            string
+	manualBranchErr    string
+	pendingBranchCheck string
+	width, height      int
 }
 
 func New() Model {
 	return Model{
-		activeStep:      workspacePickerStep,
-		workspacePicker: workspacepicker.New("Select workspace", false),
-		branchPicker:    branchpicker.New(),
-		nameInput:       textinput.New(),
+		activeStep:        workspacePickerStep,
+		workspacePicker:   workspacepicker.New("Select workspace", false),
+		branchPicker:      branchpicker.New(),
+		nameInput:         textinput.New(),
+		manualBranchInput: textinput.New(),
 	}
 }
 
@@ -64,6 +69,9 @@ func (m Model) Init() (Model, tea.Cmd) {
 	m.selectedDirPath = ""
 	m.nameErr = ""
 	m.nameInput.SetValue("")
+	m.manualBranchErr = ""
+	m.manualBranchInput.SetValue("")
+	m.pendingBranchCheck = ""
 	return m, provider.FetchWorkspaces()
 }
 
@@ -83,7 +91,7 @@ func (m Model) Keys() help.KeyMap {
 		return mergedKeyMap{keymaps: []help.KeyMap{formKeys, filepicker.Keys}}
 	case branchPickerStep:
 		return mergedKeyMap{keymaps: []help.KeyMap{formKeys, branchpicker.Keys}}
-	case dirTypeChoiceStep, branchModeStep:
+	case dirTypeChoiceStep, branchModeStep, branchManualInputStep:
 		return formKeys
 	default:
 		return formKeys
@@ -106,6 +114,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			router.NavigateTo(router.SessionProgressView),
 			sessionprogress.Start(msg.ID),
 		)
+	case provider.BranchExistsCheckedMsg:
+		return m.onBranchExistsChecked(msg), nil
 	}
 
 	switch m.activeStep {
@@ -117,6 +127,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m.updateDirTypeChoice(msg)
 	case branchPickerStep:
 		return m.updateBranchPicker(msg)
+	case branchManualInputStep:
+		return m.updateBranchManualInput(msg)
 	case branchModeStep:
 		return m.updateBranchMode(msg)
 	case nameInputStep:
@@ -210,6 +222,21 @@ func (m Model) updateBranchPicker(msg tea.Msg) (Model, tea.Cmd) {
 		m.activeStep = branchModeStep
 		return m, nil
 
+	case branchpicker.FetchRequestedMsg:
+		var cmd tea.Cmd
+		m.branchPicker, cmd = m.branchPicker.Update(msg)
+		return m, tea.Batch(cmd, provider.FetchOriginBranches(m.selectedWorkspace.ID))
+
+	case branchpicker.ManualEntryRequestedMsg:
+		m.initManualBranchInput()
+		m.activeStep = branchManualInputStep
+		return m, m.manualBranchInput.Focus()
+
+	case provider.BranchesFetchedMsg:
+		var cmd tea.Cmd
+		m.branchPicker, cmd = m.branchPicker.Update(msg)
+		return m, cmd
+
 	case tea.KeyMsg:
 		if key.Matches(msg, formKeys.Back) {
 			m.activeStep = workspacePickerStep
@@ -220,6 +247,53 @@ func (m Model) updateBranchPicker(msg tea.Msg) (Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m.branchPicker, cmd = m.branchPicker.Update(msg)
 	return m, cmd
+}
+
+func (m Model) updateBranchManualInput(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, formKeys.Submit):
+			name := strings.TrimSpace(m.manualBranchInput.Value())
+			if name == "" {
+				m.manualBranchErr = "branch name required"
+				return m, nil
+			}
+			m.manualBranchErr = ""
+			m.pendingBranchCheck = name
+			return m, provider.CheckBranchExists(m.selectedWorkspace.ID, name)
+		case key.Matches(msg, formKeys.Back):
+			m.activeStep = branchPickerStep
+			m.manualBranchErr = ""
+			m.pendingBranchCheck = ""
+			return m, nil
+		}
+	}
+
+	var cmd tea.Cmd
+	m.manualBranchInput, cmd = m.manualBranchInput.Update(msg)
+	return m, cmd
+}
+
+func (m Model) onBranchExistsChecked(msg provider.BranchExistsCheckedMsg) Model {
+	if m.pendingBranchCheck == "" || msg.Name != m.pendingBranchCheck {
+		return m
+	}
+	m.pendingBranchCheck = ""
+	if msg.Err != nil {
+		m.manualBranchErr = msg.Err.Error()
+		m.activeStep = branchManualInputStep
+		return m
+	}
+	if !msg.ExistsLocal && !msg.ExistsRemote {
+		m.manualBranchErr = "branch not found: " + msg.Name
+		m.activeStep = branchManualInputStep
+		return m
+	}
+	m.manualBranchErr = ""
+	m.selectedBranch = msg.Name
+	m.activeStep = branchModeStep
+	return m
 }
 
 func (m Model) updateBranchMode(msg tea.Msg) (Model, tea.Cmd) {
@@ -278,6 +352,14 @@ func (m *Model) initNameInput() {
 	m.nameErr = ""
 }
 
+func (m *Model) initManualBranchInput() {
+	ti := textinput.New()
+	ti.Prompt = "Branch name: "
+	m.manualBranchInput = ti
+	m.manualBranchErr = ""
+	m.pendingBranchCheck = ""
+}
+
 func (m Model) View() string {
 	switch m.activeStep {
 	case filePickerStep:
@@ -290,6 +372,17 @@ func (m Model) View() string {
 			"  esc: back"
 	case branchPickerStep:
 		return m.branchPicker.View()
+	case branchManualInputStep:
+		var b strings.Builder
+		b.WriteString("Enter a branch name (local or remote)\n\n")
+		b.WriteString(m.manualBranchInput.View())
+		if m.pendingBranchCheck != "" {
+			b.WriteString("\n\nchecking…")
+		}
+		if m.manualBranchErr != "" {
+			b.WriteString("\n" + errStyle().Render(m.manualBranchErr))
+		}
+		return b.String()
 	case branchModeStep:
 		return promptStyle().Render("Branch: ") + pathStyle().Render(m.selectedBranch) +
 			"\n\n" +

--- a/internal/tui/sessionform/sessionform.go
+++ b/internal/tui/sessionform/sessionform.go
@@ -276,18 +276,16 @@ func (m Model) updateBranchManualInput(msg tea.Msg) (Model, tea.Cmd) {
 }
 
 func (m Model) onBranchExistsChecked(msg provider.BranchExistsCheckedMsg) Model {
-	if m.pendingBranchCheck == "" || msg.Name != m.pendingBranchCheck {
+	if m.activeStep != branchManualInputStep || m.pendingBranchCheck == "" || msg.Name != m.pendingBranchCheck {
 		return m
 	}
 	m.pendingBranchCheck = ""
 	if msg.Err != nil {
 		m.manualBranchErr = msg.Err.Error()
-		m.activeStep = branchManualInputStep
 		return m
 	}
 	if !msg.ExistsLocal && !msg.ExistsRemote {
 		m.manualBranchErr = "branch not found: " + msg.Name
-		m.activeStep = branchManualInputStep
 		return m
 	}
 	m.manualBranchErr = ""

--- a/internal/workspace/types.go
+++ b/internal/workspace/types.go
@@ -68,6 +68,16 @@ type BranchListResponse struct {
 	CurrentBranch string   `json:"current_branch"`
 }
 
+type BranchRefListResponse struct {
+	Branches      []git.BranchRef `json:"branches"`
+	CurrentBranch string          `json:"current_branch"`
+}
+
+type BranchExistsResponse struct {
+	ExistsLocal  bool `json:"exists_local"`
+	ExistsRemote bool `json:"exists_remote"`
+}
+
 type PRListResponse struct {
 	PullRequests []git.PullRequest `json:"pull_requests"`
 }

--- a/internal/workspace/workspacecontroller.go
+++ b/internal/workspace/workspacecontroller.go
@@ -153,6 +153,86 @@ func (c *WorkspaceController) ListBranches(w http.ResponseWriter, r *http.Reques
 	render.JSON(w, r, BranchListResponse{Branches: branches, CurrentBranch: currentBranch})
 }
 
+func (c *WorkspaceController) FetchAndListBranches(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		common.RenderError(w, r, common.NewInvalidRequest(err.Error()))
+		return
+	}
+
+	ws, err := c.service.GetWorkspace(ctx, uint(id))
+	if err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	if !ws.IsGitRepo {
+		common.RenderError(w, r, common.NewInvalidRequest(fmt.Sprintf("workspace %q is not a git repository", ws.Name)))
+		return
+	}
+
+	if err := c.gitService.FetchOrigin(ctx, ws.Path); err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	branches, err := c.gitService.ListAllBranches(ctx, ws.Path)
+	if err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	currentBranch, err := c.gitService.CurrentBranch(ctx, ws.Path)
+	if err != nil {
+		currentBranch = ""
+	}
+
+	render.JSON(w, r, BranchRefListResponse{Branches: branches, CurrentBranch: currentBranch})
+}
+
+func (c *WorkspaceController) CheckBranchExists(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		common.RenderError(w, r, common.NewInvalidRequest(err.Error()))
+		return
+	}
+
+	name := r.URL.Query().Get("name")
+	if name == "" {
+		common.RenderError(w, r, common.NewInvalidRequest("name query parameter is required"))
+		return
+	}
+
+	ws, err := c.service.GetWorkspace(ctx, uint(id))
+	if err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	if !ws.IsGitRepo {
+		common.RenderError(w, r, common.NewInvalidRequest(fmt.Sprintf("workspace %q is not a git repository", ws.Name)))
+		return
+	}
+
+	existsLocal, err := c.gitService.HasBranch(ctx, ws.Path, name)
+	if err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	existsRemote, err := c.gitService.HasRemoteBranch(ctx, ws.Path, name)
+	if err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	render.JSON(w, r, BranchExistsResponse{ExistsLocal: existsLocal, ExistsRemote: existsRemote})
+}
+
 func (c *WorkspaceController) ListPRs(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	raw := chi.URLParam(r, "id")

--- a/internal/workspace/workspacerouter.go
+++ b/internal/workspace/workspacerouter.go
@@ -20,6 +20,8 @@ func (wr *WorkspaceRouter) Routes() chi.Router {
 	r.Get("/", wr.controller.ListWorkspaces)
 	r.Post("/", wr.controller.AddWorkspace)
 	r.Get("/{id}/branches", wr.controller.ListBranches)
+	r.Post("/{id}/branches/fetch", wr.controller.FetchAndListBranches)
+	r.Get("/{id}/branches/exists", wr.controller.CheckBranchExists)
 	r.Get("/{id}/prs", wr.controller.ListPRs)
 	r.Get("/{id}", wr.controller.GetWorkspaceByID)
 	r.Put("/{id}/hidden", wr.controller.SetWorkspaceHidden)

--- a/internal/workspace/workspacerouter_test.go
+++ b/internal/workspace/workspacerouter_test.go
@@ -271,3 +271,166 @@ func TestWorkspaceRouter_ListBranches_NotFound(t *testing.T) {
 
 	require.Equal(t, http.StatusNotFound, w.Code)
 }
+
+func initTestRepoWithOrigin(t *testing.T) string {
+	t.Helper()
+	origin := t.TempDir()
+	runCmd(t, origin, "git", "init", "--bare", "-b", "main")
+
+	upstream := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "init", "-b", "main"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "commit", "--allow-empty", "-m", "init"},
+		{"git", "remote", "add", "origin", origin},
+		{"git", "push", "origin", "main"},
+		{"git", "branch", "remote-branch"},
+		{"git", "push", "origin", "remote-branch"},
+	} {
+		runCmd(t, upstream, args[0], args[1:]...)
+	}
+
+	clone := t.TempDir()
+	runCmd(t, clone, "git", "clone", origin, ".")
+	runCmd(t, clone, "git", "config", "user.email", "test@test.com")
+	runCmd(t, clone, "git", "config", "user.name", "Test")
+	runCmd(t, clone, "git", "branch", "local-only")
+	return clone
+}
+
+func runCmd(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "command %s %v failed: %s", name, args, string(out))
+}
+
+func setupBranchRouter(t *testing.T, repoPath string) (*WorkspaceRouter, *Workspace) {
+	t.Helper()
+
+	database, err := db.OpenInMemory()
+	require.NoError(t, err)
+	database.Migrate(&Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
+	t.Cleanup(func() { database.Close() })
+
+	store := NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
+	ws := &Workspace{Name: "git-repo", Path: repoPath, IsGitRepo: true}
+	store.Add(ws)
+	notGit := &Workspace{Name: "plain", Path: "/plain", IsGitRepo: false}
+	store.Add(notGit)
+
+	service := NewWorkspaceService(store)
+	gitService := git.NewGitService(database)
+	controller := NewWorkspaceController(service, gitService)
+	router := NewWorkspaceRouter(controller)
+
+	return router, ws
+}
+
+func TestWorkspaceRouter_FetchAndListBranches(t *testing.T) {
+	repoPath := initTestRepoWithOrigin(t)
+	router, ws := setupBranchRouter(t, repoPath)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/%d/branches/fetch", ws.ID), nil)
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response BranchRefListResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	byName := map[string]git.BranchRef{}
+	for _, r := range response.Branches {
+		byName[r.Name] = r
+	}
+	require.Contains(t, byName, "main")
+	require.False(t, byName["main"].Remote)
+	require.Contains(t, byName, "local-only")
+	require.False(t, byName["local-only"].Remote)
+	require.Contains(t, byName, "remote-branch")
+	require.True(t, byName["remote-branch"].Remote)
+	require.Equal(t, "main", response.Branches[0].Name)
+}
+
+func TestWorkspaceRouter_FetchAndListBranches_NotGitRepo(t *testing.T) {
+	repoPath := initTestRepoWithOrigin(t)
+	router, _ := setupBranchRouter(t, repoPath)
+
+	req := httptest.NewRequest("POST", "/2/branches/fetch", nil)
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestWorkspaceRouter_CheckBranchExists_Remote(t *testing.T) {
+	repoPath := initTestRepoWithOrigin(t)
+	router, ws := setupBranchRouter(t, repoPath)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/%d/branches/exists?name=remote-branch", ws.ID), nil)
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response BranchExistsResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.False(t, response.ExistsLocal)
+	require.True(t, response.ExistsRemote)
+}
+
+func TestWorkspaceRouter_CheckBranchExists_Local(t *testing.T) {
+	repoPath := initTestRepoWithOrigin(t)
+	router, ws := setupBranchRouter(t, repoPath)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/%d/branches/exists?name=local-only", ws.ID), nil)
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response BranchExistsResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.True(t, response.ExistsLocal)
+	require.False(t, response.ExistsRemote)
+}
+
+func TestWorkspaceRouter_CheckBranchExists_NotFound(t *testing.T) {
+	repoPath := initTestRepoWithOrigin(t)
+	router, ws := setupBranchRouter(t, repoPath)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/%d/branches/exists?name=does-not-exist", ws.ID), nil)
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response BranchExistsResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.False(t, response.ExistsLocal)
+	require.False(t, response.ExistsRemote)
+}
+
+func TestWorkspaceRouter_CheckBranchExists_MissingName(t *testing.T) {
+	repoPath := initTestRepoWithOrigin(t)
+	router, ws := setupBranchRouter(t, repoPath)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/%d/branches/exists", ws.ID), nil)
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}


### PR DESCRIPTION
## Summary
- Adds `r` hotkey in the create-session branch picker to run `git fetch --prune origin` and repopulate the list with local + remote-only branches (remote-only tagged `remote`).
- Adds `n` hotkey to open a text input for typing a branch name; validates via a new exists-check endpoint and accepts local-or-remote, failing inline with `branch not found: <name>` otherwise.
- Backend adds `POST /workspaces/{id}/branches/fetch` and `GET /workspaces/{id}/branches/exists?name=`, plus git primitives `fetchOrigin` and `listAllBranches` (dedupes local/remote, skips `origin/HEAD`, main-first).

## Test plan
- [x] `task test` passes (new coverage in `internal/git/` and `internal/workspace/` router tests).
- [x] `task daemon:build` + `task tui:build`.
- [ ] Manual: `task daemon:run` + `task tui:run`, open create-session on a git-repo workspace.
- [ ] Press `r`: status line shows `fetching origin…` then `fetched`; remote-only branches appear with `remote` description.
- [ ] Press `n`: form opens. Submit a real remote branch → advances to branch mode with it selected. Submit nonsense → inline error, focus stays.
- [ ] Submit a local-only branch name → also accepted.
- [ ] `esc` from form returns to picker; double `r` while fetching is ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)