### PR TITLE
fix: auto-session for review requests, worktree-on-activate, recover stuck creates

### DIFF
--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -448,6 +448,14 @@ func ghPRToPullRequest(ghPR *github.PullRequest, repoID uint, branchID uint, cur
 			break
 		}
 	}
+	if !assigned {
+		for _, r := range ghPR.RequestedReviewers {
+			if r.GetLogin() == currentUser {
+				assigned = true
+				break
+			}
+		}
+	}
 	state := PRStateOpen
 	if ghPR.MergedAt != nil {
 		state = PRStateMerged

--- a/internal/git/gitservice_pr_test.go
+++ b/internal/git/gitservice_pr_test.go
@@ -320,3 +320,35 @@ func TestSyncRepoPRs_NotAssigned(t *testing.T) {
 	require.Len(t, prs, 1)
 	assert.False(t, prs[0].IsAssignedToMe)
 }
+
+func TestSyncRepoPRs_SetsIsAssignedToMe_WhenRequestedReviewer(t *testing.T) {
+	database, repo := setupGitServiceTest(t)
+	raw := makeGitHubPR(1, "Review request PR", "feature-a", "open", false)
+	raw.RequestedReviewers = []*github.User{{Login: github.Ptr("myself")}}
+	ghClient := &mockGitHubClient{repoPRs: []*github.PullRequest{raw}}
+	svc := NewGitService(database, WithGitHubClient(ghClient))
+	svc.currentUser = "myself"
+
+	err := svc.SyncRepoPRs(context.Background(), repo)
+	require.NoError(t, err)
+
+	prs := svc.prStore.ListByRepo(repo.ID)
+	require.Len(t, prs, 1)
+	assert.True(t, prs[0].IsAssignedToMe)
+}
+
+func TestSyncRepoPRs_TeamReviewRequest_DoesNotMarkAssigned(t *testing.T) {
+	database, repo := setupGitServiceTest(t)
+	raw := makeGitHubPR(1, "Team review PR", "feature-a", "open", false)
+	raw.RequestedTeams = []*github.Team{{Slug: github.Ptr("my-team")}}
+	ghClient := &mockGitHubClient{repoPRs: []*github.PullRequest{raw}}
+	svc := NewGitService(database, WithGitHubClient(ghClient))
+	svc.currentUser = "myself"
+
+	err := svc.SyncRepoPRs(context.Background(), repo)
+	require.NoError(t, err)
+
+	prs := svc.prStore.ListByRepo(repo.ID)
+	require.Len(t, prs, 1)
+	assert.False(t, prs[0].IsAssignedToMe)
+}

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -484,6 +484,14 @@ func (s *SessionService) ActivateSession(ctx context.Context, id uint) (*Session
 		return nil, ErrCannotActivate
 	}
 
+	if session.BranchID != nil && session.GitBranch != nil && session.WorkspaceID != 0 {
+		if ws, wsErr := s.workspaceService.GetWorkspace(ctx, session.WorkspaceID); wsErr == nil && ws != nil {
+			if _, wtErr := s.gitService.EnsureWorktree(ctx, session.GitBranch, ws.Path); wtErr != nil {
+				slog.Warn("failed to ensure worktree on activation", "session", id, "branch", session.GitBranch.Name, "error", wtErr)
+			}
+		}
+	}
+
 	tmuxName := ""
 	if session.TmuxSessionID != nil {
 		ts, tsErr := s.tmuxService.GetSession(*session.TmuxSessionID)

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -48,8 +48,30 @@ func (s *SessionService) OnAppStart(ctx context.Context) error {
 	s.eventBus.Subscribe(eventbus.TmuxClientAttached, s.handleTmuxClientAttached)
 	s.eventBus.Subscribe(eventbus.TmuxClientDetached, s.handleTmuxClientDetached)
 	s.eventBus.Subscribe(git.EventPRUpdated, s.handlePRUpdated)
+	s.recoverStuckCreatingSessions()
 	s.reconcileTmuxState(ctx)
 	return nil
+}
+
+func (s *SessionService) recoverStuckCreatingSessions() {
+	sessions, err := s.store.List()
+	if err != nil {
+		slog.Warn("failed to list sessions for stuck-creating recovery", "error", err)
+		return
+	}
+	for i := range sessions {
+		sess := &sessions[i]
+		if sess.Status != StatusCreating {
+			continue
+		}
+		sess.Status = StatusBroken
+		sess.StatusError = "creation interrupted by daemon restart"
+		if err := s.store.Update(sess); err != nil {
+			slog.Warn("failed to recover stuck creating session", "session", sess.ID, "error", err)
+			continue
+		}
+		slog.Info("recovered stuck creating session", "session", sess.ID, "name", sess.Name)
+	}
 }
 
 func (s *SessionService) OnAppEnd(ctx context.Context) error {

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -826,7 +826,7 @@ func (s *SessionService) handlePRUpdated(ctx context.Context, event eventbus.Eve
 	}
 
 	isNew := data.Previous == nil
-	newlyAssigned := pr.IsAssignedToMe && (isNew || !data.Previous.IsAssignedToMe)
+	newlyAssigned := pr.IsAssignedToMe && pr.State == git.PRStateOpen && (isNew || !data.Previous.IsAssignedToMe)
 	newlyMerged := pr.State == git.PRStateMerged && (isNew || data.Previous.State != git.PRStateMerged)
 
 	if newlyAssigned {

--- a/internal/session/sessionservice_pr_test.go
+++ b/internal/session/sessionservice_pr_test.go
@@ -132,6 +132,44 @@ func TestHandlePRUpdated_SkipsUnassigned(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestHandlePRUpdated_SkipsNonOpenStates(t *testing.T) {
+	cases := []struct {
+		name  string
+		state git.PRState
+	}{
+		{"draft", git.PRStateDraft},
+		{"closed", git.PRStateClosed},
+		{"merged", git.PRStateMerged},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupPRTestEnv(t)
+			ctx := context.Background()
+			branchID := env.branch.ID
+			event := eventbus.Event{
+				Type: git.EventPRUpdated,
+				Data: git.PRUpdatedEvent{
+					PullRequest: &git.PullRequest{
+						RepoID:         env.repo.ID,
+						Number:         42,
+						HeadBranchID:   &branchID,
+						State:          tc.state,
+						IsAssignedToMe: true,
+					},
+					Previous: nil,
+					Repo:     env.repo,
+				},
+			}
+
+			err := env.service.handlePRUpdated(ctx, event)
+			require.NoError(t, err)
+
+			_, err = env.sessionStore.GetByBranchID(branchID)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestHandlePRUpdated_SkipsExistingSession(t *testing.T) {
 	env := setupPRTestEnv(t)
 	ctx := context.Background()

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -335,6 +335,12 @@ func initTestRepo(t *testing.T) string {
 
 func setupWorktreeSessionService(t *testing.T, repoPath string, configDir string) (*SessionService, *SessionStore, *utmux.MockRunner, uint) {
 	t.Helper()
+	service, sessionStore, mock, wsID, _, _ := setupWorktreeSessionServiceFull(t, repoPath, configDir)
+	return service, sessionStore, mock, wsID
+}
+
+func setupWorktreeSessionServiceFull(t *testing.T, repoPath string, configDir string) (*SessionService, *SessionStore, *utmux.MockRunner, uint, db.Database, *git.GitService) {
+	t.Helper()
 
 	database := setupTestDB(t)
 	bus := eventbus.NewEventBus()
@@ -346,14 +352,10 @@ func setupWorktreeSessionService(t *testing.T, repoPath string, configDir string
 	mock := utmux.NewMockRunner()
 	tmuxService := createTmuxService(t, database, mock, bus)
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
-	gitDB, err := db.OpenInMemory()
-	require.NoError(t, err)
-	gitDB.Migrate(&git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
-	t.Cleanup(func() { gitDB.Close() })
-	gitService := git.NewGitService(gitDB)
+	gitService := git.NewGitService(database)
 	dismissedPRStore := NewDismissedPRStore(database)
 	service := NewSessionService(sessionStore, dismissedPRStore, workspaceService, gitService, tmuxService, bus, "eqt/", configDir)
-	return service, sessionStore, mock, wsGit.ID
+	return service, sessionStore, mock, wsGit.ID, database, gitService
 }
 
 func TestSessionService_CreateSession_WithWorktree(t *testing.T) {
@@ -638,6 +640,48 @@ func TestSessionService_ActivateSession_RejectsBrokenSession(t *testing.T) {
 	_, err := service.ActivateSession(ctx, session.ID)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrCannotActivate)
+}
+
+func TestSessionService_ActivateSession_PendingPR_CreatesWorktree(t *testing.T) {
+	repoPath := initTestRepo(t)
+	branchName := "harleyk--catalog-docs"
+
+	pushCmd := exec.Command("git", "-C", repoPath, "push", "origin", "main:"+branchName)
+	out, err := pushCmd.CombinedOutput()
+	require.NoError(t, err, "push remote branch failed: %s", string(out))
+
+	service, sessionStore, mock, wsGitID, gitDB, _ := setupWorktreeSessionServiceFull(t, repoPath, t.TempDir())
+
+	repo := &git.Repo{Path: repoPath, FullName: "owner/repo"}
+	require.NoError(t, gitDB.Create(repo).Error)
+	branch := &git.Branch{Name: branchName, RepoID: repo.ID, ExistsLocal: false, ExistsRemote: true}
+	require.NoError(t, gitDB.Create(branch).Error)
+
+	branchID := branch.ID
+	pending := &Session{
+		Name:        branchName,
+		WorkspaceID: wsGitID,
+		BranchID:    &branchID,
+		Status:      StatusPending,
+		LastUsedAt:  time.Now(),
+	}
+	require.NoError(t, sessionStore.Add(pending))
+
+	ctx := context.Background()
+	result, err := service.ActivateSession(ctx, pending.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusActive, result.Status)
+
+	worktreePath := filepath.Join(repoPath, ".worktrees", "harleyk--catalog-docs")
+	info, err := os.Stat(worktreePath)
+	require.NoError(t, err, "expected worktree at %s", worktreePath)
+	require.True(t, info.IsDir())
+
+	tmuxName := fmt.Sprintf("git-repo-%s", branchName)
+	require.True(t, mock.HasSessionByName(tmuxName), "tmux session %q not created", tmuxName)
+	ts, err := service.tmuxService.GetSessionByName(tmuxName)
+	require.NoError(t, err)
+	require.Equal(t, worktreePath, ts.StartDir, "tmux session start dir should be the worktree, not the repo root")
 }
 
 func TestSessionService_ActivateSession_RecreatesMissingTmux(t *testing.T) {

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -79,6 +79,26 @@ func TestSessionService_OnAppStart(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSessionService_OnAppStart_RecoversStuckCreatingSessions(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, _ := setupSessionService(t)
+	ctx := context.Background()
+
+	stuck := &Session{
+		Name:        "stuck-session",
+		WorkspaceID: ws1ID,
+		Status:      StatusCreating,
+		LastUsedAt:  time.Now().Add(-1 * time.Hour),
+	}
+	require.NoError(t, sessionStore.Add(stuck))
+
+	require.NoError(t, service.OnAppStart(ctx))
+
+	recovered, err := sessionStore.GetByID(stuck.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusBroken, recovered.Status)
+	require.NotEmpty(t, recovered.StatusError)
+}
+
 func TestSessionService_OnAppEnd(t *testing.T) {
 	service, _, _, _, _, _ := setupSessionService(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Treat GitHub review requests as "assigned to me" so pending sessions are auto-created when a teammate requests your review (was previously gated on `Assignees`, which our team doesn't use). Only direct user review requests count — team requests are intentionally ignored.
- Gate pending session creation on `PRStateOpen` so the next sync after the review-request fix doesn't revive sessions for every closed/merged/draft PR you ever reviewed.
- On `ActivateSession`, ensure the worktree exists for sessions with a branch — pending PR sessions had no worktree, so activating dropped you in the repo root instead of `<repo>/.worktrees/<branch>`.
- On `OnAppStart`, transition any leftover `creating` sessions to `broken` with a clear status_error. A creating session implies a `runSetup` goroutine is in flight; if the daemon dies mid-creation, the goroutine is gone but the session was previously frozen — neither activatable nor deletable.

## Test plan
- [x] `task test` — full suite green
- [ ] Restart daemon, confirm pending session for an open PR with you as reviewer appears in TUI
- [ ] Activate it, confirm tmux opens in `<repo>/.worktrees/<branch>`
- [ ] Confirm closed/merged/draft PRs you're a reviewer on do NOT create sessions
- [ ] Restart daemon with a stuck `creating` session in the DB, confirm it transitions to `broken`
