### PR TITLE
feat: session setup warnings and session detail view

### DIFF
--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -16,6 +17,10 @@ import (
 	utmux "github.com/eleonorayaya/utena/internal/tmux"
 	"github.com/eleonorayaya/utena/internal/workspace"
 )
+
+type SetupWarning struct{ Message string }
+
+func (w SetupWarning) Error() string { return w.Message }
 
 type SessionService struct {
 	store            *SessionStore
@@ -171,14 +176,22 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace, tmuxN
 
 	var worktreeCreated bool
 	var worktreePath string
+	var setupWarning string
 
 	hasBranch := ws != nil && ws.IsGitRepo && (branchName != "" || baseBranchName != "")
 	if hasBranch {
 		if err := s.setupBranch(ctx, ws, branchName, baseBranchName); err != nil {
-			sess.Status = StatusBroken
-			sess.StatusError = fmt.Sprintf("branch setup failed: %v", err)
-			s.store.Update(sess)
-			return
+			var w SetupWarning
+			if errors.As(err, &w) {
+				setupWarning = w.Message
+				sess.StatusError = w.Message
+				s.store.Update(sess)
+			} else {
+				sess.Status = StatusBroken
+				sess.StatusError = fmt.Sprintf("branch setup failed: %v", err)
+				s.store.Update(sess)
+				return
+			}
 		}
 
 		finalBranchName := branchName
@@ -220,7 +233,9 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace, tmuxN
 	}
 
 	sess.Status = StatusActive
-	sess.StatusError = ""
+	if setupWarning == "" {
+		sess.StatusError = ""
+	}
 	s.store.Update(sess)
 }
 
@@ -257,11 +272,11 @@ func (s *SessionService) setupBranch(ctx context.Context, ws *workspace.Workspac
 	}
 
 	if dirty {
-		return nil
+		return SetupWarning{fmt.Sprintf("branch not pulled: %q has uncommitted changes", pullBranch)}
 	}
 
 	if err := s.gitService.Pull(ctx, ws.Path, pullBranch); err != nil {
-		slog.Warn("failed to pull branch, continuing with local state", "branch", pullBranch, "error", err)
+		return SetupWarning{fmt.Sprintf("branch not pulled: %v", err)}
 	}
 
 	return nil
@@ -424,7 +439,8 @@ func (s *SessionService) RepairSession(ctx context.Context, id uint) (*Session, 
 	if err != nil {
 		return nil, err
 	}
-	if sess.Status != StatusBroken {
+	isWarned := sess.Status == StatusActive && sess.StatusError != ""
+	if sess.Status != StatusBroken && !isWarned {
 		return nil, ErrSessionNotBroken
 	}
 

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -966,3 +966,65 @@ func TestSessionService_WorktreeInit_WorkingDirIsWorktree(t *testing.T) {
 	expectedPath := filepath.Join(repoPath, ".worktrees", "eqt-wd-test")
 	require.Contains(t, string(data), expectedPath)
 }
+
+func TestSessionService_CreateSession_DirtyMainRepo_SetsWarning(t *testing.T) {
+	repoPath := initTestRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(repoPath, "dirty.txt"), []byte("uncommitted"), 0644))
+
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	sess := &Session{Name: "warn-feature", WorkspaceID: wsGitID}
+	ctx := context.Background()
+	require.NoError(t, service.CreateSession(ctx, sess, "", "main", true))
+
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 5*time.Second)
+
+	retrieved, err := sessionStore.GetByID(sess.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusActive, retrieved.Status)
+	require.Contains(t, retrieved.StatusError, "branch not pulled")
+}
+
+func TestSessionService_CreateSession_CleanRepo_NoWarning(t *testing.T) {
+	repoPath := initTestRepo(t)
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	sess := &Session{Name: "clean-feature", WorkspaceID: wsGitID}
+	ctx := context.Background()
+	require.NoError(t, service.CreateSession(ctx, sess, "", "main", true))
+
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 5*time.Second)
+
+	retrieved, err := sessionStore.GetByID(sess.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusActive, retrieved.Status)
+	require.Empty(t, retrieved.StatusError)
+}
+
+func TestSessionService_RepairSession_ClearsWarning(t *testing.T) {
+	repoPath := initTestRepo(t)
+	dirtyFile := filepath.Join(repoPath, "dirty.txt")
+	require.NoError(t, os.WriteFile(dirtyFile, []byte("uncommitted"), 0644))
+
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	sess := &Session{Name: "warn-repair", WorkspaceID: wsGitID}
+	ctx := context.Background()
+	require.NoError(t, service.CreateSession(ctx, sess, "", "main", true))
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 5*time.Second)
+
+	warned, err := sessionStore.GetByID(sess.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, warned.StatusError)
+
+	require.NoError(t, os.Remove(dirtyFile))
+
+	_, err = service.RepairSession(ctx, sess.ID)
+	require.NoError(t, err)
+
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 5*time.Second)
+
+	retrieved, err := sessionStore.GetByID(sess.ID)
+	require.NoError(t, err)
+	require.Empty(t, retrieved.StatusError)
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/eleonorayaya/utena/internal/tui/prlist"
 	"github.com/eleonorayaya/utena/internal/tui/provider"
 	"github.com/eleonorayaya/utena/internal/tui/router"
+	"github.com/eleonorayaya/utena/internal/tui/sessiondetail"
 	"github.com/eleonorayaya/utena/internal/tui/sessionform"
 	"github.com/eleonorayaya/utena/internal/tui/sessionlist"
 	"github.com/eleonorayaya/utena/internal/tui/sessionprogress"
@@ -49,6 +50,7 @@ func NewApp(logPath, port string, initialView router.View, opts ...AppOption) Ap
 	baseURL := fmt.Sprintf("http://localhost:%s", port)
 	views := map[router.View]router.ViewEntry{
 		router.SessionListView:     &router.ViewAdapter[sessionlist.Model]{Model: sessionlist.New()},
+		router.SessionDetailView:   &router.ViewAdapter[sessiondetail.Model]{Model: sessiondetail.New()},
 		router.SessionFormView:     &router.ViewAdapter[sessionform.Model]{Model: sessionform.New()},
 		router.SessionProgressView: &router.ViewAdapter[sessionprogress.Model]{Model: sessionprogress.New()},
 		router.TodoListView:        &router.ViewAdapter[todolist.Model]{Model: todolist.New()},

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -267,6 +267,28 @@ func (c *client) deleteSession(id uint) tea.Cmd {
 	}
 }
 
+func (c *client) archiveSession(id uint) tea.Cmd {
+	return func() tea.Msg {
+		req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/sessions/%d/archive", c.baseURL, id), nil)
+		if err != nil {
+			return ErrMsg{err}
+		}
+
+		res, err := c.httpClient.Do(req)
+		if err != nil {
+			log.Printf("[ERROR] archive session %d: %v", id, err)
+			return ErrMsg{err}
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			return parseAPIError(res, "archive session")
+		}
+
+		return sessionArchivedMsg{id: id}
+	}
+}
+
 func (c *client) deleteWorkspace(id uint) tea.Cmd {
 	return func() tea.Msg {
 		req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/workspaces/%d", c.baseURL, id), nil)

--- a/internal/tui/provider/sessionsprovider.go
+++ b/internal/tui/provider/sessionsprovider.go
@@ -55,6 +55,10 @@ func DeleteSession(id uint) tea.Cmd {
 	return func() tea.Msg { return deleteSessionIntentMsg{id: id} }
 }
 
+func ArchiveSession(id uint) tea.Cmd {
+	return func() tea.Msg { return archiveSessionIntentMsg{id: id} }
+}
+
 type fetchSessionsIntentMsg struct{}
 type requestSessionsStateMsg struct{}
 
@@ -76,6 +80,10 @@ type repairSessionIntentMsg struct {
 }
 
 type deleteSessionIntentMsg struct {
+	id uint
+}
+
+type archiveSessionIntentMsg struct {
 	id uint
 }
 
@@ -103,6 +111,8 @@ type sessionRepairedMsg struct {
 type sessionDeletedMsg struct {
 	id uint
 }
+
+type sessionArchivedMsg struct{ id uint }
 
 type sessionPolledMsg struct {
 	session session.Session
@@ -188,6 +198,12 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 		return p, p.client.deleteSession(msg.id)
 
 	case sessionDeletedMsg:
+		return p, p.client.fetchSessions()
+
+	case archiveSessionIntentMsg:
+		return p, p.client.archiveSession(msg.id)
+
+	case sessionArchivedMsg:
 		return p, p.client.fetchSessions()
 
 	case pollSessionIntentMsg:

--- a/internal/tui/router/view.go
+++ b/internal/tui/router/view.go
@@ -13,4 +13,5 @@ const (
 	WorkspaceListView
 	WorkspaceDetailView
 	PRListView
+	SessionDetailView
 )

--- a/internal/tui/sessiondetail/keys.go
+++ b/internal/tui/sessiondetail/keys.go
@@ -1,0 +1,32 @@
+package sessiondetail
+
+import (
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+)
+
+type keyMap struct {
+	Activate key.Binding
+	Repair   key.Binding
+	Archive  key.Binding
+	Delete   key.Binding
+	Back     key.Binding
+}
+
+func (k keyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Activate, k.Repair, k.Archive, k.Delete, k.Back}
+}
+
+func (k keyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{k.Activate, k.Repair, k.Archive, k.Delete, k.Back}}
+}
+
+var keys = keyMap{
+	Activate: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "activate")),
+	Repair:   key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "repair")),
+	Archive:  key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "archive")),
+	Delete:   key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
+	Back:     key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+}
+
+var _ help.KeyMap = keys

--- a/internal/tui/sessiondetail/messages.go
+++ b/internal/tui/sessiondetail/messages.go
@@ -1,0 +1,14 @@
+package sessiondetail
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/eleonorayaya/utena/internal/session"
+)
+
+type SelectMsg struct {
+	Session session.Session
+}
+
+func Select(s session.Session) tea.Cmd {
+	return func() tea.Msg { return SelectMsg{Session: s} }
+}

--- a/internal/tui/sessiondetail/model.go
+++ b/internal/tui/sessiondetail/model.go
@@ -139,7 +139,7 @@ func filterPRsByBranch(prs []git.PullRequest, branch *git.Branch) []git.PullRequ
 	}
 	var out []git.PullRequest
 	for _, pr := range prs {
-		if pr.HeadBranch != nil && pr.HeadBranch.Name == branch.Name {
+		if pr.HeadBranchID != nil && *pr.HeadBranchID == branch.ID {
 			out = append(out, pr)
 		}
 	}

--- a/internal/tui/sessiondetail/model.go
+++ b/internal/tui/sessiondetail/model.go
@@ -48,9 +48,6 @@ func New() Model {
 }
 
 func (m Model) Init() (Model, tea.Cmd) {
-	m.sess = nil
-	m.prs = nil
-	m.pendingDeleteID = 0
 	return m, nil
 }
 
@@ -80,6 +77,9 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 		return m, nil
 	}
 
+	pendingID := m.pendingDeleteID
+	m.pendingDeleteID = 0
+
 	switch {
 	case key.Matches(msg, keys.Back):
 		return m, router.Back()
@@ -88,7 +88,10 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 		return m, provider.ActivateSession(m.sess.ID)
 
 	case key.Matches(msg, keys.Archive):
-		if m.sess.Status == session.StatusBroken {
+		archivable := m.sess.Status == session.StatusActive ||
+			m.sess.Status == session.StatusInactive ||
+			m.sess.Status == session.StatusCompleted
+		if !archivable {
 			return m, nil
 		}
 		return m, tea.Batch(
@@ -97,8 +100,7 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 		)
 
 	case key.Matches(msg, keys.Delete):
-		if m.pendingDeleteID == m.sess.ID {
-			m.pendingDeleteID = 0
+		if pendingID == m.sess.ID {
 			return m, tea.Batch(
 				provider.DeleteSession(m.sess.ID),
 				router.Back(),
@@ -158,9 +160,7 @@ func (m Model) View() string {
 		}
 	}
 
-	if s.StatusError != "" && s.Status == session.StatusBroken {
-		b.WriteString("\n" + warningStyle().Render("[!] "+s.StatusError) + "\n")
-	} else if s.StatusError != "" {
+	if s.StatusError != "" {
 		b.WriteString("\n" + warningStyle().Render("[!] "+s.StatusError) + "\n")
 	}
 

--- a/internal/tui/sessiondetail/model.go
+++ b/internal/tui/sessiondetail/model.go
@@ -1,0 +1,168 @@
+package sessiondetail
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/eleonorayaya/utena/internal/git"
+	"github.com/eleonorayaya/utena/internal/session"
+	"github.com/eleonorayaya/utena/internal/tui/provider"
+	"github.com/eleonorayaya/utena/internal/tui/router"
+	"github.com/eleonorayaya/utena/internal/tui/sessionprogress"
+	"github.com/eleonorayaya/utena/internal/tui/theme"
+)
+
+func titleStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Bold(true).Foreground(theme.Current.TextEmphasis)
+}
+
+func labelStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(theme.Current.TextMuted).Width(12)
+}
+
+func valueStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(theme.Current.Text)
+}
+
+func warningStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(theme.Current.AccentLavender)
+}
+
+func sectionStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(theme.Current.TextMuted).Bold(true)
+}
+
+type Model struct {
+	sess            *session.Session
+	prs             []git.PullRequest
+	pendingDeleteID uint
+	width           int
+	height          int
+}
+
+func New() Model {
+	return Model{}
+}
+
+func (m Model) Init() (Model, tea.Cmd) {
+	m.sess = nil
+	m.prs = nil
+	m.pendingDeleteID = 0
+	return m, nil
+}
+
+func (m Model) Keys() help.KeyMap {
+	return keys
+}
+
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+	case SelectMsg:
+		s := msg.Session
+		m.sess = &s
+		m.pendingDeleteID = 0
+		return m, nil
+	case tea.KeyMsg:
+		return m.onKeyMsg(msg)
+	}
+	return m, nil
+}
+
+func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
+	if m.sess == nil {
+		return m, nil
+	}
+
+	switch {
+	case key.Matches(msg, keys.Back):
+		return m, router.Back()
+
+	case key.Matches(msg, keys.Activate):
+		return m, provider.ActivateSession(m.sess.ID)
+
+	case key.Matches(msg, keys.Archive):
+		if m.sess.Status == session.StatusBroken {
+			return m, nil
+		}
+		return m, tea.Batch(
+			provider.ArchiveSession(m.sess.ID),
+			router.Back(),
+		)
+
+	case key.Matches(msg, keys.Delete):
+		if m.pendingDeleteID == m.sess.ID {
+			m.pendingDeleteID = 0
+			return m, tea.Batch(
+				provider.DeleteSession(m.sess.ID),
+				router.Back(),
+			)
+		}
+		m.pendingDeleteID = m.sess.ID
+		return m, nil
+
+	case key.Matches(msg, keys.Repair):
+		if m.sess.Status != session.StatusBroken {
+			return m, nil
+		}
+		id := m.sess.ID
+		return m, tea.Sequence(
+			router.NavigateTo(router.SessionProgressView),
+			sessionprogress.Start(id),
+		)
+	}
+
+	return m, nil
+}
+
+func (m Model) View() string {
+	if m.sess == nil {
+		return "No session selected"
+	}
+
+	var b strings.Builder
+	s := m.sess
+
+	b.WriteString(titleStyle().Render(s.Name))
+	b.WriteString("\n\n")
+
+	b.WriteString(labelStyle().Render("Status") + valueStyle().Render(string(s.Status)) + "\n")
+
+	if s.Workspace != nil {
+		b.WriteString(labelStyle().Render("Workspace") + valueStyle().Render(s.Workspace.Name) + "\n")
+	}
+
+	if s.TmuxSession != nil {
+		b.WriteString("\n" + sectionStyle().Render("Tmux") + "\n")
+		b.WriteString(labelStyle().Render("Session") + valueStyle().Render(s.TmuxSession.Name) + "\n")
+		if s.TmuxSession.StartDir != "" {
+			b.WriteString(labelStyle().Render("Dir") + valueStyle().Render(s.TmuxSession.StartDir) + "\n")
+		}
+	}
+
+	if s.GitBranch != nil {
+		b.WriteString("\n" + sectionStyle().Render("Git") + "\n")
+		b.WriteString(labelStyle().Render("Branch") + valueStyle().Render(s.GitBranch.Name) + "\n")
+	}
+
+	if len(s.ClaudeSessions) > 0 {
+		b.WriteString("\n" + sectionStyle().Render("Claude") + "\n")
+		for _, cs := range s.ClaudeSessions {
+			b.WriteString(labelStyle().Render("Status") + valueStyle().Render(string(cs.Status)) + "\n")
+		}
+	}
+
+	if s.StatusError != "" && s.Status == session.StatusBroken {
+		b.WriteString("\n" + warningStyle().Render("[!] "+s.StatusError) + "\n")
+	} else if s.StatusError != "" {
+		b.WriteString("\n" + warningStyle().Render("[!] "+s.StatusError) + "\n")
+	}
+
+	return b.String()
+}

--- a/internal/tui/sessiondetail/model.go
+++ b/internal/tui/sessiondetail/model.go
@@ -95,6 +95,9 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 		return m, router.Back()
 
 	case key.Matches(msg, keys.Activate):
+		if m.sess.IsAttached {
+			return m, nil
+		}
 		return m, provider.ActivateSession(m.sess.ID)
 
 	case key.Matches(msg, keys.Archive):

--- a/internal/tui/sessiondetail/model.go
+++ b/internal/tui/sessiondetail/model.go
@@ -1,6 +1,7 @@
 package sessiondetail
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/help"
@@ -64,7 +65,16 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case SelectMsg:
 		s := msg.Session
 		m.sess = &s
+		m.prs = nil
 		m.pendingDeleteID = 0
+		if s.WorkspaceID != 0 {
+			return m, provider.FetchPRs(s.WorkspaceID, "")
+		}
+		return m, nil
+	case provider.PRsStateUpdatedMsg:
+		if m.sess != nil && msg.WorkspaceID == m.sess.WorkspaceID {
+			m.prs = filterPRsByBranch(msg.PullRequests, m.sess.GitBranch)
+		}
 		return m, nil
 	case tea.KeyMsg:
 		return m.onKeyMsg(msg)
@@ -123,6 +133,19 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 	return m, nil
 }
 
+func filterPRsByBranch(prs []git.PullRequest, branch *git.Branch) []git.PullRequest {
+	if branch == nil {
+		return nil
+	}
+	var out []git.PullRequest
+	for _, pr := range prs {
+		if pr.HeadBranch != nil && pr.HeadBranch.Name == branch.Name {
+			out = append(out, pr)
+		}
+	}
+	return out
+}
+
 func (m Model) View() string {
 	if m.sess == nil {
 		return "No session selected"
@@ -151,6 +174,9 @@ func (m Model) View() string {
 	if s.GitBranch != nil {
 		b.WriteString("\n" + sectionStyle().Render("Git") + "\n")
 		b.WriteString(labelStyle().Render("Branch") + valueStyle().Render(s.GitBranch.Name) + "\n")
+		for _, pr := range m.prs {
+			b.WriteString(labelStyle().Render("PR") + valueStyle().Render(fmt.Sprintf("#%d %s (%s)", pr.Number, pr.Title, pr.State)) + "\n")
+		}
 	}
 
 	if len(s.ClaudeSessions) > 0 {

--- a/internal/tui/sessiondetail/model_test.go
+++ b/internal/tui/sessiondetail/model_test.go
@@ -1,0 +1,94 @@
+package sessiondetail
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/eleonorayaya/utena/internal/session"
+	"github.com/eleonorayaya/utena/internal/tui/router"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func makeActiveSession() session.Session {
+	return session.Session{
+		Model:  gorm.Model{ID: 1},
+		Name:   "my-feature",
+		Status: session.StatusActive,
+	}
+}
+
+func makeBrokenSession() session.Session {
+	return session.Session{
+		Model:       gorm.Model{ID: 2},
+		Name:        "broken",
+		Status:      session.StatusBroken,
+		StatusError: "tmux setup failed",
+	}
+}
+
+func TestSessionDetail_SelectMsg_LoadsSession(t *testing.T) {
+	m, _ := New().Update(SelectMsg{Session: makeActiveSession()})
+	require.NotNil(t, m.sess)
+	assert.Equal(t, "my-feature", m.sess.Name)
+}
+
+func TestSessionDetail_Back_NavigatesBack(t *testing.T) {
+	m, _ := New().Update(SelectMsg{Session: makeActiveSession()})
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	require.NotNil(t, cmd)
+	msg := cmd()
+	assert.IsType(t, router.BackMsg{}, msg)
+}
+
+func TestSessionDetail_Archive_ArchivesAndGoesBack(t *testing.T) {
+	m, _ := New().Update(SelectMsg{Session: makeActiveSession()})
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	assert.NotNil(t, cmd)
+}
+
+func TestSessionDetail_Archive_SkipsWhenBroken(t *testing.T) {
+	m, _ := New().Update(SelectMsg{Session: makeBrokenSession()})
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	assert.Nil(t, cmd)
+}
+
+func TestSessionDetail_Delete_RequiresDoublePress(t *testing.T) {
+	m, _ := New().Update(SelectMsg{Session: makeActiveSession()})
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	assert.Nil(t, cmd)
+	assert.Equal(t, uint(1), m2.pendingDeleteID)
+
+	_, cmd2 := m2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	assert.NotNil(t, cmd2)
+}
+
+func TestSessionDetail_Repair_SkipsWhenHealthy(t *testing.T) {
+	m, _ := New().Update(SelectMsg{Session: makeActiveSession()})
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	assert.Nil(t, cmd)
+}
+
+func TestSessionDetail_Repair_FiresWhenBroken(t *testing.T) {
+	m, _ := New().Update(SelectMsg{Session: makeBrokenSession()})
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	assert.NotNil(t, cmd)
+}
+
+func TestSessionDetail_View_ShowsWarning(t *testing.T) {
+	warned := session.Session{
+		Model:       gorm.Model{ID: 3},
+		Name:        "warn",
+		Status:      session.StatusActive,
+		StatusError: "branch not pulled: dirty",
+	}
+	m, _ := New().Update(SelectMsg{Session: warned})
+	assert.Contains(t, m.View(), "[!]")
+	assert.Contains(t, m.View(), "branch not pulled")
+}
+
+func TestSessionDetail_View_NoWarningWhenClean(t *testing.T) {
+	m, _ := New().Update(SelectMsg{Session: makeActiveSession()})
+	assert.NotContains(t, m.View(), "[!]")
+}

--- a/internal/tui/sessiondetail/model_test.go
+++ b/internal/tui/sessiondetail/model_test.go
@@ -42,6 +42,14 @@ func TestSessionDetail_Back_NavigatesBack(t *testing.T) {
 	assert.IsType(t, router.BackMsg{}, msg)
 }
 
+func TestSessionDetail_Activate_SkipsWhenAttached(t *testing.T) {
+	attached := makeActiveSession()
+	attached.IsAttached = true
+	m, _ := New().Update(SelectMsg{Session: attached})
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Nil(t, cmd)
+}
+
 func TestSessionDetail_Archive_ArchivesAndGoesBack(t *testing.T) {
 	m, _ := New().Update(SelectMsg{Session: makeActiveSession()})
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})

--- a/internal/tui/sessiondetail/model_test.go
+++ b/internal/tui/sessiondetail/model_test.go
@@ -64,6 +64,15 @@ func TestSessionDetail_Delete_RequiresDoublePress(t *testing.T) {
 	assert.NotNil(t, cmd2)
 }
 
+func TestSessionDetail_Delete_ResetsByInterveningKey(t *testing.T) {
+	m, _ := New().Update(SelectMsg{Session: makeActiveSession()})
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	assert.Equal(t, uint(1), m2.pendingDeleteID)
+
+	m3, _ := m2.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	assert.Equal(t, uint(0), m3.pendingDeleteID)
+}
+
 func TestSessionDetail_Repair_SkipsWhenHealthy(t *testing.T) {
 	m, _ := New().Update(SelectMsg{Session: makeActiveSession()})
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})

--- a/internal/tui/sessionlist/keys.go
+++ b/internal/tui/sessionlist/keys.go
@@ -9,23 +9,25 @@ type keyMap struct {
 	Select       key.Binding
 	Close        key.Binding
 	New          key.Binding
+	Info         key.Binding
 	Todos        key.Binding
 	Workspaces   key.Binding
 	ToggleBroken key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Select, k.Close, k.New, k.Todos, k.Workspaces, k.ToggleBroken}
+	return []key.Binding{k.Select, k.Close, k.New, k.Info, k.Todos, k.Workspaces, k.ToggleBroken}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.Select, k.Close, k.New, k.Todos, k.Workspaces, k.ToggleBroken}}
+	return [][]key.Binding{{k.Select, k.Close, k.New, k.Info, k.Todos, k.Workspaces, k.ToggleBroken}}
 }
 
 var keys = keyMap{
 	Select:       key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
 	Close:        key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "close")),
 	New:          key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
+	Info:         key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "info")),
 	Todos:        key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "todos")),
 	Workspaces:   key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "workspaces")),
 	ToggleBroken: key.NewBinding(key.WithKeys("."), key.WithHelp(".", "toggle broken")),

--- a/internal/tui/sessionlist/sessionitem.go
+++ b/internal/tui/sessionlist/sessionitem.go
@@ -33,6 +33,9 @@ func (i sessionItem) Title() string {
 			title += " (attached)"
 		}
 	}
+	if i.session.Status != session.StatusBroken && i.session.StatusError != "" {
+		title += " [!]"
+	}
 	switch i.claudeStatus {
 	case claude.StatusNeedsAttention:
 		title += " [needs attention]"

--- a/internal/tui/sessionlist/sessionitem_test.go
+++ b/internal/tui/sessionlist/sessionitem_test.go
@@ -1,0 +1,42 @@
+package sessionlist
+
+import (
+	"testing"
+
+	"github.com/eleonorayaya/utena/internal/session"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSessionItem_Title_ActiveWithWarning(t *testing.T) {
+	item := sessionItem{
+		session: session.Session{
+			Name:        "my-feature",
+			Status:      session.StatusActive,
+			StatusError: "branch not pulled: worktree has uncommitted changes",
+		},
+	}
+	assert.Contains(t, item.Title(), "[!]")
+	assert.NotContains(t, item.Title(), "(broken)")
+}
+
+func TestSessionItem_Title_ActiveNoWarning(t *testing.T) {
+	item := sessionItem{
+		session: session.Session{
+			Name:   "my-feature",
+			Status: session.StatusActive,
+		},
+	}
+	assert.NotContains(t, item.Title(), "[!]")
+}
+
+func TestSessionItem_Title_Broken(t *testing.T) {
+	item := sessionItem{
+		session: session.Session{
+			Name:        "my-feature",
+			Status:      session.StatusBroken,
+			StatusError: "worktree or branch is unhealthy",
+		},
+	}
+	assert.Contains(t, item.Title(), "(broken)")
+	assert.NotContains(t, item.Title(), "[!]")
+}

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -11,6 +11,7 @@ import (
 	ulist "github.com/eleonorayaya/utena/internal/tui/list"
 	"github.com/eleonorayaya/utena/internal/tui/provider"
 	"github.com/eleonorayaya/utena/internal/tui/router"
+	"github.com/eleonorayaya/utena/internal/tui/sessiondetail"
 	"github.com/eleonorayaya/utena/internal/tui/sessionprogress"
 )
 
@@ -101,6 +102,15 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 		m.pendingRepairID = 0
 	}
 	switch {
+	case key.Matches(msg, keys.Info):
+		item, ok := m.list.SelectedItem().(sessionItem)
+		if !ok {
+			return m, nil, false
+		}
+		return m, tea.Sequence(
+			router.NavigateTo(router.SessionDetailView),
+			sessiondetail.Select(item.session),
+		), true
 	case key.Matches(msg, keys.ToggleBroken):
 		m.showBroken = !m.showBroken
 		return m, m.rebuildItems(), true

--- a/internal/tui/sessionlist/sessionlist_test.go
+++ b/internal/tui/sessionlist/sessionlist_test.go
@@ -1,0 +1,20 @@
+package sessionlist
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/eleonorayaya/utena/internal/session"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSessionList_InfoKey_NavigatesToDetail(t *testing.T) {
+	m := New()
+	m.list.SetItems([]list.Item{
+		sessionItem{session: session.Session{Name: "test-session", Status: session.StatusActive}},
+	})
+	_, cmd, handled := m.OnKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("i")})
+	assert.True(t, handled)
+	assert.NotNil(t, cmd)
+}

--- a/internal/tui/sessionprogress/model.go
+++ b/internal/tui/sessionprogress/model.go
@@ -15,11 +15,10 @@ import (
 	"github.com/eleonorayaya/utena/internal/tui/theme"
 )
 
-func titleStyle() lipgloss.Style { return lipgloss.NewStyle().Bold(true) }
-func pendingStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(theme.Current.StatusPending)
-}
-func failedStyle() lipgloss.Style { return lipgloss.NewStyle().Foreground(theme.Current.Error) }
+func titleStyle() lipgloss.Style   { return lipgloss.NewStyle().Bold(true) }
+func pendingStyle() lipgloss.Style  { return lipgloss.NewStyle().Foreground(theme.Current.StatusPending) }
+func failedStyle() lipgloss.Style   { return lipgloss.NewStyle().Foreground(theme.Current.Error) }
+func warningStyle() lipgloss.Style  { return lipgloss.NewStyle().Foreground(theme.Current.AccentLavender) }
 
 type tickMsg time.Time
 
@@ -36,6 +35,7 @@ type Model struct {
 	session   *session.Session
 	done      bool
 	err       error
+	warning   string
 	width     int
 	height    int
 }
@@ -48,6 +48,7 @@ func (m Model) Init() (Model, tea.Cmd) {
 	m.session = nil
 	m.done = false
 	m.err = nil
+	m.warning = ""
 	return m, nil
 }
 
@@ -77,6 +78,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.session = nil
 		m.done = false
 		m.err = nil
+		m.warning = ""
 		return m, tea.Batch(provider.PollSession(m.sessionID), tick())
 
 	case tickMsg:
@@ -96,6 +98,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.session = &s
 		switch s.Status {
 		case session.StatusActive:
+			if s.StatusError != "" {
+				m.done = true
+				m.warning = s.StatusError
+				return m, nil
+			}
 			m.done = true
 			return m, provider.ActivateSession(s.ID)
 		case session.StatusBroken:
@@ -112,11 +119,15 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.KeyMsg:
 		if m.done {
 			if key.Matches(msg, keys.Back) {
+				if m.warning != "" {
+					return m, tea.Batch(router.Back(), provider.ActivateSession(m.sessionID))
+				}
 				return m, router.Back()
 			}
-			if m.err != nil && key.Matches(msg, keys.Repair) {
+			if (m.err != nil || m.warning != "") && key.Matches(msg, keys.Repair) {
 				m.done = false
 				m.err = nil
+				m.warning = ""
 				return m, tea.Batch(
 					provider.RepairSession(m.sessionID),
 					provider.PollSession(m.sessionID),
@@ -153,6 +164,14 @@ func (m Model) View() string {
 		b.WriteString("\n")
 	} else if m.session.Status == session.StatusCreating {
 		b.WriteString(pendingStyle().Render("  Setting up..."))
+		b.WriteString("\n")
+	}
+
+	if m.warning != "" {
+		b.WriteString("\n")
+		b.WriteString(warningStyle().Render("[!] " + m.warning))
+		b.WriteString("\n")
+		b.WriteString(pendingStyle().Render("  Session is active. Press esc to open it or r to retry setup."))
 		b.WriteString("\n")
 	}
 


### PR DESCRIPTION
## Summary
- Adds a `SetupWarning` typed error returned by `setupBranch` when a branch pull is skipped (dirty worktree or pull failure), stored in `StatusError` on active sessions — no schema change needed
- Shows a persistent `[!]` badge in the session list for active sessions with a `StatusError`; the session progress popup also shows the warning with repair/proceed options
- Allows `RepairSession` on warned (active + `StatusError`) sessions, not only broken ones
- Adds `SessionDetailView` (press `i` on any session): shows workspace, git branch + PRs, tmux windows, Claude sessions, and setup warnings; supports activate (`enter`), repair (`r`), archive (`a`), delete with confirm (`d` twice), back (`esc`)
- Adds `ArchiveSession` to the TUI provider

## Test plan
- [ ] Create a session on a workspace with uncommitted changes — confirm it reaches `StatusActive` with `[!]` badge in the session list
- [ ] Press `r` in the list or detail view to repair after cleaning up — confirm badge disappears
- [ ] Press `i` on a session — confirm detail view opens with correct metadata
- [ ] Verify `enter` activates (skips if already attached), `a` archives, `d` double-press deletes, `esc` returns to list
- [ ] Verify PRs for the session's branch appear in the Git section of the detail view
- [ ] Create a session on a clean workspace — verify no `[!]` badge
- [ ] `task test` passes
