### PR TITLE
feat: bare repository workspace pattern + default branch in picker

### DIFF
--- a/internal/git/gitcli.go
+++ b/internal/git/gitcli.go
@@ -62,7 +62,7 @@ func (s *gitCLI) listBranches(ctx context.Context, repoPath string) ([]string, e
 	def := s.defaultBranch(ctx, repoPath)
 
 	if def != "" && !slices.Contains(branches, def) {
-		branches = append([]string{def}, branches...)
+		return append([]string{def}, branches...), nil
 	}
 
 	priority := def
@@ -303,8 +303,7 @@ func (s *gitCLI) migrateToBare(ctx context.Context, workspacePath string) error 
 		return fmt.Errorf("git clone --bare failed (backup at %s): %s: %w", backupPath, strings.TrimSpace(string(output)), err)
 	}
 
-	gitFile := filepath.Join(workspacePath, ".git")
-	if err := os.WriteFile(gitFile, []byte("gitdir: ./.bare\n"), 0644); err != nil {
+	if err := os.WriteFile(gitDir, []byte("gitdir: ./.bare\n"), 0644); err != nil {
 		return fmt.Errorf("failed to write .git file (backup at %s): %w", backupPath, err)
 	}
 

--- a/internal/git/gitcli.go
+++ b/internal/git/gitcli.go
@@ -110,6 +110,14 @@ func (s *gitCLI) pull(ctx context.Context, repoPath string, branch string) error
 	return nil
 }
 
+func (s *gitCLI) fetch(ctx context.Context, repoPath string, branch string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "fetch", "origin", branch+":"+branch)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git fetch failed: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
 func (s *gitCLI) createWorktree(ctx context.Context, repoPath string, branchName string, baseBranch string) (string, error) {
 	worktreePath := s.worktreePath(repoPath, branchName)
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "worktree", "add", "-b", branchName, worktreePath, baseBranch)
@@ -189,8 +197,20 @@ func (s *gitCLI) validateWorktree(ctx context.Context, worktreePath string, expe
 	return true, nil
 }
 
+func isBareWorkspace(path string) bool {
+	gitInfo, err := os.Stat(filepath.Join(path, ".git"))
+	if err != nil || gitInfo.IsDir() {
+		return false
+	}
+	bareInfo, err := os.Stat(filepath.Join(path, ".bare"))
+	return err == nil && bareInfo.IsDir()
+}
+
 func (s *gitCLI) worktreePath(repoPath string, branch string) string {
 	dirName := strings.ReplaceAll(branch, "/", "-")
+	if isBareWorkspace(repoPath) {
+		return filepath.Join(repoPath, dirName)
+	}
 	return filepath.Join(repoPath, ".worktrees", dirName)
 }
 
@@ -217,6 +237,51 @@ func (s *gitCLI) remoteURL(ctx context.Context, repoPath string) (string, error)
 		return "", fmt.Errorf("failed to get remote URL: %w", err)
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+func (s *gitCLI) migrateToBare(ctx context.Context, workspacePath string) error {
+	backupPath := workspacePath + "-backup"
+
+	if _, err := os.Stat(backupPath); err == nil {
+		return fmt.Errorf("backup directory already exists: %s", backupPath)
+	}
+
+	gitDir := filepath.Join(workspacePath, ".git")
+	info, err := os.Stat(gitDir)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("workspace does not have a .git directory: %s", workspacePath)
+	}
+
+	remoteURL, err := s.remoteURL(ctx, workspacePath)
+	if err != nil {
+		return fmt.Errorf("failed to get remote URL (workspace must have a remote named 'origin'): %w", err)
+	}
+
+	if err := os.Rename(workspacePath, backupPath); err != nil {
+		return fmt.Errorf("failed to move workspace to backup: %w", err)
+	}
+
+	if err := os.Mkdir(workspacePath, 0755); err != nil {
+		return fmt.Errorf("failed to create workspace directory (backup at %s): %w", backupPath, err)
+	}
+
+	barePath := filepath.Join(workspacePath, ".bare")
+	cmd := exec.CommandContext(ctx, "git", "clone", "--bare", remoteURL, barePath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git clone --bare failed (backup at %s): %s: %w", backupPath, strings.TrimSpace(string(output)), err)
+	}
+
+	gitFile := filepath.Join(workspacePath, ".git")
+	if err := os.WriteFile(gitFile, []byte("gitdir: ./.bare\n"), 0644); err != nil {
+		return fmt.Errorf("failed to write .git file (backup at %s): %w", backupPath, err)
+	}
+
+	cmd = exec.CommandContext(ctx, "git", "-C", workspacePath, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to set fetch refspec (backup at %s): %s: %w", backupPath, strings.TrimSpace(string(output)), err)
+	}
+
+	return nil
 }
 
 func (s *gitCLI) parseRepoFullName(remoteURL string) (owner string, repo string, err error) {

--- a/internal/git/gitcli.go
+++ b/internal/git/gitcli.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -20,6 +21,26 @@ func newGitCLI() *gitCLI {
 type BranchRef struct {
 	Name   string `json:"name"`
 	Remote bool   `json:"remote"`
+}
+
+func (s *gitCLI) defaultBranch(ctx context.Context, repoPath string) string {
+	ref := "refs/remotes/origin/HEAD"
+	if isBareWorkspace(repoPath) {
+		ref = "HEAD"
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "symbolic-ref", ref)
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	resolved := strings.TrimSpace(string(output))
+	if name, ok := strings.CutPrefix(resolved, "refs/heads/"); ok {
+		return name
+	}
+	if name, ok := strings.CutPrefix(resolved, "refs/remotes/origin/"); ok {
+		return name
+	}
+	return ""
 }
 
 func (s *gitCLI) listBranches(ctx context.Context, repoPath string) ([]string, error) {
@@ -38,11 +59,20 @@ func (s *gitCLI) listBranches(ctx context.Context, repoPath string) ([]string, e
 		}
 	}
 
+	def := s.defaultBranch(ctx, repoPath)
+
+	if def != "" && !slices.Contains(branches, def) {
+		branches = append([]string{def}, branches...)
+	}
+
+	priority := def
+	if priority == "" {
+		priority = "main"
+	}
 	for i, b := range branches {
-		if b == "main" {
+		if b == priority {
 			branches = append(branches[:i], branches[i+1:]...)
-			branches = append([]string{"main"}, branches...)
-			break
+			return append([]string{priority}, branches...), nil
 		}
 	}
 
@@ -80,11 +110,13 @@ func (s *gitCLI) listAllBranches(ctx context.Context, repoPath string) ([]Branch
 		refs = append(refs, BranchRef{Name: name, Remote: remote})
 	}
 
-	for i, r := range refs {
-		if r.Name == "main" {
-			refs = append(refs[:i], refs[i+1:]...)
-			refs = append([]BranchRef{r}, refs...)
-			break
+	if def := s.defaultBranch(ctx, repoPath); def != "" {
+		for i, r := range refs {
+			if r.Name == def {
+				refs = append(refs[:i], refs[i+1:]...)
+				refs = append([]BranchRef{r}, refs...)
+				break
+			}
 		}
 	}
 

--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -72,12 +72,58 @@ func (s *GitService) Pull(ctx context.Context, repoPath string, branch string) e
 	return s.cli.pull(ctx, repoPath, branch)
 }
 
-func (s *GitService) CreateWorktree(ctx context.Context, repoPath string, branchName string, baseBranch string) (string, error) {
-	return s.cli.createWorktree(ctx, repoPath, branchName, baseBranch)
+func (s *GitService) Fetch(ctx context.Context, repoPath string, branch string) error {
+	return s.cli.fetch(ctx, repoPath, branch)
 }
 
-func (s *GitService) CheckoutWorktree(ctx context.Context, repoPath string, branch string) (string, error) {
-	return s.cli.checkoutWorktree(ctx, repoPath, branch)
+func (s *GitService) SetupWorktree(ctx context.Context, repoPath string, branchName string, baseBranch string, branchID uint, repoID uint) (bool, string, error) {
+	creatingNew := baseBranch != ""
+
+	exists, err := s.cli.hasBranch(ctx, repoPath, branchName)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to check branch %q: %v", branchName, err)
+	}
+	if creatingNew && exists {
+		return false, "", fmt.Errorf("branch %q already exists; use it as an existing branch instead", branchName)
+	}
+	if !creatingNew && !exists {
+		return false, "", fmt.Errorf("branch %q does not exist; provide a base branch to create it", branchName)
+	}
+
+	wtPath := s.cli.worktreePath(repoPath, branchName)
+
+	alreadyExists, err := s.cli.validateWorktree(ctx, wtPath, branchName)
+	if err != nil {
+		return false, "", err
+	}
+	if alreadyExists {
+		s.ensureWorktreeRecord(branchID, repoID, wtPath)
+		return false, wtPath, nil
+	}
+
+	var path string
+	if creatingNew {
+		path, err = s.cli.createWorktree(ctx, repoPath, branchName, baseBranch)
+		if err != nil {
+			return false, "", fmt.Errorf("failed to create worktree: %v", err)
+		}
+	} else {
+		path, err = s.cli.checkoutWorktree(ctx, repoPath, branchName)
+		if err != nil {
+			return false, "", fmt.Errorf("failed to checkout worktree: %v", err)
+		}
+	}
+
+	s.ensureWorktreeRecord(branchID, repoID, path)
+	return true, path, nil
+}
+
+func (s *GitService) ensureWorktreeRecord(branchID uint, repoID uint, path string) {
+	if branchID == 0 || repoID == 0 {
+		return
+	}
+	_ = s.worktreeStore.DeleteByBranchID(branchID)
+	_ = s.worktreeStore.Add(&Worktree{Path: path, BranchID: branchID, RepoID: repoID})
 }
 
 func (s *GitService) CurrentBranch(ctx context.Context, repoPath string) (string, error) {
@@ -106,6 +152,10 @@ func (s *GitService) WorktreePath(repoPath string, branch string) string {
 
 func (s *GitService) RemoveWorktree(ctx context.Context, repoPath string, worktreePath string) error {
 	return s.cli.removeWorktree(ctx, repoPath, worktreePath)
+}
+
+func (s *GitService) MigrateToBare(ctx context.Context, workspacePath string) error {
+	return s.cli.migrateToBare(ctx, workspacePath)
 }
 
 func (s *GitService) DeleteBranch(ctx context.Context, repoPath string, branchName string) error {
@@ -244,6 +294,11 @@ func (s *GitService) HasWorktree(branchID uint) bool {
 	_, err := s.worktreeStore.GetByBranchID(branchID)
 	return err == nil
 }
+
+func (s *GitService) DeleteWorktreesByRepoID(repoID uint) error {
+	return s.worktreeStore.DeleteByRepoID(repoID)
+}
+
 
 func (s *GitService) IsHealthy(ctx context.Context, branch *Branch, repoPath string) bool {
 	wt, err := s.worktreeStore.GetByBranchID(branch.ID)

--- a/internal/git/worktreestore.go
+++ b/internal/git/worktreestore.go
@@ -66,20 +66,22 @@ func (s *WorktreeStore) GetByPath(path string) (*Worktree, error) {
 }
 
 func (s *WorktreeStore) Delete(id uint) error {
-	var worktree Worktree
-	if err := s.db.First(&worktree, "id = ?", id).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return ErrWorktreeNotFound
-		}
-		return err
+	result := s.db.Where("id = ?", id).Unscoped().Delete(&Worktree{})
+	if result.Error != nil {
+		return result.Error
 	}
-
-	return s.db.Delete(&Worktree{}, id).Error
+	if result.RowsAffected == 0 {
+		return ErrWorktreeNotFound
+	}
+	return nil
 }
 
 func (s *WorktreeStore) DeleteByBranchID(branchID uint) error {
-	result := s.db.Where("branch_id = ?", branchID).Delete(&Worktree{})
-	return result.Error
+	return s.db.Where("branch_id = ?", branchID).Unscoped().Delete(&Worktree{}).Error
+}
+
+func (s *WorktreeStore) DeleteByRepoID(repoID uint) error {
+	return s.db.Where("repo_id = ?", repoID).Unscoped().Delete(&Worktree{}).Error
 }
 
 func (s *WorktreeStore) ListByRepo(repoID uint) []Worktree {

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -291,6 +291,12 @@ func (s *SessionService) setupBranch(ctx context.Context, ws *workspace.Workspac
 
 	checkPath := s.gitService.WorktreePath(ws.Path, pullBranch)
 	if _, err := os.Stat(checkPath); os.IsNotExist(err) {
+		if ws.IsBare {
+			if err := s.gitService.Fetch(ctx, ws.Path, pullBranch); err != nil {
+				return SetupWarning{fmt.Sprintf("branch not fetched: %v", err)}
+			}
+			return nil
+		}
 		checkPath = ws.Path
 	}
 
@@ -298,12 +304,11 @@ func (s *SessionService) setupBranch(ctx context.Context, ws *workspace.Workspac
 	if err != nil {
 		return fmt.Errorf("failed to check dirty state for %q: %v", pullBranch, err)
 	}
-
 	if dirty {
 		return SetupWarning{fmt.Sprintf("branch not pulled: %q has uncommitted changes", pullBranch)}
 	}
 
-	if err := s.gitService.Pull(ctx, ws.Path, pullBranch); err != nil {
+	if err := s.gitService.Pull(ctx, checkPath, pullBranch); err != nil {
 		return SetupWarning{fmt.Sprintf("branch not pulled: %v", err)}
 	}
 
@@ -311,46 +316,20 @@ func (s *SessionService) setupBranch(ctx context.Context, ws *workspace.Workspac
 }
 
 func (s *SessionService) setupWorktree(ctx context.Context, sess *Session, ws *workspace.Workspace, branchName string, baseBranchName string) (bool, string, error) {
-	creatingNewBranch := baseBranchName != ""
-
 	finalBranchName := branchName
-	if creatingNewBranch {
+	if baseBranchName != "" {
 		finalBranchName = s.branchPrefix + sess.Name
 	}
 
-	branchExists, err := s.gitService.HasBranch(ctx, ws.Path, finalBranchName)
-	if err != nil {
-		return false, "", fmt.Errorf("failed to check branch %q: %v", finalBranchName, err)
+	var branchID, repoID uint
+	if sess.BranchID != nil {
+		branchID = *sess.BranchID
 	}
-	if creatingNewBranch && branchExists {
-		return false, "", fmt.Errorf("branch %q already exists; use it as an existing branch instead", finalBranchName)
-	}
-	if !creatingNewBranch && !branchExists {
-		return false, "", fmt.Errorf("branch %q does not exist; provide a base branch to create it", finalBranchName)
+	if ws.RepoID != nil {
+		repoID = *ws.RepoID
 	}
 
-	worktreePath := s.gitService.WorktreePath(ws.Path, finalBranchName)
-
-	exists, err := s.gitService.ValidateWorktree(ctx, worktreePath, finalBranchName)
-	if err != nil {
-		return false, "", err
-	}
-	if exists {
-		return false, worktreePath, nil
-	}
-
-	if creatingNewBranch {
-		path, err := s.gitService.CreateWorktree(ctx, ws.Path, finalBranchName, baseBranchName)
-		if err != nil {
-			return false, "", fmt.Errorf("failed to create worktree: %v", err)
-		}
-		return true, path, nil
-	}
-	path, err := s.gitService.CheckoutWorktree(ctx, ws.Path, finalBranchName)
-	if err != nil {
-		return false, "", fmt.Errorf("failed to checkout worktree: %v", err)
-	}
-	return true, path, nil
+	return s.gitService.SetupWorktree(ctx, ws.Path, finalBranchName, baseBranchName, branchID, repoID)
 }
 
 func (s *SessionService) setupTmux(ctx context.Context, sess *Session, tmuxName string, worktreePath string) error {

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -378,6 +378,28 @@ func (c *client) deleteWorkspace(id uint) tea.Cmd {
 	}
 }
 
+func (c *client) migrateWorkspaceToBare(id uint) tea.Cmd {
+	return func() tea.Msg {
+		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/workspaces/%d/migrate-bare", c.baseURL, id), nil)
+		if err != nil {
+			return ErrMsg{err}
+		}
+
+		res, err := c.httpClient.Do(req)
+		if err != nil {
+			log.Printf("[ERROR] migrate workspace %d to bare: %v", id, err)
+			return ErrMsg{err}
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusNoContent {
+			return parseAPIError(res, "migrate workspace to bare")
+		}
+
+		return workspaceMigratedToBareMsg{}
+	}
+}
+
 func (c *client) setWorkspaceHidden(id uint, hidden bool) tea.Cmd {
 	return func() tea.Msg {
 		body, _ := json.Marshal(map[string]bool{"hidden": hidden})

--- a/internal/tui/provider/workspacesprovider.go
+++ b/internal/tui/provider/workspacesprovider.go
@@ -62,6 +62,10 @@ func DeleteWorkspace(id uint) tea.Cmd {
 	return func() tea.Msg { return deleteWorkspaceIntentMsg{id: id} }
 }
 
+func MigrateWorkspaceToBare(id uint) tea.Cmd {
+	return func() tea.Msg { return migrateWorkspaceToBareIntentMsg{id: id} }
+}
+
 func SetWorkspaceHidden(id uint, hidden bool) tea.Cmd {
 	return func() tea.Msg { return setWorkspaceHiddenIntentMsg{id: id, hidden: hidden} }
 }
@@ -133,6 +137,11 @@ type branchesLoadedMsg struct {
 type workspaceDeletedMsg struct{}
 type workspaceHiddenToggledMsg struct{}
 type workspaceAddedMsg struct{}
+type workspaceMigratedToBareMsg struct{}
+
+type migrateWorkspaceToBareIntentMsg struct {
+	id uint
+}
 
 type workspacesProvider struct {
 	client            *client
@@ -224,6 +233,12 @@ func (p workspacesProvider) Update(msg tea.Msg) (workspacesProvider, tea.Cmd) {
 		return p, p.client.addWorkspace(msg.path, msg.asRoot)
 
 	case workspaceAddedMsg:
+		return p, p.client.fetchWorkspaces()
+
+	case migrateWorkspaceToBareIntentMsg:
+		return p, p.client.migrateWorkspaceToBare(msg.id)
+
+	case workspaceMigratedToBareMsg:
 		return p, p.client.fetchWorkspaces()
 	}
 

--- a/internal/tui/workspacedetail/keys.go
+++ b/internal/tui/workspacedetail/keys.go
@@ -6,21 +6,23 @@ import (
 )
 
 type keyMap struct {
-	PRs  key.Binding
-	Back key.Binding
+	PRs     key.Binding
+	Migrate key.Binding
+	Back    key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.PRs, k.Back}
+	return []key.Binding{k.PRs, k.Migrate, k.Back}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.PRs, k.Back}}
+	return [][]key.Binding{{k.PRs, k.Migrate, k.Back}}
 }
 
 var keys = keyMap{
-	PRs:  key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "pull requests")),
-	Back: key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+	PRs:     key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "pull requests")),
+	Migrate: key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "migrate to bare")),
+	Back:    key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
 }
 
 var _ help.KeyMap = keys

--- a/internal/tui/workspacedetail/model.go
+++ b/internal/tui/workspacedetail/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/eleonorayaya/utena/internal/common"
 	"github.com/eleonorayaya/utena/internal/tui/prlist"
+	"github.com/eleonorayaya/utena/internal/tui/provider"
 	"github.com/eleonorayaya/utena/internal/tui/router"
 	"github.com/eleonorayaya/utena/internal/tui/theme"
 	"github.com/eleonorayaya/utena/internal/workspace"
@@ -28,6 +29,7 @@ func valueStyle() lipgloss.Style {
 
 type Model struct {
 	workspace *workspace.Workspace
+	actionErr string
 	width     int
 	height    int
 }
@@ -53,6 +55,21 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case SelectMsg:
 		ws := msg.Workspace
 		m.workspace = &ws
+		m.actionErr = ""
+		return m, nil
+	case provider.WorkspacesStateUpdatedMsg:
+		if m.workspace != nil {
+			for _, ws := range msg.Workspaces {
+				if ws.ID == m.workspace.ID {
+					wsCopy := ws
+					m.workspace = &wsCopy
+					break
+				}
+			}
+		}
+		return m, nil
+	case provider.ErrMsg:
+		m.actionErr = msg.Err.Error()
 		return m, nil
 	case tea.KeyMsg:
 		return m.onKeyMsg(msg)
@@ -70,6 +87,12 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 			router.NavigateTo(router.PRListView),
 			prlist.Select(m.workspace.ID),
 		)
+	case key.Matches(msg, keys.Migrate):
+		if m.workspace == nil || !m.workspace.IsGitRepo || m.workspace.IsBare {
+			return m, nil
+		}
+		m.actionErr = ""
+		return m, provider.MigrateWorkspaceToBare(m.workspace.ID)
 	case key.Matches(msg, keys.Back):
 		return m, router.Back()
 	}
@@ -95,12 +118,23 @@ func (m Model) View() string {
 			repoName = ws.Repo.FullName
 		}
 		b.WriteString(labelStyle().Render("Repository") + valueStyle().Render(repoName) + "\n")
+
+		bareStatus := "no  (press m to migrate)"
+		if ws.IsBare {
+			bareStatus = "yes"
+		}
+		b.WriteString(labelStyle().Render("Bare") + valueStyle().Render(bareStatus) + "\n")
 	} else {
 		b.WriteString(labelStyle().Render("Repository") + valueStyle().Render("not a git repo") + "\n")
 	}
 
 	if !ws.LastUsedAt.IsZero() {
 		b.WriteString(labelStyle().Render("Last used") + valueStyle().Render(common.TimeAgo(ws.LastUsedAt)) + "\n")
+	}
+
+	if m.actionErr != "" {
+		b.WriteString("\n")
+		b.WriteString(lipgloss.NewStyle().Foreground(theme.Current.Error).Render("Error: "+m.actionErr) + "\n")
 	}
 
 	return b.String()

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -12,6 +12,7 @@ type Workspace struct {
 	Name       string    `json:"name"`
 	Path       string    `json:"path" gorm:"uniqueIndex"`
 	IsGitRepo  bool      `json:"is_git_repo"`
+	IsBare     bool      `json:"is_bare" gorm:"default:false"`
 	IsHidden   bool      `json:"is_hidden" gorm:"default:false"`
 	RepoID     *uint     `json:"repo_id,omitempty" gorm:"index"`
 	Repo       *git.Repo `json:"repo,omitempty" gorm:"foreignKey:RepoID"`

--- a/internal/workspace/workspacecontroller.go
+++ b/internal/workspace/workspacecontroller.go
@@ -233,6 +233,51 @@ func (c *WorkspaceController) CheckBranchExists(w http.ResponseWriter, r *http.R
 	render.JSON(w, r, BranchExistsResponse{ExistsLocal: existsLocal, ExistsRemote: existsRemote})
 }
 
+func (c *WorkspaceController) MigrateWorkspaceToBare(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		common.RenderError(w, r, common.NewInvalidRequest(err.Error()))
+		return
+	}
+
+	ws, err := c.service.GetWorkspace(ctx, uint(id))
+	if err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	if !ws.IsGitRepo {
+		common.RenderError(w, r, common.NewInvalidRequest(fmt.Sprintf("workspace %q is not a git repository", ws.Name)))
+		return
+	}
+
+	if ws.IsBare {
+		common.RenderError(w, r, common.NewInvalidRequest(fmt.Sprintf("workspace %q is already using the bare pattern", ws.Name)))
+		return
+	}
+
+	if err := c.gitService.MigrateToBare(ctx, ws.Path); err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	if ws.RepoID != nil {
+		if err := c.gitService.DeleteWorktreesByRepoID(*ws.RepoID); err != nil {
+			common.RenderError(w, r, fmt.Errorf("migration succeeded but failed to clear worktree records: %w", err))
+			return
+		}
+	}
+
+	if err := c.service.MarkAsBare(ctx, uint(id)); err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	render.NoContent(w, r)
+}
+
 func (c *WorkspaceController) ListPRs(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	raw := chi.URLParam(r, "id")

--- a/internal/workspace/workspacerouter.go
+++ b/internal/workspace/workspacerouter.go
@@ -25,6 +25,7 @@ func (wr *WorkspaceRouter) Routes() chi.Router {
 	r.Get("/{id}/prs", wr.controller.ListPRs)
 	r.Get("/{id}", wr.controller.GetWorkspaceByID)
 	r.Put("/{id}/hidden", wr.controller.SetWorkspaceHidden)
+	r.Post("/{id}/migrate-bare", wr.controller.MigrateWorkspaceToBare)
 	r.Delete("/{id}", wr.controller.DeleteWorkspace)
 
 	return r

--- a/internal/workspace/workspaceservice.go
+++ b/internal/workspace/workspaceservice.go
@@ -69,6 +69,15 @@ func (s *WorkspaceService) DeleteWorkspace(ctx context.Context, id uint) error {
 	return nil
 }
 
+func (s *WorkspaceService) MarkAsBare(ctx context.Context, id uint) error {
+	ws, err := s.store.GetByID(id)
+	if err != nil {
+		return err
+	}
+	ws.IsBare = true
+	return s.store.Update(ws)
+}
+
 func (s *WorkspaceService) AddWorkspace(ctx context.Context, path string, asRoot bool) (*Workspace, error) {
 	if asRoot {
 		_, err := s.store.AddWorkspaceRoot(path)

--- a/internal/workspace/workspacestore.go
+++ b/internal/workspace/workspacestore.go
@@ -187,11 +187,12 @@ func (s *WorkspaceStore) AddWorkspace(path string) (*Workspace, error) {
 		return nil, fmt.Errorf("workspace already exists: %s", path)
 	}
 
+	isGit, isBare := s.detectRepoKind(path)
 	ws := &Workspace{
 		Name:      filepath.Base(path),
 		Path:      path,
-		IsGitRepo: s.isGitRepository(path),
-		IsBare:    s.isBareRepository(path),
+		IsGitRepo: isGit,
+		IsBare:    isBare,
 	}
 
 	if err := s.Add(ws); err != nil {
@@ -236,11 +237,12 @@ func (s *WorkspaceStore) AddWorkspaceRoot(path string) ([]Workspace, error) {
 			continue
 		}
 
+		isGit, isBare := s.detectRepoKind(fullPath)
 		ws := &Workspace{
 			Name:      entry.Name(),
 			Path:      fullPath,
-			IsGitRepo: s.isGitRepository(fullPath),
-			IsBare:    s.isBareRepository(fullPath),
+			IsGitRepo: isGit,
+			IsBare:    isBare,
 		}
 		if err := s.Add(ws); err != nil {
 			continue
@@ -312,8 +314,7 @@ func (s *WorkspaceStore) discoverWorkspaces() ([]*Workspace, error) {
 			}
 
 			fullPath := filepath.Join(expanded, entry.Name())
-			isGitRepo := s.isGitRepository(fullPath)
-			isBare := s.isBareRepository(fullPath)
+			isGitRepo, isBare := s.detectRepoKind(fullPath)
 
 			workspaces = append(workspaces, &Workspace{
 				Name:      entry.Name(),
@@ -330,8 +331,7 @@ func (s *WorkspaceStore) discoverWorkspaces() ([]*Workspace, error) {
 		if err != nil || !info.IsDir() {
 			continue
 		}
-		isGitRepo := s.isGitRepository(expanded)
-		isBare := s.isBareRepository(expanded)
+		isGitRepo, isBare := s.detectRepoKind(expanded)
 		workspaces = append(workspaces, &Workspace{
 			Name:      filepath.Base(expanded),
 			Path:      expanded,
@@ -383,19 +383,23 @@ func expandHome(path string) string {
 	return path
 }
 
-func (s *WorkspaceStore) isGitRepository(path string) bool {
+func (s *WorkspaceStore) detectRepoKind(path string) (isGit, isBare bool) {
 	info, err := s.fs.Stat(filepath.Join(path, ".git"))
-	if err == nil && info.IsDir() {
-		return true
+	if err != nil {
+		return false, false
 	}
-	return s.isBareRepository(path)
-}
-
-func (s *WorkspaceStore) isBareRepository(path string) bool {
-	gitInfo, err := s.fs.Stat(filepath.Join(path, ".git"))
-	if err != nil || gitInfo.IsDir() {
-		return false
+	if info.IsDir() {
+		return true, false
 	}
 	bareInfo, err := s.fs.Stat(filepath.Join(path, ".bare"))
-	return err == nil && bareInfo.IsDir()
+	if err == nil && bareInfo.IsDir() {
+		return true, true
+	}
+	return false, false
 }
+
+func (s *WorkspaceStore) isGitRepository(path string) bool {
+	isGit, _ := s.detectRepoKind(path)
+	return isGit
+}
+

--- a/internal/workspace/workspacestore.go
+++ b/internal/workspace/workspacestore.go
@@ -191,6 +191,7 @@ func (s *WorkspaceStore) AddWorkspace(path string) (*Workspace, error) {
 		Name:      filepath.Base(path),
 		Path:      path,
 		IsGitRepo: s.isGitRepository(path),
+		IsBare:    s.isBareRepository(path),
 	}
 
 	if err := s.Add(ws); err != nil {
@@ -239,6 +240,7 @@ func (s *WorkspaceStore) AddWorkspaceRoot(path string) ([]Workspace, error) {
 			Name:      entry.Name(),
 			Path:      fullPath,
 			IsGitRepo: s.isGitRepository(fullPath),
+			IsBare:    s.isBareRepository(fullPath),
 		}
 		if err := s.Add(ws); err != nil {
 			continue
@@ -269,6 +271,7 @@ func (s *WorkspaceStore) OnAppStart(ctx context.Context) error {
 		if err := s.db.First(&existing, "path = ?", ws.Path).Error; err == nil {
 			existing.Name = ws.Name
 			existing.IsGitRepo = ws.IsGitRepo
+			existing.IsBare = ws.IsBare
 			s.db.Save(&existing)
 		} else {
 			s.db.Create(ws)
@@ -310,11 +313,13 @@ func (s *WorkspaceStore) discoverWorkspaces() ([]*Workspace, error) {
 
 			fullPath := filepath.Join(expanded, entry.Name())
 			isGitRepo := s.isGitRepository(fullPath)
+			isBare := s.isBareRepository(fullPath)
 
 			workspaces = append(workspaces, &Workspace{
 				Name:      entry.Name(),
 				Path:      fullPath,
 				IsGitRepo: isGitRepo,
+				IsBare:    isBare,
 			})
 		}
 	}
@@ -326,10 +331,12 @@ func (s *WorkspaceStore) discoverWorkspaces() ([]*Workspace, error) {
 			continue
 		}
 		isGitRepo := s.isGitRepository(expanded)
+		isBare := s.isBareRepository(expanded)
 		workspaces = append(workspaces, &Workspace{
 			Name:      filepath.Base(expanded),
 			Path:      expanded,
 			IsGitRepo: isGitRepo,
+			IsBare:    isBare,
 		})
 	}
 
@@ -378,8 +385,17 @@ func expandHome(path string) string {
 
 func (s *WorkspaceStore) isGitRepository(path string) bool {
 	info, err := s.fs.Stat(filepath.Join(path, ".git"))
-	if err != nil {
+	if err == nil && info.IsDir() {
+		return true
+	}
+	return s.isBareRepository(path)
+}
+
+func (s *WorkspaceStore) isBareRepository(path string) bool {
+	gitInfo, err := s.fs.Stat(filepath.Join(path, ".git"))
+	if err != nil || gitInfo.IsDir() {
 		return false
 	}
-	return info.IsDir()
+	bareInfo, err := s.fs.Stat(filepath.Join(path, ".bare"))
+	return err == nil && bareInfo.IsDir()
 }


### PR DESCRIPTION
## Summary

- **Bare repository pattern**: workspaces can use `.bare/` + `.git` file layout; worktrees land as flat subdirectories `{workspace}/{branch}/` instead of `.worktrees/{branch}/`
- **Migrate action**: `POST /{id}/migrate-bare` backs up the existing repo, clones `--bare`, writes a `.git` pointer file, and marks the workspace as bare in the DB; triggered via `m` in the workspace detail view
- **Worktree DB records**: `GitService.SetupWorktree` consolidates branch/worktree setup and always registers a `Worktree` DB record, fixing `CleanupBranch` which was leaving orphaned worktrees and failing to delete checked-out branches
- **Pull location fix**: `setupBranch` now pulls inside the base-branch worktree when it exists; for bare repos with no local worktree it uses `git fetch origin branch:branch` instead of pulling from the bare root (which has no working tree)
- **Default branch in picker**: `listBranches` reads `refs/remotes/origin/HEAD` (non-bare) or `HEAD` (bare) and prepends the default branch to the list if it isn't cloned locally

## Test plan

- [ ] Create a bare workspace (`git clone --bare <url> .bare`, write `.git` file) — workspace detail shows `Bare: yes`
- [ ] Create a non-bare workspace — workspace detail shows `Bare: no (press m to migrate)`, press `m`, verify `.bare/` exists and new sessions create worktrees at `{workspace}/{branch}/`
- [ ] Non-bare workspace: create/checkout sessions — worktrees still go to `.worktrees/` (no regression)
- [ ] Branch picker on a bare workspace where `main` is not checked out locally — `main` appears at the top of the list
- [ ] Delete a session — worktree and branch are cleaned up (no orphaned worktrees)
- [ ] `POST /{id}/migrate-bare` on already-bare workspace returns 400; on non-git workspace returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)