### PR TITLE
fix: extend deadlines for workspace bare migration

### DIFF
--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -380,12 +381,16 @@ func (c *client) deleteWorkspace(id uint) tea.Cmd {
 
 func (c *client) migrateWorkspaceToBare(id uint) tea.Cmd {
 	return func() tea.Msg {
-		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/workspaces/%d/migrate-bare", c.baseURL, id), nil)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/workspaces/%d/migrate-bare", c.baseURL, id), nil)
 		if err != nil {
 			return ErrMsg{err}
 		}
 
-		res, err := c.httpClient.Do(req)
+		httpClient := &http.Client{}
+		res, err := httpClient.Do(req)
 		if err != nil {
 			log.Printf("[ERROR] migrate workspace %d to bare: %v", id, err)
 			return ErrMsg{err}

--- a/internal/workspace/workspacecontroller.go
+++ b/internal/workspace/workspacecontroller.go
@@ -1,9 +1,11 @@
 package workspace
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/eleonorayaya/utena/internal/common"
 	"github.com/eleonorayaya/utena/internal/git"
@@ -234,7 +236,8 @@ func (c *WorkspaceController) CheckBranchExists(w http.ResponseWriter, r *http.R
 }
 
 func (c *WorkspaceController) MigrateWorkspaceToBare(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
+	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Minute)
+	defer cancel()
 	raw := chi.URLParam(r, "id")
 	id, err := strconv.ParseUint(raw, 10, 64)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Migrating a workspace to the bare pattern was timing out on large repos because the TUI's shared `http.Client` enforces a 10s timeout — `git clone --bare` for a big monorepo blows past that, the request gets cancelled, and the daemon kills the clone.
- TUI: switch the migrate call to `http.NewRequestWithContext` with a 5m deadline and a dedicated `http.Client{}` so the shared 10s ceiling no longer applies.
- Daemon: wrap the migrate handler's request context with a 6m timeout (just for this op). The daemon ceiling sits above the TUI ceiling so the client times out first rather than the server cutting off mid-clone.

## Test plan
- [ ] Trigger `m` (migrate to bare) on a small repo workspace — completes successfully as before.
- [ ] Trigger migrate on a large repo where the previous 10s timeout would fire — clone completes, workspace is marked bare.
- [ ] Confirm cancelling the TUI mid-migrate still cancels the daemon-side `git clone` (request context propagation preserved).
