### PR TITLE
feat(tui): force-delete sessions stuck in creating

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -49,6 +49,10 @@ type Session struct {
 	TmuxSession    *utmux.TmuxSession     `json:"tmux_session,omitempty" gorm:"foreignKey:TmuxSessionID"`
 }
 
+func (s Session) IsCreating() bool {
+	return s.Status == StatusCreating
+}
+
 func SanitizeTmuxName(name string) string {
 	r := strings.NewReplacer(
 		" ", "-",

--- a/internal/session/sessioncontroller.go
+++ b/internal/session/sessioncontroller.go
@@ -132,8 +132,9 @@ func (c *SessionController) DeleteSession(w http.ResponseWriter, r *http.Request
 	}
 
 	deleteBranch := r.URL.Query().Get("delete_branch") != "false"
+	force := r.URL.Query().Get("force") == "true"
 
-	if err := c.service.DeleteSession(ctx, id, deleteBranch, false); err != nil {
+	if err := c.service.DeleteSession(ctx, id, deleteBranch, force); err != nil {
 		common.RenderError(w, r, err)
 		return
 	}

--- a/internal/session/sessioncontroller.go
+++ b/internal/session/sessioncontroller.go
@@ -133,7 +133,7 @@ func (c *SessionController) DeleteSession(w http.ResponseWriter, r *http.Request
 
 	deleteBranch := r.URL.Query().Get("delete_branch") != "false"
 
-	if err := c.service.DeleteSession(ctx, id, deleteBranch); err != nil {
+	if err := c.service.DeleteSession(ctx, id, deleteBranch, false); err != nil {
 		common.RenderError(w, r, err)
 		return
 	}

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -596,7 +596,7 @@ func (s *SessionService) ActivateSession(ctx context.Context, id uint) (*Session
 	return session, nil
 }
 
-func (s *SessionService) DeleteSession(ctx context.Context, id uint, deleteBranch bool) error {
+func (s *SessionService) DeleteSession(ctx context.Context, id uint, deleteBranch bool, force bool) error {
 	session, err := s.store.GetByID(id)
 	if err != nil {
 		return err
@@ -606,7 +606,7 @@ func (s *SessionService) DeleteSession(ctx context.Context, id uint, deleteBranc
 		return ErrSessionAttached
 	}
 
-	if session.Status == StatusCreating {
+	if session.Status == StatusCreating && !force {
 		return common.NewInvalidRequest("cannot delete session while it is being created")
 	}
 

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -305,7 +305,7 @@ func TestSessionService_DeleteSession(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, retrieved.TmuxSessionID)
 
-	err = service.DeleteSession(ctx, retrieved.ID, true)
+	err = service.DeleteSession(ctx, retrieved.ID, true, false)
 	require.NoError(t, err)
 
 	retrieved, err = sessionStore.GetByID(session.ID)
@@ -317,9 +317,58 @@ func TestSessionService_DeleteSession_NotFound(t *testing.T) {
 	service, _, _, _, _, _ := setupSessionService(t)
 
 	ctx := context.Background()
-	err := service.DeleteSession(ctx, 99999, true)
+	err := service.DeleteSession(ctx, 99999, true, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not found")
+}
+
+func TestSessionService_DeleteSession_Creating_Blocked(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, _ := setupSessionService(t)
+
+	sess := &Session{
+		Name:        "stuck-session",
+		WorkspaceID: ws1ID,
+		Status:      StatusActive,
+		LastUsedAt:  time.Now(),
+	}
+
+	ctx := context.Background()
+	err := sessionStore.Add(sess)
+	require.NoError(t, err)
+
+	sess.Status = StatusCreating
+	err = sessionStore.Update(sess)
+	require.NoError(t, err)
+
+	err = service.DeleteSession(ctx, sess.ID, true, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot delete session while it is being created")
+}
+
+func TestSessionService_DeleteSession_Creating_Force(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, _ := setupSessionService(t)
+
+	sess := &Session{
+		Name:        "stuck-session",
+		WorkspaceID: ws1ID,
+		Status:      StatusActive,
+		LastUsedAt:  time.Now(),
+	}
+
+	ctx := context.Background()
+	err := sessionStore.Add(sess)
+	require.NoError(t, err)
+
+	sess.Status = StatusCreating
+	err = sessionStore.Update(sess)
+	require.NoError(t, err)
+
+	err = service.DeleteSession(ctx, sess.ID, true, true)
+	require.NoError(t, err)
+
+	retrieved, err := sessionStore.GetByID(sess.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusDeleted, retrieved.Status)
 }
 
 func initTestRepo(t *testing.T) string {

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -328,16 +328,12 @@ func TestSessionService_DeleteSession_Creating_Blocked(t *testing.T) {
 	sess := &Session{
 		Name:        "stuck-session",
 		WorkspaceID: ws1ID,
-		Status:      StatusActive,
+		Status:      StatusCreating,
 		LastUsedAt:  time.Now(),
 	}
 
 	ctx := context.Background()
 	err := sessionStore.Add(sess)
-	require.NoError(t, err)
-
-	sess.Status = StatusCreating
-	err = sessionStore.Update(sess)
 	require.NoError(t, err)
 
 	err = service.DeleteSession(ctx, sess.ID, true, false)
@@ -351,16 +347,12 @@ func TestSessionService_DeleteSession_Creating_Force(t *testing.T) {
 	sess := &Session{
 		Name:        "stuck-session",
 		WorkspaceID: ws1ID,
-		Status:      StatusActive,
+		Status:      StatusCreating,
 		LastUsedAt:  time.Now(),
 	}
 
 	ctx := context.Background()
 	err := sessionStore.Add(sess)
-	require.NoError(t, err)
-
-	sess.Status = StatusCreating
-	err = sessionStore.Update(sess)
 	require.NoError(t, err)
 
 	err = service.DeleteSession(ctx, sess.ID, true, true)

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -312,9 +312,13 @@ func (c *client) createSession(name string, workspaceID uint, branch string, bas
 	}
 }
 
-func (c *client) deleteSession(id uint) tea.Cmd {
+func (c *client) deleteSession(id uint, force bool) tea.Cmd {
 	return func() tea.Msg {
-		req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/sessions/%d", c.baseURL, id), nil)
+		url := fmt.Sprintf("%s/sessions/%d", c.baseURL, id)
+		if force {
+			url += "?force=true"
+		}
+		req, err := http.NewRequest(http.MethodDelete, url, nil)
 		if err != nil {
 			return ErrMsg{err}
 		}

--- a/internal/tui/provider/sessionsprovider.go
+++ b/internal/tui/provider/sessionsprovider.go
@@ -51,8 +51,8 @@ func PollSession(id uint) tea.Cmd {
 	return func() tea.Msg { return pollSessionIntentMsg{id: id} }
 }
 
-func DeleteSession(id uint) tea.Cmd {
-	return func() tea.Msg { return deleteSessionIntentMsg{id: id} }
+func DeleteSession(id uint, force bool) tea.Cmd {
+	return func() tea.Msg { return deleteSessionIntentMsg{id: id, force: force} }
 }
 
 func ArchiveSession(id uint) tea.Cmd {
@@ -80,7 +80,8 @@ type repairSessionIntentMsg struct {
 }
 
 type deleteSessionIntentMsg struct {
-	id uint
+	id    uint
+	force bool
 }
 
 type archiveSessionIntentMsg struct {
@@ -195,7 +196,7 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 		return p, p.client.switchTmuxSession(msg.tmuxSessionName)
 
 	case deleteSessionIntentMsg:
-		return p, p.client.deleteSession(msg.id)
+		return p, p.client.deleteSession(msg.id, msg.force)
 
 	case sessionDeletedMsg:
 		return p, p.client.fetchSessions()

--- a/internal/tui/sessiondetail/model.go
+++ b/internal/tui/sessiondetail/model.go
@@ -114,8 +114,9 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 
 	case key.Matches(msg, keys.Delete):
 		if pendingID == m.sess.ID {
+			force := m.sess.Status == session.StatusCreating
 			return m, tea.Batch(
-				provider.DeleteSession(m.sess.ID, false),
+				provider.DeleteSession(m.sess.ID, force),
 				router.Back(),
 			)
 		}

--- a/internal/tui/sessiondetail/model.go
+++ b/internal/tui/sessiondetail/model.go
@@ -114,9 +114,8 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 
 	case key.Matches(msg, keys.Delete):
 		if pendingID == m.sess.ID {
-			force := m.sess.Status == session.StatusCreating
 			return m, tea.Batch(
-				provider.DeleteSession(m.sess.ID, force),
+				provider.DeleteSession(m.sess.ID, m.sess.IsCreating()),
 				router.Back(),
 			)
 		}

--- a/internal/tui/sessiondetail/model.go
+++ b/internal/tui/sessiondetail/model.go
@@ -115,7 +115,7 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case key.Matches(msg, keys.Delete):
 		if pendingID == m.sess.ID {
 			return m, tea.Batch(
-				provider.DeleteSession(m.sess.ID),
+				provider.DeleteSession(m.sess.ID, false),
 				router.Back(),
 			)
 		}

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -161,7 +161,7 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 		}
 		if m.pendingDeleteID == item.session.ID {
 			m.pendingDeleteID = 0
-			return m, provider.DeleteSession(item.session.ID), true
+			return m, provider.DeleteSession(item.session.ID, false), true
 		}
 		m.pendingDeleteID = item.session.ID
 		return m, m.list.NewStatusMessage(fmt.Sprintf("press d again to close %s", item.displayName())), true

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -166,7 +166,7 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 		}
 		m.pendingDeleteID = item.session.ID
 		if item.session.Status == session.StatusCreating {
-			return m, m.list.NewStatusMessage(fmt.Sprintf("session is still creating — press d again to force delete %s", item.displayName())), true
+			return m, m.list.NewStatusMessage(forceDeleteMessage(item.displayName())), true
 		}
 		return m, m.list.NewStatusMessage(fmt.Sprintf("press d again to close %s", item.displayName())), true
 	}
@@ -175,4 +175,8 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 
 func (m Model) View() string {
 	return m.list.View()
+}
+
+func forceDeleteMessage(name string) string {
+	return fmt.Sprintf("session is still creating — press d again to force delete %s", name)
 }

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -161,11 +161,10 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 		}
 		if m.pendingDeleteID == item.session.ID {
 			m.pendingDeleteID = 0
-			force := item.session.Status == session.StatusCreating
-			return m, provider.DeleteSession(item.session.ID, force), true
+			return m, provider.DeleteSession(item.session.ID, item.session.IsCreating()), true
 		}
 		m.pendingDeleteID = item.session.ID
-		if item.session.Status == session.StatusCreating {
+		if item.session.IsCreating() {
 			return m, m.list.NewStatusMessage(forceDeleteMessage(item.displayName())), true
 		}
 		return m, m.list.NewStatusMessage(fmt.Sprintf("press d again to close %s", item.displayName())), true

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -161,9 +161,13 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 		}
 		if m.pendingDeleteID == item.session.ID {
 			m.pendingDeleteID = 0
-			return m, provider.DeleteSession(item.session.ID, false), true
+			force := item.session.Status == session.StatusCreating
+			return m, provider.DeleteSession(item.session.ID, force), true
 		}
 		m.pendingDeleteID = item.session.ID
+		if item.session.Status == session.StatusCreating {
+			return m, m.list.NewStatusMessage(fmt.Sprintf("session is still creating — press d again to force delete %s", item.displayName())), true
+		}
 		return m, m.list.NewStatusMessage(fmt.Sprintf("press d again to close %s", item.displayName())), true
 	}
 	return m, nil, false

--- a/internal/tui/sessionlist/sessionlist_test.go
+++ b/internal/tui/sessionlist/sessionlist_test.go
@@ -30,7 +30,7 @@ func TestSessionList_Delete_Creating_FirstPress_ShowsForceMessage(t *testing.T) 
 	assert.True(t, handled)
 	assert.NotNil(t, cmd)
 	assert.Equal(t, uint(1), result.pendingDeleteID)
-	assert.Contains(t, forceDeleteMessage("stuck"), "force delete")
+	assert.Equal(t, "session is still creating — press d again to force delete stuck", forceDeleteMessage("stuck"))
 }
 
 func TestSessionList_Delete_Creating_SecondPress_ForceDeletes(t *testing.T) {

--- a/internal/tui/sessionlist/sessionlist_test.go
+++ b/internal/tui/sessionlist/sessionlist_test.go
@@ -30,6 +30,7 @@ func TestSessionList_Delete_Creating_FirstPress_ShowsForceMessage(t *testing.T) 
 	assert.True(t, handled)
 	assert.NotNil(t, cmd)
 	assert.Equal(t, uint(1), result.pendingDeleteID)
+	assert.Contains(t, forceDeleteMessage("stuck"), "force delete")
 }
 
 func TestSessionList_Delete_Creating_SecondPress_ForceDeletes(t *testing.T) {

--- a/internal/tui/sessionlist/sessionlist_test.go
+++ b/internal/tui/sessionlist/sessionlist_test.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/eleonorayaya/utena/internal/session"
 	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
 )
 
 func TestSessionList_InfoKey_NavigatesToDetail(t *testing.T) {
@@ -17,4 +18,29 @@ func TestSessionList_InfoKey_NavigatesToDetail(t *testing.T) {
 	_, cmd, handled := m.OnKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("i")})
 	assert.True(t, handled)
 	assert.NotNil(t, cmd)
+}
+
+func TestSessionList_Delete_Creating_FirstPress_ShowsForceMessage(t *testing.T) {
+	m := New()
+	m.list.SetItems([]list.Item{
+		sessionItem{session: session.Session{Model: gorm.Model{ID: 1}, Name: "stuck", Status: session.StatusCreating}},
+	})
+
+	result, cmd, handled := m.OnKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	assert.True(t, handled)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, uint(1), result.pendingDeleteID)
+}
+
+func TestSessionList_Delete_Creating_SecondPress_ForceDeletes(t *testing.T) {
+	m := New()
+	m.list.SetItems([]list.Item{
+		sessionItem{session: session.Session{Model: gorm.Model{ID: 1}, Name: "stuck", Status: session.StatusCreating}},
+	})
+	m.pendingDeleteID = 1
+
+	result, cmd, handled := m.OnKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	assert.True(t, handled)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, uint(0), result.pendingDeleteID)
 }


### PR DESCRIPTION
## Summary
- Sessions stuck in `StatusCreating` could not be deleted — the service blocked it with no escape hatch
- Adds a `force` flag through the full stack (service → controller → HTTP client → provider → TUI) that bypasses the creating guard while keeping the `IsAttached` guard intact
- TUI `d`+`d` flow shows a distinct warning on first press for creating sessions and sends `?force=true` on second press, in both session list and session detail views

## Test plan
- [ ] Start the daemon, create a session, kill it while it's still in `StatusCreating` (or reproduce via a stuck session), open the TUI
- [ ] Select the stuck session, press `d` — verify status bar shows "session is still creating — press d again to force delete"
- [ ] Press `d` again — verify session disappears from the list
- [ ] Verify normal sessions still show the normal "press d again to close" confirmation message
- [ ] `task test -- ./internal/...` — all tests pass
