### PR TITLE
feat: auto-bootstrap .claude/settings.local.json for bare workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out/
 .task/
 *.log
 .worktrees/
+.claude/settings.local.json

--- a/internal/claudesettings/claudesettings.go
+++ b/internal/claudesettings/claudesettings.go
@@ -1,0 +1,34 @@
+package claudesettings
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+)
+
+type settingsLocal struct {
+	Sandbox struct {
+		Filesystem struct {
+			AllowWrite []string `json:"allowWrite"`
+		} `json:"filesystem"`
+	} `json:"sandbox"`
+}
+
+func defaultSettingsJSON(workspacePath string) ([]byte, error) {
+	var s settingsLocal
+	s.Sandbox.Filesystem.AllowWrite = []string{filepath.Join(workspacePath, ".git")}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal settings: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func EnsureWorkspaceRoot(workspacePath string) error {
+	return errors.New("not implemented")
+}
+
+func LinkWorktree(workspacePath, worktreePath string) error {
+	return errors.New("not implemented")
+}

--- a/internal/claudesettings/claudesettings.go
+++ b/internal/claudesettings/claudesettings.go
@@ -39,6 +39,35 @@ func settingsFileExists(path string) (bool, error) {
 	return false, fmt.Errorf("stat %s: %w", filepath.Base(path), err)
 }
 
+func mergeAllowWrite(data []byte, gitPath string) ([]byte, bool, error) {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, false, fmt.Errorf("parse settings: %w", err)
+	}
+	sandbox, _ := raw["sandbox"].(map[string]any)
+	if sandbox == nil {
+		sandbox = make(map[string]any)
+		raw["sandbox"] = sandbox
+	}
+	filesystem, _ := sandbox["filesystem"].(map[string]any)
+	if filesystem == nil {
+		filesystem = make(map[string]any)
+		sandbox["filesystem"] = filesystem
+	}
+	allowWrite, _ := filesystem["allowWrite"].([]any)
+	for _, entry := range allowWrite {
+		if s, ok := entry.(string); ok && s == gitPath {
+			return nil, false, nil
+		}
+	}
+	filesystem["allowWrite"] = append(allowWrite, gitPath)
+	out, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return nil, false, fmt.Errorf("marshal settings: %w", err)
+	}
+	return append(out, '\n'), true, nil
+}
+
 func EnsureWorkspaceRoot(workspacePath string) error {
 	claudeDir := filepath.Join(workspacePath, ".claude")
 	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
@@ -49,7 +78,19 @@ func EnsureWorkspaceRoot(workspacePath string) error {
 	if err != nil {
 		return err
 	}
+	gitPath := filepath.Join(workspacePath, ".git")
 	if exists {
+		data, err := os.ReadFile(settingsPath)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", settingsFileName, err)
+		}
+		merged, changed, err := mergeAllowWrite(data, gitPath)
+		if err != nil || !changed {
+			return err
+		}
+		if err := os.WriteFile(settingsPath, merged, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", settingsFileName, err)
+		}
 		return nil
 	}
 	data, err := defaultSettingsJSON(workspacePath)

--- a/internal/claudesettings/claudesettings.go
+++ b/internal/claudesettings/claudesettings.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 )
 
+const settingsFileName = "settings.local.json"
+
 type settingsLocal struct {
 	Sandbox struct {
 		Filesystem struct {
@@ -26,23 +28,36 @@ func defaultSettingsJSON(workspacePath string) ([]byte, error) {
 	return append(data, '\n'), nil
 }
 
+func settingsFileExists(path string) (bool, error) {
+	_, err := os.Lstat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, fmt.Errorf("stat %s: %w", filepath.Base(path), err)
+}
+
 func EnsureWorkspaceRoot(workspacePath string) error {
 	claudeDir := filepath.Join(workspacePath, ".claude")
 	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
 		return fmt.Errorf("create .claude dir: %w", err)
 	}
-	settingsPath := filepath.Join(claudeDir, "settings.local.json")
-	if _, err := os.Lstat(settingsPath); err == nil {
+	settingsPath := filepath.Join(claudeDir, settingsFileName)
+	exists, err := settingsFileExists(settingsPath)
+	if err != nil {
+		return err
+	}
+	if exists {
 		return nil
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("stat settings.local.json: %w", err)
 	}
 	data, err := defaultSettingsJSON(workspacePath)
 	if err != nil {
 		return err
 	}
 	if err := os.WriteFile(settingsPath, data, 0o644); err != nil {
-		return fmt.Errorf("write settings.local.json: %w", err)
+		return fmt.Errorf("write %s: %w", settingsFileName, err)
 	}
 	return nil
 }
@@ -52,15 +67,15 @@ func LinkWorktree(workspacePath, worktreePath string) error {
 	if err := os.MkdirAll(dstDir, 0o755); err != nil {
 		return fmt.Errorf("create worktree .claude dir: %w", err)
 	}
-	dst := filepath.Join(dstDir, "settings.local.json")
-
-	if _, err := os.Lstat(dst); err == nil {
-		return nil
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("stat worktree settings.local.json: %w", err)
+	dst := filepath.Join(dstDir, settingsFileName)
+	exists, err := settingsFileExists(dst)
+	if err != nil {
+		return err
 	}
-
-	src := filepath.Join(workspacePath, ".claude", "settings.local.json")
+	if exists {
+		return nil
+	}
+	src := filepath.Join(workspacePath, ".claude", settingsFileName)
 	rel, err := filepath.Rel(dstDir, src)
 	if err != nil {
 		return fmt.Errorf("compute relative path: %w", err)

--- a/internal/claudesettings/claudesettings.go
+++ b/internal/claudesettings/claudesettings.go
@@ -48,5 +48,25 @@ func EnsureWorkspaceRoot(workspacePath string) error {
 }
 
 func LinkWorktree(workspacePath, worktreePath string) error {
-	return errors.New("not implemented")
+	dstDir := filepath.Join(worktreePath, ".claude")
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		return fmt.Errorf("create worktree .claude dir: %w", err)
+	}
+	dst := filepath.Join(dstDir, "settings.local.json")
+
+	if _, err := os.Lstat(dst); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat worktree settings.local.json: %w", err)
+	}
+
+	src := filepath.Join(workspacePath, ".claude", "settings.local.json")
+	rel, err := filepath.Rel(dstDir, src)
+	if err != nil {
+		return fmt.Errorf("compute relative path: %w", err)
+	}
+	if err := os.Symlink(rel, dst); err != nil {
+		return fmt.Errorf("create symlink: %w", err)
+	}
+	return nil
 }

--- a/internal/claudesettings/claudesettings.go
+++ b/internal/claudesettings/claudesettings.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 )
 
@@ -26,7 +27,24 @@ func defaultSettingsJSON(workspacePath string) ([]byte, error) {
 }
 
 func EnsureWorkspaceRoot(workspacePath string) error {
-	return errors.New("not implemented")
+	claudeDir := filepath.Join(workspacePath, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		return fmt.Errorf("create .claude dir: %w", err)
+	}
+	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+	if _, err := os.Lstat(settingsPath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat settings.local.json: %w", err)
+	}
+	data, err := defaultSettingsJSON(workspacePath)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(settingsPath, data, 0o644); err != nil {
+		return fmt.Errorf("write settings.local.json: %w", err)
+	}
+	return nil
 }
 
 func LinkWorktree(workspacePath, worktreePath string) error {

--- a/internal/claudesettings/claudesettings_test.go
+++ b/internal/claudesettings/claudesettings_test.go
@@ -1,0 +1,68 @@
+package claudesettings
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureWorkspaceRoot_CreatesFileWhenMissing(t *testing.T) {
+	root := t.TempDir()
+
+	if err := EnsureWorkspaceRoot(root); err != nil {
+		t.Fatalf("EnsureWorkspaceRoot: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, ".claude", "settings.local.json"))
+	if err != nil {
+		t.Fatalf("read settings.local.json: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatalf("expected non-empty settings.local.json")
+	}
+	want, err := defaultSettingsJSON(root)
+	if err != nil {
+		t.Fatalf("defaultSettingsJSON: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("contents do not match expected:\ngot:  %s\nwant: %s", got, want)
+	}
+}
+
+func TestEnsureWorkspaceRoot_DoesNotOverwriteExisting(t *testing.T) {
+	root := t.TempDir()
+	claudeDir := filepath.Join(root, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	custom := []byte(`{"custom": true}`)
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), custom, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureWorkspaceRoot(root); err != nil {
+		t.Fatalf("EnsureWorkspaceRoot: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(claudeDir, "settings.local.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(custom) {
+		t.Fatalf("user file was overwritten: %s", got)
+	}
+}
+
+func TestEnsureWorkspaceRoot_CreatesClaudeDir(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureWorkspaceRoot(root); err != nil {
+		t.Fatalf("EnsureWorkspaceRoot: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(root, ".claude"))
+	if err != nil {
+		t.Fatalf("stat .claude: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf(".claude is not a directory")
+	}
+}

--- a/internal/claudesettings/claudesettings_test.go
+++ b/internal/claudesettings/claudesettings_test.go
@@ -66,3 +66,80 @@ func TestEnsureWorkspaceRoot_CreatesClaudeDir(t *testing.T) {
 		t.Fatalf(".claude is not a directory")
 	}
 }
+
+func TestLinkWorktree_CreatesRelativeSymlink(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureWorkspaceRoot(root); err != nil {
+		t.Fatal(err)
+	}
+	worktree := filepath.Join(root, "feature-x")
+	if err := os.Mkdir(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := LinkWorktree(root, worktree); err != nil {
+		t.Fatalf("LinkWorktree: %v", err)
+	}
+
+	linkPath := filepath.Join(worktree, ".claude", "settings.local.json")
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	if filepath.IsAbs(target) {
+		t.Fatalf("target should be relative, got %q", target)
+	}
+	resolved := filepath.Join(filepath.Dir(linkPath), target)
+	rootSettings := filepath.Join(root, ".claude", "settings.local.json")
+	gotAbs, _ := filepath.EvalSymlinks(resolved)
+	wantAbs, _ := filepath.EvalSymlinks(rootSettings)
+	if gotAbs != wantAbs {
+		t.Fatalf("symlink resolves to %q, want %q", gotAbs, wantAbs)
+	}
+}
+
+func TestLinkWorktree_PreservesExistingFile(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureWorkspaceRoot(root); err != nil {
+		t.Fatal(err)
+	}
+	worktree := filepath.Join(root, "feature-y")
+	wtClaude := filepath.Join(worktree, ".claude")
+	if err := os.MkdirAll(wtClaude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	custom := []byte(`{"per-worktree": true}`)
+	settingsPath := filepath.Join(wtClaude, "settings.local.json")
+	if err := os.WriteFile(settingsPath, custom, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := LinkWorktree(root, worktree); err != nil {
+		t.Fatalf("LinkWorktree: %v", err)
+	}
+
+	got, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(custom) {
+		t.Fatalf("regular file was clobbered")
+	}
+}
+
+func TestLinkWorktree_IdempotentOnExistingCorrectSymlink(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureWorkspaceRoot(root); err != nil {
+		t.Fatal(err)
+	}
+	worktree := filepath.Join(root, "feature-z")
+	if err := os.Mkdir(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := LinkWorktree(root, worktree); err != nil {
+		t.Fatal(err)
+	}
+	if err := LinkWorktree(root, worktree); err != nil {
+		t.Fatalf("second call should be no-op: %v", err)
+	}
+}

--- a/internal/claudesettings/claudesettings_test.go
+++ b/internal/claudesettings/claudesettings_test.go
@@ -1,6 +1,7 @@
 package claudesettings
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,14 +30,13 @@ func TestEnsureWorkspaceRoot_CreatesFileWhenMissing(t *testing.T) {
 	}
 }
 
-func TestEnsureWorkspaceRoot_DoesNotOverwriteExisting(t *testing.T) {
+func TestEnsureWorkspaceRoot_MergesIntoExistingSettings(t *testing.T) {
 	root := t.TempDir()
 	claudeDir := filepath.Join(root, ".claude")
 	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	custom := []byte(`{"custom": true}`)
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), custom, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), []byte(`{"custom": true}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -44,12 +44,61 @@ func TestEnsureWorkspaceRoot_DoesNotOverwriteExisting(t *testing.T) {
 		t.Fatalf("EnsureWorkspaceRoot: %v", err)
 	}
 
-	got, err := os.ReadFile(filepath.Join(claudeDir, "settings.local.json"))
+	raw, err := os.ReadFile(filepath.Join(claudeDir, "settings.local.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(got) != string(custom) {
-		t.Fatalf("user file was overwritten: %s", got)
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if out["custom"] != true {
+		t.Fatalf("existing key 'custom' was removed")
+	}
+	sandbox, _ := out["sandbox"].(map[string]any)
+	fs, _ := sandbox["filesystem"].(map[string]any)
+	allowWrite, _ := fs["allowWrite"].([]any)
+	gitPath := filepath.Join(root, ".git")
+	found := false
+	for _, v := range allowWrite {
+		if v == gitPath {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("allowWrite missing %q; got %v", gitPath, allowWrite)
+	}
+}
+
+func TestEnsureWorkspaceRoot_DoesNotDuplicateAllowWrite(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureWorkspaceRoot(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureWorkspaceRoot(root); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(root, ".claude", "settings.local.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	sandbox, _ := out["sandbox"].(map[string]any)
+	fs, _ := sandbox["filesystem"].(map[string]any)
+	allowWrite, _ := fs["allowWrite"].([]any)
+	gitPath := filepath.Join(root, ".git")
+	count := 0
+	for _, v := range allowWrite {
+		if v == gitPath {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected git path once in allowWrite, got %d times", count)
 	}
 }
 

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/eleonorayaya/utena/internal/claudesettings"
 	"github.com/eleonorayaya/utena/internal/common"
 	"github.com/eleonorayaya/utena/internal/eventbus"
 	"github.com/eleonorayaya/utena/internal/git"
@@ -415,6 +416,17 @@ func (s *SessionService) setupWorktreeInit(ctx context.Context, sess *Session, w
 	for _, script := range scripts {
 		if err := s.runScript(ctx, script, worktreePath, env); err != nil {
 			slog.Warn("worktree setup script failed", "script", script, "error", err)
+			warnings = append(warnings, err.Error())
+		}
+	}
+
+	if ws != nil && ws.IsBare {
+		if err := claudesettings.EnsureWorkspaceRoot(ws.Path); err != nil {
+			slog.Warn("ensure workspace claude settings failed", "workspace", ws.Name, "error", err)
+			warnings = append(warnings, err.Error())
+		}
+		if err := claudesettings.LinkWorktree(ws.Path, worktreePath); err != nil {
+			slog.Warn("link worktree claude settings failed", "worktree", worktreePath, "error", err)
 			warnings = append(warnings, err.Error())
 		}
 	}

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -424,8 +424,7 @@ func (s *SessionService) setupWorktreeInit(ctx context.Context, sess *Session, w
 		if err := claudesettings.EnsureWorkspaceRoot(ws.Path); err != nil {
 			slog.Warn("ensure workspace claude settings failed", "workspace", ws.Name, "error", err)
 			warnings = append(warnings, err.Error())
-		}
-		if err := claudesettings.LinkWorktree(ws.Path, worktreePath); err != nil {
+		} else if err := claudesettings.LinkWorktree(ws.Path, worktreePath); err != nil {
 			slog.Warn("link worktree claude settings failed", "worktree", worktreePath, "error", err)
 			warnings = append(warnings, err.Error())
 		}

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -1182,3 +1182,62 @@ func TestSessionService_RepairSession_ClearsWarning(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, retrieved.StatusError)
 }
+
+func setupBareWorktreeSessionService(t *testing.T, configDir string) (*SessionService, *SessionStore, *utmux.MockRunner, uint, string) {
+	t.Helper()
+
+	repoPath := initTestRepo(t)
+
+	database := setupTestDB(t)
+	gitService := git.NewGitService(database)
+	ctx := context.Background()
+	require.NoError(t, gitService.MigrateToBare(ctx, repoPath))
+
+	bus := eventbus.NewEventBus()
+	sessionStore := NewSessionStore(database)
+	workspaceStore := workspace.NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
+	wsGit := &workspace.Workspace{Name: "git-repo", Path: repoPath, IsGitRepo: true, IsBare: true}
+	workspaceStore.Add(wsGit)
+
+	mock := utmux.NewMockRunner()
+	tmuxService := createTmuxService(t, database, mock, bus)
+	workspaceService := workspace.NewWorkspaceService(workspaceStore)
+	dismissedPRStore := NewDismissedPRStore(database)
+	sessionActionStore := NewSessionActionStore(database)
+	service := NewSessionService(sessionStore, dismissedPRStore, sessionActionStore, workspaceService, gitService, tmuxService, bus, "eqt/", configDir)
+	return service, sessionStore, mock, wsGit.ID, repoPath
+}
+
+func TestRunSetup_BareWorkspace_LinksClaudeSettings(t *testing.T) {
+	service, sessionStore, _, wsID, repoPath := setupBareWorktreeSessionService(t, t.TempDir())
+
+	session := &Session{
+		Name:        "my-feature",
+		WorkspaceID: wsID,
+	}
+
+	ctx := context.Background()
+	err := service.CreateSession(ctx, session, "", "main", true)
+	require.NoError(t, err)
+
+	waitForStatus(t, sessionStore, session.ID, StatusActive, 5*time.Second)
+
+	worktreePath := filepath.Join(repoPath, "eqt-my-feature")
+
+	rootSettings := filepath.Join(repoPath, ".claude", "settings.local.json")
+	data, err := os.ReadFile(rootSettings)
+	require.NoError(t, err, "workspace root settings.local.json should exist")
+	require.NotEmpty(t, data)
+
+	linkPath := filepath.Join(worktreePath, ".claude", "settings.local.json")
+	target, err := os.Readlink(linkPath)
+	require.NoError(t, err, "worktree settings.local.json should be a symlink")
+	require.False(t, filepath.IsAbs(target), "symlink target should be relative, got %q", target)
+
+	resolved := filepath.Join(filepath.Dir(linkPath), target)
+	gotAbs, err := filepath.EvalSymlinks(resolved)
+	require.NoError(t, err)
+	wantAbs, err := filepath.EvalSymlinks(rootSettings)
+	require.NoError(t, err)
+	require.Equal(t, wantAbs, gotAbs, "symlink should resolve to workspace root settings")
+}

--- a/internal/workspace/workspacecontroller.go
+++ b/internal/workspace/workspacecontroller.go
@@ -2,9 +2,11 @@ package workspace
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 
+	"github.com/eleonorayaya/utena/internal/claudesettings"
 	"github.com/eleonorayaya/utena/internal/common"
 	"github.com/eleonorayaya/utena/internal/git"
 	"github.com/go-chi/chi/v5"
@@ -273,6 +275,11 @@ func (c *WorkspaceController) MigrateWorkspaceToBare(w http.ResponseWriter, r *h
 	if err := c.service.MarkAsBare(ctx, uint(id)); err != nil {
 		common.RenderError(w, r, err)
 		return
+	}
+
+	if err := claudesettings.EnsureWorkspaceRoot(ws.Path); err != nil {
+		slog.Warn("failed to bootstrap claude settings after bare migration",
+			"workspace", ws.Name, "error", err)
 	}
 
 	render.NoContent(w, r)

--- a/internal/workspace/workspacerouter_test.go
+++ b/internal/workspace/workspacerouter_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -433,4 +434,21 @@ func TestWorkspaceRouter_CheckBranchExists_MissingName(t *testing.T) {
 	router.Routes().ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestWorkspaceRouter_MigrateToBare_BootstrapsClaudeSettings(t *testing.T) {
+	repoPath := initTestRepoWithOrigin(t)
+	router, ws := setupBranchRouter(t, repoPath)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/%d/migrate-bare", ws.ID), nil)
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+
+	settingsPath := filepath.Join(repoPath, ".claude", "settings.local.json")
+	data, err := os.ReadFile(settingsPath)
+	require.NoError(t, err, "settings.local.json should exist after bare migration")
+	require.NotEmpty(t, data)
 }


### PR DESCRIPTION
## Summary

- New \`internal/claudesettings\` package with \`EnsureWorkspaceRoot\` and \`LinkWorktree\`
- \`EnsureWorkspaceRoot\`: creates \`settings.local.json\` with \`sandbox.filesystem.allowWrite\` for the workspace \`.git\` path; if the file already exists, merges the entry in without touching other settings
- \`LinkWorktree\`: creates a relative symlink from the worktree's \`.claude/settings.local.json\` to the workspace root's
- \`MigrateWorkspaceToBare\` calls \`EnsureWorkspaceRoot\` after migration
- \`setupWorktreeInit\` calls \`EnsureWorkspaceRoot\` + \`LinkWorktree\` on every new bare-workspace worktree

## Test Plan

- [x] \`task test\` passes
- [x] Manual: workspace root with \`{}\` gets \`allowWrite\` merged in on session creation
- [x] Manual: new worktree gets a relative symlink (\`../../.claude/settings.local.json\`)
- [ ] Manual: pre-existing user-managed settings in a worktree are left untouched
- [ ] Manual: permission failure on \`.claude/\` dir surfaces as session warning, session still reaches Active

🤖 Generated with [Claude Code](https://claude.com/claude-code)