### PR TITLE
fix(session,tmux): timeout setup, serialize tmux ops, instrument

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/eleonorayaya/utena/internal/api"
+	slogctx "github.com/veqryn/slog-context"
 )
 
 func main() {
@@ -18,7 +19,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := slog.New(slogctx.NewHandler(slog.NewTextHandler(os.Stdout, nil), nil))
 	slog.SetDefault(logger)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	github.com/veqryn/slog-context v0.9.0
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.1
 )
@@ -29,6 +30,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/go-chi/httplog/v3 v3.3.0 h1:Gr6Y7nSzbpyCyRwKPOVKjDH3BH6TH5uvRNDsTZWDp
 github.com/go-chi/httplog/v3 v3.3.0/go.mod h1:N/J1l5l1fozUrqIVuT8Z/HzNeSy8TF2EFyokPLe6y2w=
 github.com/go-chi/render v1.0.3 h1:AsXqd2a1/INaIfUSKq3G5uA8weYx20FOsM7uSoCyyt4=
 github.com/go-chi/render v1.0.3/go.mod h1:/gr3hVkmYR0YlEy3LxCuVRFzEu9Ruok+gFqbIofjao0=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
@@ -84,6 +86,8 @@ github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/veqryn/slog-context v0.9.0 h1:VNXHBWufRGfKiumi7cYoh7p2iElquZ4v8AnAumFOhEI=
+github.com/veqryn/slog-context v0.9.0/go.mod h1:l953waOLsWW6hArZeJDGGKZYLrsOIPBeJ/QQnOA8RU0=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -16,11 +16,37 @@ import (
 	"github.com/eleonorayaya/utena/internal/git"
 	utmux "github.com/eleonorayaya/utena/internal/tmux"
 	"github.com/eleonorayaya/utena/internal/workspace"
+	slogctx "github.com/veqryn/slog-context"
 )
 
 type SetupWarning struct{ Message string }
 
 func (w SetupWarning) Error() string { return w.Message }
+
+const defaultSetupTimeout = 5 * time.Minute
+
+func traceOp(ctx context.Context, op string, fn func() error, attrs ...any) error {
+	opAttrs := append([]any{"op", op}, attrs...)
+	slog.InfoContext(ctx, "setup op: start", opAttrs...)
+	start := time.Now()
+	err := fn()
+	doneAttrs := append([]any{"op", op, "duration_ms", time.Since(start).Milliseconds()}, attrs...)
+	if err != nil {
+		doneAttrs = append(doneAttrs, "error", err.Error())
+	}
+	slog.InfoContext(ctx, "setup op: done", doneAttrs...)
+	return err
+}
+
+func tracedOp[T any](ctx context.Context, op string, fn func() (T, error), attrs ...any) (T, error) {
+	var v T
+	err := traceOp(ctx, op, func() error {
+		var e error
+		v, e = fn()
+		return e
+	}, attrs...)
+	return v, err
+}
 
 type SessionService struct {
 	store              *SessionStore
@@ -32,6 +58,7 @@ type SessionService struct {
 	eventBus           eventbus.EventBus
 	branchPrefix       string
 	configDir          string
+	setupTimeout       time.Duration
 }
 
 func NewSessionService(store *SessionStore, dismissedPRStore *DismissedPRStore, sessionActionStore *SessionActionStore, workspaceService *workspace.WorkspaceService, gitService *git.GitService, tmuxService *utmux.TmuxService, bus eventbus.EventBus, branchPrefix string, configDir string) *SessionService {
@@ -45,6 +72,7 @@ func NewSessionService(store *SessionStore, dismissedPRStore *DismissedPRStore, 
 		eventBus:           bus,
 		branchPrefix:       branchPrefix,
 		configDir:          configDir,
+		setupTimeout:       defaultSetupTimeout,
 	}
 }
 
@@ -194,12 +222,39 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, br
 }
 
 func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace, tmuxName string, branchName string, baseBranchName string, createWorktree bool) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), s.setupTimeout)
+	defer cancel()
 
 	sess, err := s.store.GetByID(sessionID)
 	if err != nil {
 		slog.Error("runSetup: failed to load session", "id", sessionID, "error", err)
 		return
+	}
+
+	wsName := ""
+	if ws != nil {
+		wsName = ws.Name
+	}
+	ctx = slogctx.Append(ctx,
+		"session", sess.ID,
+		"ws", wsName,
+		"branch", branchName,
+		"base_branch", baseBranchName,
+	)
+	slog.InfoContext(ctx, "session setup: start", "tmux", tmuxName, "create_worktree", createWorktree, "timeout", s.setupTimeout)
+	setupStart := time.Now()
+	defer func() {
+		slog.InfoContext(ctx, "session setup: done", "status", sess.Status, "duration_ms", time.Since(setupStart).Milliseconds())
+	}()
+
+	markBroken := func(stage string, err error) {
+		sess.Status = StatusBroken
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			sess.StatusError = fmt.Sprintf("%s timed out after %s", stage, s.setupTimeout)
+		} else {
+			sess.StatusError = fmt.Sprintf("%s failed: %v", stage, err)
+		}
+		s.store.Update(sess)
 	}
 
 	var worktreeCreated bool
@@ -215,9 +270,7 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace, tmuxN
 				sess.StatusError = w.Message
 				s.store.Update(sess)
 			} else {
-				sess.Status = StatusBroken
-				sess.StatusError = fmt.Sprintf("branch setup failed: %v", err)
-				s.store.Update(sess)
+				markBroken("branch setup", err)
 				return
 			}
 		}
@@ -227,7 +280,9 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace, tmuxN
 			finalBranchName = s.branchPrefix + sess.Name
 		}
 		if ws.RepoID != nil {
-			branch, err := s.gitService.FindOrCreateBranch(ctx, finalBranchName, *ws.RepoID)
+			branch, err := tracedOp(ctx, "find-or-create-branch", func() (*git.Branch, error) {
+				return s.gitService.FindOrCreateBranch(ctx, finalBranchName, *ws.RepoID)
+			}, "name", finalBranchName)
 			if err != nil {
 				slog.Warn("failed to create branch record", "branch", finalBranchName, "error", err)
 			} else {
@@ -239,9 +294,7 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace, tmuxN
 		if createWorktree {
 			created, wtPath, err := s.setupWorktree(ctx, sess, ws, branchName, baseBranchName)
 			if err != nil {
-				sess.Status = StatusBroken
-				sess.StatusError = fmt.Sprintf("worktree setup failed: %v", err)
-				s.store.Update(sess)
+				markBroken("worktree setup", err)
 				return
 			}
 			worktreeCreated = created
@@ -254,9 +307,7 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace, tmuxN
 	}
 
 	if err := s.setupTmux(ctx, sess, tmuxName, worktreePath); err != nil {
-		sess.Status = StatusBroken
-		sess.StatusError = fmt.Sprintf("tmux setup failed: %v", err)
-		s.store.Update(sess)
+		markBroken("tmux setup", err)
 		return
 	}
 
@@ -273,13 +324,17 @@ func (s *SessionService) setupBranch(ctx context.Context, ws *workspace.Workspac
 		pullBranch = baseBranchName
 	}
 
-	hasRemote, err := s.gitService.HasRemoteBranch(ctx, ws.Path, pullBranch)
+	hasRemote, err := tracedOp(ctx, "git ls-remote", func() (bool, error) {
+		return s.gitService.HasRemoteBranch(ctx, ws.Path, pullBranch)
+	}, "branch", pullBranch)
 	if err != nil {
 		return fmt.Errorf("failed to check remote branch %q: %v", pullBranch, err)
 	}
 
 	if !hasRemote {
-		hasLocal, err := s.gitService.HasBranch(ctx, ws.Path, pullBranch)
+		hasLocal, err := tracedOp(ctx, "git rev-parse", func() (bool, error) {
+			return s.gitService.HasBranch(ctx, ws.Path, pullBranch)
+		}, "branch", pullBranch)
 		if err != nil {
 			return fmt.Errorf("failed to check local branch %q: %v", pullBranch, err)
 		}
@@ -292,7 +347,9 @@ func (s *SessionService) setupBranch(ctx context.Context, ws *workspace.Workspac
 	checkPath := s.gitService.WorktreePath(ws.Path, pullBranch)
 	if _, err := os.Stat(checkPath); os.IsNotExist(err) {
 		if ws.IsBare {
-			if err := s.gitService.Fetch(ctx, ws.Path, pullBranch); err != nil {
+			if err := traceOp(ctx, "git fetch (bare)", func() error {
+				return s.gitService.Fetch(ctx, ws.Path, pullBranch)
+			}, "branch", pullBranch); err != nil {
 				return SetupWarning{fmt.Sprintf("branch not fetched: %v", err)}
 			}
 			return nil
@@ -300,7 +357,9 @@ func (s *SessionService) setupBranch(ctx context.Context, ws *workspace.Workspac
 		checkPath = ws.Path
 	}
 
-	dirty, err := s.gitService.IsDirty(ctx, checkPath)
+	dirty, err := tracedOp(ctx, "git status (dirty check)", func() (bool, error) {
+		return s.gitService.IsDirty(ctx, checkPath)
+	}, "path", checkPath)
 	if err != nil {
 		return fmt.Errorf("failed to check dirty state for %q: %v", pullBranch, err)
 	}
@@ -308,7 +367,9 @@ func (s *SessionService) setupBranch(ctx context.Context, ws *workspace.Workspac
 		return SetupWarning{fmt.Sprintf("branch not pulled: %q has uncommitted changes", pullBranch)}
 	}
 
-	if err := s.gitService.Pull(ctx, checkPath, pullBranch); err != nil {
+	if err := traceOp(ctx, "git pull", func() error {
+		return s.gitService.Pull(ctx, checkPath, pullBranch)
+	}, "branch", pullBranch, "path", checkPath); err != nil {
 		return SetupWarning{fmt.Sprintf("branch not pulled: %v", err)}
 	}
 
@@ -329,7 +390,16 @@ func (s *SessionService) setupWorktree(ctx context.Context, sess *Session, ws *w
 		repoID = *ws.RepoID
 	}
 
-	return s.gitService.SetupWorktree(ctx, ws.Path, finalBranchName, baseBranchName, branchID, repoID)
+	var (
+		created bool
+		path    string
+	)
+	err := traceOp(ctx, "git worktree add", func() error {
+		var e error
+		created, path, e = s.gitService.SetupWorktree(ctx, ws.Path, finalBranchName, baseBranchName, branchID, repoID)
+		return e
+	}, "branch", finalBranchName, "base", baseBranchName)
+	return created, path, err
 }
 
 func (s *SessionService) setupTmux(ctx context.Context, sess *Session, tmuxName string, worktreePath string) error {
@@ -339,11 +409,14 @@ func (s *SessionService) setupTmux(ctx context.Context, sess *Session, tmuxName 
 				sess.TmuxSessionID = &ts.ID
 			}
 		}
+		slog.InfoContext(ctx, "setup tmux: reusing existing session", "tmux", tmuxName)
 		return nil
 	}
 
 	if sess.TmuxSessionID != nil {
-		if err := s.tmuxService.RecreateSession(*sess.TmuxSessionID); err != nil {
+		if err := traceOp(ctx, "tmux recreate-session", func() error {
+			return s.tmuxService.RecreateSession(*sess.TmuxSessionID)
+		}, "tmux", tmuxName, "tmux_id", *sess.TmuxSessionID); err != nil {
 			return fmt.Errorf("failed to recreate tmux session: %v", err)
 		}
 		return nil
@@ -354,15 +427,10 @@ func (s *SessionService) setupTmux(ctx context.Context, sess *Session, tmuxName 
 		startDir = s.resolveStartDir(ctx, sess)
 	}
 	env := map[string]string{"UTENA_SESSION_ID": fmt.Sprintf("%d", sess.ID)}
-	if s.tmuxService.HasSession(tmuxName) {
-		ts, err := s.tmuxService.GetOrTrackSession(tmuxName, startDir, env)
-		if err != nil {
-			return fmt.Errorf("failed to attach to existing tmux session: %v", err)
-		}
-		sess.TmuxSessionID = &ts.ID
-		return nil
-	}
-	ts, err := s.tmuxService.CreateSession(tmuxName, startDir, env)
+
+	ts, err := tracedOp(ctx, "tmux new-session", func() (*utmux.TmuxSession, error) {
+		return s.tmuxService.CreateSession(tmuxName, startDir, env)
+	}, "tmux", tmuxName, "start_dir", startDir)
 	if err != nil {
 		if !s.tmuxService.HasSession(tmuxName) {
 			return fmt.Errorf("failed to create tmux session: %v", err)
@@ -375,6 +443,7 @@ func (s *SessionService) setupTmux(ctx context.Context, sess *Session, tmuxName 
 		if actions, err := s.sessionActionStore.ListBySessionIDAndTrigger(sess.ID, TriggerOnCreate); err != nil {
 			slog.Warn("failed to load session actions", "session", sess.ID, "error", err)
 		} else if len(actions) > 0 {
+			slog.InfoContext(ctx, "setup tmux: dispatching on-create actions", "tmux", tmuxName, "count", len(actions))
 			go executeSessionActions(actions, s.tmuxService, s.sessionActionStore, tmuxName, startDir)
 		}
 	}
@@ -413,7 +482,10 @@ func (s *SessionService) setupWorktreeInit(ctx context.Context, sess *Session, w
 
 	var warnings []string
 	for _, script := range scripts {
-		if err := s.runScript(ctx, script, worktreePath, env); err != nil {
+		err := traceOp(ctx, "worktree-setup script", func() error {
+			return s.runScript(ctx, script, worktreePath, env)
+		}, "script", script)
+		if err != nil {
 			slog.Warn("worktree setup script failed", "script", script, "error", err)
 			warnings = append(warnings, err.Error())
 		}

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -493,6 +493,28 @@ func TestSessionService_CreateSession_WithWorktree_ReusesLocalOnlyBranch(t *test
 	waitForStatus(t, sessionStore, session.ID, StatusActive, 5*time.Second)
 }
 
+func TestSessionService_CreateSession_TimesOut(t *testing.T) {
+	repoPath := initTestRepo(t)
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+	service.setupTimeout = 1 * time.Nanosecond
+
+	session := &Session{
+		Name:        "slow-feature",
+		WorkspaceID: wsGitID,
+	}
+
+	ctx := context.Background()
+	err := service.CreateSession(ctx, session, "", "main", true)
+	require.NoError(t, err)
+
+	waitForStatus(t, sessionStore, session.ID, StatusBroken, 5*time.Second)
+
+	retrieved, err := sessionStore.GetByID(session.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusBroken, retrieved.Status)
+	require.Contains(t, retrieved.StatusError, "timed out")
+}
+
 func TestSessionService_CreateSession_WithWorktree_InvalidBranch(t *testing.T) {
 	repoPath := initTestRepo(t)
 	service, sessionStore, mock, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())

--- a/internal/tmux/testing.go
+++ b/internal/tmux/testing.go
@@ -17,6 +17,8 @@ type MockRunner struct {
 	SpawnedWindows []SpawnedWindow
 	CreateErr      error
 	KillErr        error
+	OnNewSession   func()
+	OnKillSession  func()
 }
 
 func NewMockRunner() *MockRunner {
@@ -35,6 +37,9 @@ func (m *MockRunner) newWindow(sessionName, startDir, command string) error {
 }
 
 func (m *MockRunner) newSession(name, startDir string, env map[string]string) error {
+	if m.OnNewSession != nil {
+		m.OnNewSession()
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.CreateErr != nil {
@@ -48,6 +53,9 @@ func (m *MockRunner) newSession(name, startDir string, env map[string]string) er
 }
 
 func (m *MockRunner) killSession(name string) error {
+	if m.OnKillSession != nil {
+		m.OnKillSession()
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.KillErr != nil {

--- a/internal/tmux/tmuxclient.go
+++ b/internal/tmux/tmuxclient.go
@@ -51,7 +51,13 @@ func (r *gotmuxRunner) newWindow(sessionName, startDir, command string) error {
 	return err
 }
 
-func (r *gotmuxRunner) killSession(name string) error {
+func (r *gotmuxRunner) killSession(name string) (err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			slog.Warn("tmux killSession recovered from panic", "name", name, "panic", rec)
+			err = fmt.Errorf("tmux killSession panicked: %v", rec)
+		}
+	}()
 	if !r.tmux.HasSession(name) {
 		return nil
 	}

--- a/internal/tmux/tmuxservice.go
+++ b/internal/tmux/tmuxservice.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/eleonorayaya/utena/internal/eventbus"
 )
@@ -14,6 +15,14 @@ type TmuxService struct {
 	store            *TmuxStore
 	eventBus         eventbus.EventBus
 	windowsBySession map[string][]Window
+	nameLocks        sync.Map
+}
+
+func (t *TmuxService) lockName(name string) func() {
+	actual, _ := t.nameLocks.LoadOrStore(name, &sync.Mutex{})
+	mu := actual.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
 }
 
 func NewTmuxService(runner tmuxRunner, store *TmuxStore, bus eventbus.EventBus) *TmuxService {
@@ -37,6 +46,7 @@ func (t *TmuxService) CreateSession(name, startDir string, env map[string]string
 	if t.runner == nil {
 		return nil, ErrTmuxNotAvailable
 	}
+	defer t.lockName(name)()
 	if err := t.runner.newSession(name, startDir, env); err != nil {
 		return nil, err
 	}
@@ -73,6 +83,7 @@ func (t *TmuxService) KillSession(id uint) error {
 	if err != nil {
 		return err
 	}
+	defer t.lockName(ts.Name)()
 	if err := t.runner.killSession(ts.Name); err != nil {
 		return err
 	}
@@ -84,6 +95,7 @@ func (t *TmuxService) KillSessionByName(name string) error {
 	if t.runner == nil {
 		return ErrTmuxNotAvailable
 	}
+	defer t.lockName(name)()
 	if err := t.runner.killSession(name); err != nil {
 		return err
 	}
@@ -106,6 +118,7 @@ func (t *TmuxService) RecreateSession(id uint) error {
 	if err != nil {
 		return err
 	}
+	defer t.lockName(ts.Name)()
 	if err := t.runner.newSession(ts.Name, ts.StartDir, ts.Env); err != nil {
 		return err
 	}

--- a/internal/tmux/tmuxservice_test.go
+++ b/internal/tmux/tmuxservice_test.go
@@ -1,0 +1,115 @@
+package tmux
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/eventbus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTmuxService_LockNameSerializesSameName(t *testing.T) {
+	svc := &TmuxService{}
+
+	unlock1 := svc.lockName("foo")
+
+	acquired := make(chan struct{})
+	go func() {
+		unlock2 := svc.lockName("foo")
+		close(acquired)
+		unlock2()
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second lockName(\"foo\") acquired while first still held")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	unlock1()
+
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("second lockName(\"foo\") did not unblock after first released")
+	}
+}
+
+func TestTmuxService_LockNameDoesNotBlockDifferentNames(t *testing.T) {
+	svc := &TmuxService{}
+
+	unlockFoo := svc.lockName("foo")
+	defer unlockFoo()
+
+	acquired := make(chan struct{})
+	go func() {
+		unlockBar := svc.lockName("bar")
+		close(acquired)
+		unlockBar()
+	}()
+
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("lockName(\"bar\") blocked behind lockName(\"foo\")")
+	}
+}
+
+func TestTmuxService_ConcurrentKillCreateNoOverlap(t *testing.T) {
+	database, err := db.OpenInMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+	require.NoError(t, database.Migrate(&TmuxSession{}))
+
+	bus := eventbus.NewEventBus()
+	mock := NewMockRunner()
+	store := NewTmuxStore(database)
+	svc := NewTmuxService(mock, store, bus)
+
+	var inFlight int32
+	var maxInFlight int32
+	mock.OnNewSession = func() {
+		n := atomic.AddInt32(&inFlight, 1)
+		for {
+			cur := atomic.LoadInt32(&maxInFlight)
+			if n <= cur || atomic.CompareAndSwapInt32(&maxInFlight, cur, n) {
+				break
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+		atomic.AddInt32(&inFlight, -1)
+	}
+	mock.OnKillSession = func() {
+		n := atomic.AddInt32(&inFlight, 1)
+		for {
+			cur := atomic.LoadInt32(&maxInFlight)
+			if n <= cur || atomic.CompareAndSwapInt32(&maxInFlight, cur, n) {
+				break
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+		atomic.AddInt32(&inFlight, -1)
+	}
+
+	const goroutines = 20
+	done := make(chan struct{}, goroutines)
+	for range goroutines {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			ts, err := svc.CreateSession("shared", "/tmp", nil)
+			if err == nil {
+				_ = svc.KillSession(ts.ID)
+			} else {
+				_ = svc.KillSessionByName("shared")
+			}
+		}()
+	}
+	for range goroutines {
+		<-done
+	}
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&maxInFlight),
+		"per-name lock should keep at most one tmux op in flight for the same name")
+}


### PR DESCRIPTION
## Summary
- Add 5-minute timeout to `runSetup` so a hung git op marks the session `broken` with a clear message instead of stranding it in `creating` until the daemon restarts.
- Instrument every blocking git/tmux op in setup with `setup op: start`/`setup op: done` lines (op name, duration, error) via a `traceOp`/`tracedOp` helper. Per-session attrs (`session`, `ws`, `branch`, `base_branch`) flow through every log via `veqryn/slog-context` — no prop-drilling. The last `start` with no matching `done` pinpoints any future hang.
- Serialize concurrent tmux ops on the same session name with a per-name `sync.Map` of `*sync.Mutex` on `TmuxService`. Eliminates races when `DeleteSession`/`ArchiveSession`/`completedCleanupTask`/`runSetup` touch the same name.
- Recover from panics in `gotmuxRunner.killSession`. The chi recoverer catches HTTP panics today, but background jobs (`completedCleanupTask` → `ArchiveSession` → `KillSession`) had no net — a panic there crashed the daemon.

## Test plan
- [x] `task test` passes (151 tests in `internal/tmux` and `internal/session`)
- [x] `go test -race ./internal/tmux/ ./internal/session/` clean
- [x] `go vet ./...` clean
- [x] New `TestSessionService_CreateSession_TimesOut` asserts a 1ns timeout marks the session `broken` with `"timed out"` in `status_error`
- [x] New `TestTmuxService_LockNameSerializesSameName` / `LockNameDoesNotBlockDifferentNames` / `ConcurrentKillCreateNoOverlap` exercise the per-name lock under concurrency
- [ ] Manual: `task daemon:install`, create a session for an existing remote branch in a bare workspace, confirm it lands `active` and `setup op: ...` lines appear in `~/Library/Logs/utena/daemon.stdout.log`
- [ ] Manual: spam-click delete on a stuck-creating session — confirm no `Kill(0x0)` panics in `daemon.stderr.log`
