### PR TITLE
fix(session): bare-workspace PR sessions, duplicate-name guard, lint sweep

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+  settings:
+    errcheck:
+      check-type-assertions: false
+      check-blank: false
+      exclude-functions:
+        - (io.Closer).Close
+        - (*os.File).Close
+
+formatters:
+  enable:
+    - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,9 @@ linters:
       exclude-functions:
         - (io.Closer).Close
         - (*os.File).Close
+  exclusions:
+    paths:
+      - internal/tui/
 
 formatters:
   enable:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,6 +23,12 @@ tasks:
       - '**/*.go'
     cmds:
       - go test ./...
+  go:lint:
+    sources:
+      - '**/*.go'
+      - .golangci.yml
+    cmds:
+      - golangci-lint run ./...
 
   test:
     cmds:
@@ -30,6 +36,9 @@ tasks:
   fmt:
     cmds:
       - task: go:fmt
+  lint:
+    cmds:
+      - task: go:lint
   tmux:install:
     cmds:
       - mkdir -p ~/.config/tmux/plugins/utena-tmux

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -43,7 +43,9 @@ func main() {
 func setupLogging() string {
 	logfilePath := os.Getenv("BUBBLETEA_LOG")
 	if logfilePath == "" {
-		os.MkdirAll(defaultLogDir, 0755)
+		if err := os.MkdirAll(defaultLogDir, 0755); err != nil {
+			log.Fatalf("failed to create log directory: %v", err)
+		}
 		logfilePath = filepath.Join(defaultLogDir, "tui.log")
 	}
 	if _, err := tea.LogToFile(logfilePath, "utena"); err != nil {

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -34,7 +34,9 @@ func LoadConfig(args []string) (Config, error) {
 	}
 
 	if v := os.Getenv("UTENA_PORT"); v != "" {
-		fmt.Sscanf(v, "%d", &cfg.Port)
+		if _, err := fmt.Sscanf(v, "%d", &cfg.Port); err != nil {
+			return Config{}, fmt.Errorf("invalid UTENA_PORT %q: %w", v, err)
+		}
 	}
 	if v := os.Getenv("UTENA_DATA_DIR"); v != "" {
 		cfg.ConfigDir = v

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -41,8 +41,8 @@ func setupTestRouter(t *testing.T) (*App, chi.Router, *tmux.MockRunner, uint, ui
 
 	ws1 := &workspace.Workspace{Name: "utena", Path: "/tmp/utena"}
 	ws2 := &workspace.Workspace{Name: "other", Path: "/tmp/other"}
-	app.Workspace.Store.Add(ws1)
-	app.Workspace.Store.Add(ws2)
+	require.NoError(t, app.Workspace.Store.Add(ws1))
+	require.NoError(t, app.Workspace.Store.Add(ws2))
 
 	server := BuildServer(app, cfg)
 

--- a/internal/claude/claudecontroller.go
+++ b/internal/claude/claudecontroller.go
@@ -44,5 +44,5 @@ func (c *ClaudeController) ListClaudeSessions(w http.ResponseWriter, r *http.Req
 	}
 
 	response := NewClaudeSessionListResponse(sessions)
-	render.Render(w, r, response)
+	common.RenderResponse(w, r, response)
 }

--- a/internal/claude/claudeservice_test.go
+++ b/internal/claude/claudeservice_test.go
@@ -20,11 +20,11 @@ func TestPreToolUse_ClearsNeedsAttention(t *testing.T) {
 	service, store, database := setupService(t)
 	sessionID := createTestSession(t, database)
 
-	store.Create(&ClaudeSession{
+	require.NoError(t, store.Create(&ClaudeSession{
 		ClaudeSessionID: "cs-1",
 		SessionID:       sessionID,
 		Status:          StatusNeedsAttention,
-	})
+	}))
 
 	err := service.HandleHookEvent(context.Background(), &HookEventRequest{
 		Event:           "PreToolUse",
@@ -42,11 +42,11 @@ func TestPreToolUse_NoOpWhenWorking(t *testing.T) {
 	service, store, database := setupService(t)
 	sessionID := createTestSession(t, database)
 
-	store.Create(&ClaudeSession{
+	require.NoError(t, store.Create(&ClaudeSession{
 		ClaudeSessionID: "cs-1",
 		SessionID:       sessionID,
 		Status:          StatusWorking,
-	})
+	}))
 
 	err := service.HandleHookEvent(context.Background(), &HookEventRequest{
 		Event:           "PreToolUse",
@@ -64,11 +64,11 @@ func TestPreToolUse_ClearsReadyForReview(t *testing.T) {
 	service, store, database := setupService(t)
 	sessionID := createTestSession(t, database)
 
-	store.Create(&ClaudeSession{
+	require.NoError(t, store.Create(&ClaudeSession{
 		ClaudeSessionID: "cs-1",
 		SessionID:       sessionID,
 		Status:          StatusReadyForReview,
-	})
+	}))
 
 	err := service.HandleHookEvent(context.Background(), &HookEventRequest{
 		Event:           "PreToolUse",
@@ -86,11 +86,11 @@ func TestPreToolUse_ClearsDone(t *testing.T) {
 	service, store, database := setupService(t)
 	sessionID := createTestSession(t, database)
 
-	store.Create(&ClaudeSession{
+	require.NoError(t, store.Create(&ClaudeSession{
 		ClaudeSessionID: "cs-1",
 		SessionID:       sessionID,
 		Status:          StatusDone,
-	})
+	}))
 
 	err := service.HandleHookEvent(context.Background(), &HookEventRequest{
 		Event:           "PreToolUse",
@@ -109,37 +109,37 @@ func TestFullFlow_NeedsAttentionToWorkingViaPreToolUse(t *testing.T) {
 	sessionID := createTestSession(t, database)
 	ctx := context.Background()
 
-	service.HandleHookEvent(ctx, &HookEventRequest{
+	require.NoError(t, service.HandleHookEvent(ctx, &HookEventRequest{
 		Event:           "SessionStart",
 		ClaudeSessionID: "cs-1",
 		SessionID:       sessionID,
 		CWD:             "/tmp",
-	})
+	}))
 	sessions := store.List()
 	require.Equal(t, StatusIdle, sessions[0].Status)
 
-	service.HandleHookEvent(ctx, &HookEventRequest{
+	require.NoError(t, service.HandleHookEvent(ctx, &HookEventRequest{
 		Event:            "Notification",
 		ClaudeSessionID:  "cs-1",
 		SessionID:        sessionID,
 		NotificationType: "permission_prompt",
-	})
+	}))
 	sessions = store.List()
 	require.Equal(t, StatusNeedsAttention, sessions[0].Status)
 
-	service.HandleHookEvent(ctx, &HookEventRequest{
+	require.NoError(t, service.HandleHookEvent(ctx, &HookEventRequest{
 		Event:           "PreToolUse",
 		ClaudeSessionID: "cs-1",
 		SessionID:       sessionID,
-	})
+	}))
 	sessions = store.List()
 	require.Equal(t, StatusWorking, sessions[0].Status)
 
-	service.HandleHookEvent(ctx, &HookEventRequest{
+	require.NoError(t, service.HandleHookEvent(ctx, &HookEventRequest{
 		Event:           "Stop",
 		ClaudeSessionID: "cs-1",
 		SessionID:       sessionID,
-	})
+	}))
 	sessions = store.List()
 	require.Equal(t, StatusReadyForReview, sessions[0].Status)
 }

--- a/internal/claude/claudestore_test.go
+++ b/internal/claude/claudestore_test.go
@@ -20,8 +20,12 @@ func setupTestDB(t *testing.T) db.Database {
 	if err != nil {
 		t.Fatal(err)
 	}
-	database.Migrate(&testSession{}, &ClaudeSession{})
-	t.Cleanup(func() { database.Close() })
+	require.NoError(t, database.Migrate(&testSession{}, &ClaudeSession{}))
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 	return database
 }
 
@@ -42,11 +46,11 @@ func TestUpdateStatus(t *testing.T) {
 	store, database := setupStore(t)
 	sessionID := createTestSession(t, database)
 
-	store.Create(&ClaudeSession{
+	require.NoError(t, store.Create(&ClaudeSession{
 		ClaudeSessionID: "cs-1",
 		SessionID:       sessionID,
 		Status:          StatusNeedsAttention,
-	})
+	}))
 
 	err := store.UpdateStatus("cs-1", StatusWorking)
 	require.NoError(t, err)

--- a/internal/claude/claudestore_test.go
+++ b/internal/claude/claudestore_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
@@ -15,18 +16,7 @@ type testSession struct {
 func (testSession) TableName() string { return "sessions" }
 
 func setupTestDB(t *testing.T) db.Database {
-	t.Helper()
-	database, err := db.OpenInMemory()
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.NoError(t, database.Migrate(&testSession{}, &ClaudeSession{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
-	return database
+	return testdb.New(t, &testSession{}, &ClaudeSession{})
 }
 
 func createTestSession(t *testing.T, database db.Database) uint {

--- a/internal/common/error.go
+++ b/internal/common/error.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/go-chi/render"
@@ -90,7 +91,7 @@ func RenderError(w http.ResponseWriter, r *http.Request, err error) {
 			statusText = "Internal server error."
 		}
 
-		render.Render(w, r, &errResponse{
+		RenderResponse(w, r, &errResponse{
 			Err:            appErr,
 			HTTPStatusCode: statusCode,
 			StatusText:     statusText,
@@ -99,10 +100,16 @@ func RenderError(w http.ResponseWriter, r *http.Request, err error) {
 		return
 	}
 
-	render.Render(w, r, &errResponse{
+	RenderResponse(w, r, &errResponse{
 		Err:            err,
 		HTTPStatusCode: http.StatusInternalServerError,
 		StatusText:     "Internal server error.",
 		ErrorText:      err.Error(),
 	})
+}
+
+func RenderResponse(w http.ResponseWriter, r *http.Request, v render.Renderer) {
+	if err := render.Render(w, r, v); err != nil {
+		slog.Error("failed to render response", "path", r.URL.Path, "error", err)
+	}
 }

--- a/internal/db/testdb/testdb.go
+++ b/internal/db/testdb/testdb.go
@@ -1,0 +1,26 @@
+package testdb
+
+import (
+	"testing"
+
+	"github.com/eleonorayaya/utena/internal/db"
+)
+
+func New(t *testing.T, models ...any) db.Database {
+	t.Helper()
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatalf("open in-memory db: %v", err)
+	}
+	if len(models) > 0 {
+		if err := database.Migrate(models...); err != nil {
+			t.Fatalf("migrate: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
+	return database
+}

--- a/internal/git/branchstore_test.go
+++ b/internal/git/branchstore_test.go
@@ -12,7 +12,11 @@ func setupBranchTestDB(t *testing.T) db.Database {
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
 	require.NoError(t, database.Migrate(&Repo{}, &Branch{}))
-	t.Cleanup(func() { database.Close() })
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 	return database
 }
 

--- a/internal/git/branchstore_test.go
+++ b/internal/git/branchstore_test.go
@@ -4,20 +4,12 @@ import (
 	"testing"
 
 	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/stretchr/testify/require"
 )
 
 func setupBranchTestDB(t *testing.T) db.Database {
-	t.Helper()
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(&Repo{}, &Branch{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
-	return database
+	return testdb.New(t, &Repo{}, &Branch{})
 }
 
 func createTestRepo(t *testing.T, store *RepoStore) *Repo {

--- a/internal/git/githubclient_test.go
+++ b/internal/git/githubclient_test.go
@@ -26,7 +26,9 @@ func TestListRepoPRs(t *testing.T) {
 			{Number: github.Ptr(1), Title: github.Ptr("Fix bug"), State: github.Ptr("open"), Draft: github.Ptr(false), HTMLURL: github.Ptr("https://github.com/octocat/hello/pull/1")},
 			{Number: github.Ptr(2), Title: github.Ptr("Add feature"), State: github.Ptr("open"), Draft: github.Ptr(true), HTMLURL: github.Ptr("https://github.com/octocat/hello/pull/2")},
 		}
-		json.NewEncoder(w).Encode(prs)
+		if err := json.NewEncoder(w).Encode(prs); err != nil {
+			t.Errorf("encode PRs response: %v", err)
+		}
 	})
 
 	client := setupMockSDKClient(t, mux)
@@ -57,7 +59,9 @@ func TestGetPR(t *testing.T) {
 			Head:    &github.PullRequestBranch{Ref: github.Ptr("feature-branch")},
 			Base:    &github.PullRequestBranch{Ref: github.Ptr("main")},
 		}
-		json.NewEncoder(w).Encode(pr)
+		if err := json.NewEncoder(w).Encode(pr); err != nil {
+			t.Errorf("encode PR response: %v", err)
+		}
 	})
 
 	client := setupMockSDKClient(t, mux)
@@ -87,10 +91,14 @@ func TestGetPRDiff(t *testing.T) {
 	mux.HandleFunc("/repos/octocat/hello/pulls/1", func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		if strings.Contains(accept, "diff") {
-			w.Write([]byte("diff --git a/file.go b/file.go\n--- a/file.go\n+++ b/file.go\n@@ -1 +1 @@\n-old\n+new\n"))
+			if _, err := w.Write([]byte("diff --git a/file.go b/file.go\n--- a/file.go\n+++ b/file.go\n@@ -1 +1 @@\n-old\n+new\n")); err != nil {
+				t.Errorf("write diff response: %v", err)
+			}
 			return
 		}
-		json.NewEncoder(w).Encode(github.PullRequest{Number: github.Ptr(1)})
+		if err := json.NewEncoder(w).Encode(github.PullRequest{Number: github.Ptr(1)}); err != nil {
+			t.Errorf("encode PR response: %v", err)
+		}
 	})
 
 	client := setupMockSDKClient(t, mux)
@@ -107,7 +115,9 @@ func TestGetPRDiff(t *testing.T) {
 func TestGetCurrentUser(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(github.User{Login: github.Ptr("testuser")})
+		if err := json.NewEncoder(w).Encode(github.User{Login: github.Ptr("testuser")}); err != nil {
+			t.Errorf("encode user response: %v", err)
+		}
 	})
 
 	client := setupMockSDKClient(t, mux)

--- a/internal/git/gitmodule_test.go
+++ b/internal/git/gitmodule_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/eleonorayaya/utena/internal/eventbus"
 	"github.com/eleonorayaya/utena/internal/jobs"
 	"github.com/stretchr/testify/assert"
@@ -12,13 +12,7 @@ import (
 )
 
 func TestGitModule_Models(t *testing.T) {
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	database := testdb.New(t)
 
 	bus := eventbus.NewEventBus()
 	service := NewGitService(database, WithEventBus(bus))
@@ -29,13 +23,7 @@ func TestGitModule_Models(t *testing.T) {
 }
 
 func TestGitModule_RegisterJobs(t *testing.T) {
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	database := testdb.New(t)
 
 	bus := eventbus.NewEventBus()
 	service := NewGitService(database, WithEventBus(bus))
@@ -50,31 +38,18 @@ func TestGitModule_RegisterJobs(t *testing.T) {
 }
 
 func TestGitModule_OnAppStart_SetsCurrentUser(t *testing.T) {
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	database := testdb.New(t)
 
 	bus := &mockEventBus{}
 	module := NewGitModule(database, bus)
 	module.Service.githubClient = &mockGitHubClient{currentUser: "testuser"}
 
-	err = module.OnAppStart(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, module.OnAppStart(context.Background()))
 	assert.Equal(t, "testuser", module.Service.currentUser)
 }
 
 func TestGitModule_InitializesWithoutError(t *testing.T) {
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	database := testdb.New(t)
 
 	bus := eventbus.NewEventBus()
 	service := NewGitService(database, WithEventBus(bus))

--- a/internal/git/gitmodule_test.go
+++ b/internal/git/gitmodule_test.go
@@ -14,7 +14,11 @@ import (
 func TestGitModule_Models(t *testing.T) {
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	t.Cleanup(func() { database.Close() })
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	bus := eventbus.NewEventBus()
 	service := NewGitService(database, WithEventBus(bus))
@@ -27,7 +31,11 @@ func TestGitModule_Models(t *testing.T) {
 func TestGitModule_RegisterJobs(t *testing.T) {
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	t.Cleanup(func() { database.Close() })
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	bus := eventbus.NewEventBus()
 	service := NewGitService(database, WithEventBus(bus))
@@ -44,7 +52,11 @@ func TestGitModule_RegisterJobs(t *testing.T) {
 func TestGitModule_OnAppStart_SetsCurrentUser(t *testing.T) {
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	t.Cleanup(func() { database.Close() })
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	bus := &mockEventBus{}
 	module := NewGitModule(database, bus)
@@ -58,7 +70,11 @@ func TestGitModule_OnAppStart_SetsCurrentUser(t *testing.T) {
 func TestGitModule_InitializesWithoutError(t *testing.T) {
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	t.Cleanup(func() { database.Close() })
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	bus := eventbus.NewEventBus()
 	service := NewGitService(database, WithEventBus(bus))

--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -452,10 +452,12 @@ func (s *GitService) syncGitHubPR(ctx context.Context, ghPR *github.PullRequest,
 		}
 	}
 	if s.eventBus != nil && prChanged(previous, pr) {
-		s.eventBus.Publish(ctx, eventbus.Event{
+		if err := s.eventBus.Publish(ctx, eventbus.Event{
 			Type: EventPRUpdated,
 			Data: PRUpdatedEvent{PullRequest: pr, Previous: previous, Repo: repo},
-		})
+		}); err != nil {
+			slog.Warn("failed to publish PR-updated event", "pr", pr.Number, "error", err)
+		}
 	}
 	return nil
 }

--- a/internal/git/gitservice_pr_test.go
+++ b/internal/git/gitservice_pr_test.go
@@ -66,7 +66,11 @@ func setupGitServiceTest(t *testing.T) (db.Database, *Repo) {
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
 	require.NoError(t, database.Migrate(&Repo{}, &Branch{}, &Worktree{}, &PullRequest{}))
-	t.Cleanup(func() { database.Close() })
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	repoStore := NewRepoStore(database)
 	repo := &Repo{Path: "/test/repo", FullName: "owner/repo"}

--- a/internal/git/gitservice_pr_test.go
+++ b/internal/git/gitservice_pr_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/eleonorayaya/utena/internal/eventbus"
 	"github.com/google/go-github/v72/github"
 	"github.com/stretchr/testify/assert"
@@ -63,14 +64,7 @@ func (m *mockEventBus) Subscribe(eventType string, handler eventbus.Handler) {}
 
 func setupGitServiceTest(t *testing.T) (db.Database, *Repo) {
 	t.Helper()
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(&Repo{}, &Branch{}, &Worktree{}, &PullRequest{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	database := testdb.New(t, &Repo{}, &Branch{}, &Worktree{}, &PullRequest{})
 
 	repoStore := NewRepoStore(database)
 	repo := &Repo{Path: "/test/repo", FullName: "owner/repo"}

--- a/internal/git/prstore_test.go
+++ b/internal/git/prstore_test.go
@@ -12,7 +12,11 @@ func setupPRTestDB(t *testing.T) db.Database {
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
 	require.NoError(t, database.Migrate(&Repo{}, &Branch{}, &PullRequest{}))
-	t.Cleanup(func() { database.Close() })
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 	return database
 }
 

--- a/internal/git/prstore_test.go
+++ b/internal/git/prstore_test.go
@@ -4,20 +4,12 @@ import (
 	"testing"
 
 	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/stretchr/testify/require"
 )
 
 func setupPRTestDB(t *testing.T) db.Database {
-	t.Helper()
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(&Repo{}, &Branch{}, &PullRequest{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
-	return database
+	return testdb.New(t, &Repo{}, &Branch{}, &PullRequest{})
 }
 
 func createPRTestRepo(t *testing.T, store *RepoStore) *Repo {

--- a/internal/git/repostore_test.go
+++ b/internal/git/repostore_test.go
@@ -12,7 +12,11 @@ func setupTestDB(t *testing.T) db.Database {
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
 	require.NoError(t, database.Migrate(&Repo{}))
-	t.Cleanup(func() { database.Close() })
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 	return database
 }
 

--- a/internal/git/repostore_test.go
+++ b/internal/git/repostore_test.go
@@ -4,20 +4,12 @@ import (
 	"testing"
 
 	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/stretchr/testify/require"
 )
 
 func setupTestDB(t *testing.T) db.Database {
-	t.Helper()
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(&Repo{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
-	return database
+	return testdb.New(t, &Repo{})
 }
 
 func TestRepoStore_AddAndGetByID(t *testing.T) {

--- a/internal/git/worktreestore_test.go
+++ b/internal/git/worktreestore_test.go
@@ -12,7 +12,11 @@ func setupWorktreeTestDB(t *testing.T) db.Database {
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
 	require.NoError(t, database.Migrate(&Repo{}, &Branch{}, &Worktree{}))
-	t.Cleanup(func() { database.Close() })
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 	return database
 }
 

--- a/internal/git/worktreestore_test.go
+++ b/internal/git/worktreestore_test.go
@@ -4,20 +4,12 @@ import (
 	"testing"
 
 	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/stretchr/testify/require"
 )
 
 func setupWorktreeTestDB(t *testing.T) db.Database {
-	t.Helper()
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(&Repo{}, &Branch{}, &Worktree{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
-	return database
+	return testdb.New(t, &Repo{}, &Branch{}, &Worktree{})
 }
 
 func createWorktreeTestRepoAndBranch(t *testing.T, database db.Database, path, branchName string) (*Repo, *Branch) {

--- a/internal/session/dismissedprstore_test.go
+++ b/internal/session/dismissedprstore_test.go
@@ -4,21 +4,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/stretchr/testify/require"
 )
 
 func setupDismissedPRStore(t *testing.T) *DismissedPRStore {
-	t.Helper()
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(&DismissedPR{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
-	return NewDismissedPRStore(database)
+	return NewDismissedPRStore(testdb.New(t, &DismissedPR{}))
 }
 
 func TestAddAndIsDismissed(t *testing.T) {

--- a/internal/session/dismissedprstore_test.go
+++ b/internal/session/dismissedprstore_test.go
@@ -12,8 +12,12 @@ func setupDismissedPRStore(t *testing.T) *DismissedPRStore {
 	t.Helper()
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	database.Migrate(&DismissedPR{})
-	t.Cleanup(func() { database.Close() })
+	require.NoError(t, database.Migrate(&DismissedPR{}))
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 	return NewDismissedPRStore(database)
 }
 

--- a/internal/session/sessionactionexecutor.go
+++ b/internal/session/sessionactionexecutor.go
@@ -32,9 +32,13 @@ func executeSessionActions(actions []SessionAction, spawner WindowSpawner, store
 		}
 		if err != nil {
 			slog.Warn("session action failed", "type", action.Type, "session", tmuxName, "error", err)
-			store.UpdateError(action, err.Error())
+			if updateErr := store.UpdateError(action, err.Error()); updateErr != nil {
+				slog.Warn("failed to persist session action error", "action", action.ID, "error", updateErr)
+			}
 		} else if action.Error != "" {
-			store.UpdateError(action, "")
+			if updateErr := store.UpdateError(action, ""); updateErr != nil {
+				slog.Warn("failed to clear session action error", "action", action.ID, "error", updateErr)
+			}
 		}
 	}
 }

--- a/internal/session/sessioncontroller.go
+++ b/internal/session/sessioncontroller.go
@@ -37,7 +37,7 @@ func (c *SessionController) ListSessions(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	render.Render(w, r, NewSessionListResponse(sessions))
+	common.RenderResponse(w, r, NewSessionListResponse(sessions))
 }
 
 func (c *SessionController) GetSessionByID(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +54,7 @@ func (c *SessionController) GetSessionByID(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	render.Render(w, r, NewSessionResponse(session))
+	common.RenderResponse(w, r, NewSessionResponse(session))
 }
 
 func (c *SessionController) ListSessionsByWorkspace(w http.ResponseWriter, r *http.Request) {
@@ -72,7 +72,7 @@ func (c *SessionController) ListSessionsByWorkspace(w http.ResponseWriter, r *ht
 		return
 	}
 
-	render.Render(w, r, NewSessionListResponse(sessions))
+	common.RenderResponse(w, r, NewSessionListResponse(sessions))
 }
 
 func (c *SessionController) CreateSession(w http.ResponseWriter, r *http.Request) {
@@ -96,7 +96,7 @@ func (c *SessionController) CreateSession(w http.ResponseWriter, r *http.Request
 	}
 
 	render.Status(r, http.StatusAccepted)
-	render.Render(w, r, NewSessionResponse(session))
+	common.RenderResponse(w, r, NewSessionResponse(session))
 }
 
 func (c *SessionController) UpdateSession(w http.ResponseWriter, r *http.Request) {
@@ -113,14 +113,14 @@ func (c *SessionController) UpdateSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	data.Session.ID = id
+	data.ID = id
 
 	if err := c.service.UpdateSession(ctx, data.Session); err != nil {
 		common.RenderError(w, r, err)
 		return
 	}
 
-	render.Render(w, r, NewSessionResponse(data.Session))
+	common.RenderResponse(w, r, NewSessionResponse(data.Session))
 }
 
 func (c *SessionController) DeleteSession(w http.ResponseWriter, r *http.Request) {
@@ -156,7 +156,7 @@ func (c *SessionController) ActivateSession(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	render.Render(w, r, NewSessionResponse(session))
+	common.RenderResponse(w, r, NewSessionResponse(session))
 }
 
 func (c *SessionController) RepairSession(w http.ResponseWriter, r *http.Request) {
@@ -173,7 +173,7 @@ func (c *SessionController) RepairSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	render.Render(w, r, NewSessionResponse(session))
+	common.RenderResponse(w, r, NewSessionResponse(session))
 }
 
 func (c *SessionController) ArchiveSession(w http.ResponseWriter, r *http.Request) {
@@ -190,7 +190,7 @@ func (c *SessionController) ArchiveSession(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	render.Render(w, r, NewSessionResponse(session))
+	common.RenderResponse(w, r, NewSessionResponse(session))
 }
 
 func (c *SessionController) DismissSession(w http.ResponseWriter, r *http.Request) {

--- a/internal/session/sessionmodule.go
+++ b/internal/session/sessionmodule.go
@@ -82,7 +82,9 @@ func (t *reconcileSyncTask) Run(ctx context.Context) error {
 	}
 	for _, sess := range sessions {
 		if sess.Status != StatusDeleted && sess.Status != StatusArchived && sess.Status != StatusCreating {
-			t.service.ReconcileSession(ctx, sess.ID)
+			if _, err := t.service.ReconcileSession(ctx, sess.ID); err != nil {
+				slog.Warn("reconcile failed for session", "session", sess.ID, "error", err)
+			}
 		}
 	}
 	return nil

--- a/internal/session/sessionrouter_test.go
+++ b/internal/session/sessionrouter_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/eleonorayaya/utena/internal/eventbus"
 	"github.com/eleonorayaya/utena/internal/git"
 	utmux "github.com/eleonorayaya/utena/internal/tmux"
@@ -34,14 +34,7 @@ func setupSessionRouter(t *testing.T) (*SessionRouter, *SessionStore, *workspace
 	mock := utmux.NewMockRunner()
 	tmuxService := createTmuxService(t, database, mock, bus)
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
-	gitDB, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, gitDB.Migrate(&git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
-	t.Cleanup(func() {
-		if err := gitDB.Close(); err != nil {
-			t.Logf("close gitDB: %v", err)
-		}
-	})
+	gitDB := testdb.New(t, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
 	gitService := git.NewGitService(gitDB)
 	dismissedPRStore := NewDismissedPRStore(database)
 	sessionActionStore := NewSessionActionStore(database)

--- a/internal/session/sessionrouter_test.go
+++ b/internal/session/sessionrouter_test.go
@@ -28,16 +28,20 @@ func setupSessionRouter(t *testing.T) (*SessionRouter, *SessionStore, *workspace
 
 	ws1 := &workspace.Workspace{Name: "utena", Path: "/tmp/utena"}
 	ws2 := &workspace.Workspace{Name: "other", Path: "/tmp/other"}
-	workspaceStore.Add(ws1)
-	workspaceStore.Add(ws2)
+	require.NoError(t, workspaceStore.Add(ws1))
+	require.NoError(t, workspaceStore.Add(ws2))
 
 	mock := utmux.NewMockRunner()
 	tmuxService := createTmuxService(t, database, mock, bus)
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitDB, err := db.OpenInMemory()
 	require.NoError(t, err)
-	gitDB.Migrate(&git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
-	t.Cleanup(func() { gitDB.Close() })
+	require.NoError(t, gitDB.Migrate(&git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
+	t.Cleanup(func() {
+		if err := gitDB.Close(); err != nil {
+			t.Logf("close gitDB: %v", err)
+		}
+	})
 	gitService := git.NewGitService(gitDB)
 	dismissedPRStore := NewDismissedPRStore(database)
 	sessionActionStore := NewSessionActionStore(database)
@@ -54,8 +58,8 @@ func TestSessionRouter_ListSessions(t *testing.T) {
 	now := time.Now()
 	session1 := &Session{Name: "session-1", WorkspaceID: ws1ID, Status: StatusActive, LastUsedAt: now}
 	session2 := &Session{Name: "session-2", WorkspaceID: ws2ID, Status: StatusActive, LastUsedAt: now}
-	sessionStore.Add(session1)
-	sessionStore.Add(session2)
+	require.NoError(t, sessionStore.Add(session1))
+	require.NoError(t, sessionStore.Add(session2))
 
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
@@ -87,7 +91,7 @@ func TestSessionRouter_GetSessionByID(t *testing.T) {
 		Status:      StatusActive,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/%d", session.ID), nil)
 	w := httptest.NewRecorder()
@@ -123,9 +127,9 @@ func TestSessionRouter_ListSessionsByWorkspace(t *testing.T) {
 	session1 := &Session{Name: "session-1", WorkspaceID: ws1ID, Status: StatusActive, LastUsedAt: now}
 	session2 := &Session{Name: "session-2", WorkspaceID: ws2ID, Status: StatusActive, LastUsedAt: now}
 	session3 := &Session{Name: "session-3", WorkspaceID: ws1ID, Status: StatusActive, LastUsedAt: now}
-	sessionStore.Add(session1)
-	sessionStore.Add(session2)
-	sessionStore.Add(session3)
+	require.NoError(t, sessionStore.Add(session1))
+	require.NoError(t, sessionStore.Add(session2))
+	require.NoError(t, sessionStore.Add(session3))
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/workspace/%d", ws1ID), nil)
 	w := httptest.NewRecorder()
@@ -246,7 +250,7 @@ func TestSessionRouter_UpdateSession(t *testing.T) {
 		Status:      StatusActive,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	session.IsAttached = true
 	body, err := json.Marshal(session)
@@ -274,7 +278,7 @@ func TestSessionRouter_DeleteSession(t *testing.T) {
 		Status:      StatusActive,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	req := httptest.NewRequest("DELETE", fmt.Sprintf("/%d", session.ID), nil)
 	w := httptest.NewRecorder()
@@ -297,7 +301,7 @@ func TestSessionRouter_RepairSession(t *testing.T) {
 		Status:      StatusBroken,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	req := httptest.NewRequest("PUT", fmt.Sprintf("/%d/repair", session.ID), nil)
 	w := httptest.NewRecorder()
@@ -336,7 +340,7 @@ func TestSessionRouter_RepairSession_NotBroken(t *testing.T) {
 		Status:      StatusActive,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	req := httptest.NewRequest("PUT", fmt.Sprintf("/%d/repair", session.ID), nil)
 	w := httptest.NewRecorder()
@@ -355,7 +359,7 @@ func TestSessionRouter_ActivateSession_RejectsBrokenSession(t *testing.T) {
 		Status:      StatusBroken,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	req := httptest.NewRequest("PUT", fmt.Sprintf("/%d/activate", session.ID), nil)
 	w := httptest.NewRecorder()
@@ -374,7 +378,7 @@ func TestSessionRouter_GetSessionByID_ShowsCreatingStatus(t *testing.T) {
 		Status:      StatusCreating,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/%d", session.ID), nil)
 	w := httptest.NewRecorder()
@@ -399,7 +403,7 @@ func TestSessionRouter_GetSessionByID_ShowsBrokenStatusError(t *testing.T) {
 		StatusError: "worktree setup failed: timeout",
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/%d", session.ID), nil)
 	w := httptest.NewRecorder()

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -100,9 +100,7 @@ func (s *SessionService) recoverStuckCreatingSessions() {
 		if sess.Status != StatusCreating {
 			continue
 		}
-		sess.Status = StatusBroken
-		sess.StatusError = "creation interrupted by daemon restart"
-		if err := s.store.Update(sess); err != nil {
+		if err := s.markSessionBroken(sess, "creation interrupted by daemon restart"); err != nil {
 			slog.Warn("failed to recover stuck creating session", "session", sess.ID, "error", err)
 			continue
 		}
@@ -163,7 +161,7 @@ func (s *SessionService) findSessionByTmuxName(tmuxName string) (*Session, error
 	return s.store.GetByTmuxSessionID(ts.ID)
 }
 
-func (s *SessionService) CreateSession(ctx context.Context, session *Session, branchName string, baseBranchName string, createWorktree bool, onCreateActions ...*SessionAction) error {
+func (s *SessionService) CreateSession(ctx context.Context, session *Session, branchName string, baseBranchName string, createWorktree bool, actions ...*SessionAction) error {
 	var ws *workspace.Workspace
 	if session.WorkspaceID != 0 {
 		var err error
@@ -214,8 +212,12 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, br
 	}
 
 	if session.WorkspaceID != 0 && session.Name != "" {
-		if existing, err := s.store.GetByWorkspaceAndName(session.WorkspaceID, session.Name, StatusDeleted, StatusArchived); err == nil && existing != nil {
+		_, err := s.store.GetByWorkspaceAndName(session.WorkspaceID, session.Name, StatusDeleted, StatusArchived)
+		switch {
+		case err == nil:
 			return fmt.Errorf("session %q already exists in workspace: %w", session.Name, ErrSessionAlreadyExists)
+		case !errors.Is(err, ErrSessionNotFound):
+			return fmt.Errorf("failed to check for duplicate session: %w", err)
 		}
 	}
 
@@ -223,11 +225,10 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, br
 		return err
 	}
 
-	for _, action := range onCreateActions {
+	for _, action := range actions {
 		action.SessionID = session.ID
-		action.Trigger = TriggerOnCreate
 		if err := s.sessionActionStore.Add(action); err != nil {
-			slog.Warn("failed to add on-create session action", "session", session.ID, "error", err)
+			slog.Error("failed to persist session action", "session", session.ID, "trigger", action.Trigger, "error", err)
 		}
 	}
 
@@ -269,13 +270,13 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace, tmuxN
 	}()
 
 	markBroken := func(stage string, err error) {
-		sess.Status = StatusBroken
+		var msg string
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			sess.StatusError = fmt.Sprintf("%s timed out after %s", stage, s.setupTimeout)
+			msg = fmt.Sprintf("%s timed out after %s", stage, s.setupTimeout)
 		} else {
-			sess.StatusError = fmt.Sprintf("%s failed: %v", stage, err)
+			msg = fmt.Sprintf("%s failed: %v", stage, err)
 		}
-		if updateErr := s.store.Update(sess); updateErr != nil {
+		if updateErr := s.markSessionBroken(sess, msg); updateErr != nil {
 			slog.ErrorContext(ctx, "failed to persist broken status", "stage", stage, "error", updateErr)
 		}
 	}
@@ -309,13 +310,13 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace, tmuxN
 				return s.gitService.FindOrCreateBranch(ctx, finalBranchName, *ws.RepoID)
 			}, "name", finalBranchName)
 			if err != nil {
-				slog.Warn("failed to create branch record", "branch", finalBranchName, "error", err)
-			} else {
-				sess.BranchID = &branch.ID
-				if updateErr := s.store.Update(sess); updateErr != nil {
-					markBroken("persist branch id", updateErr)
-					return
-				}
+				markBroken("find-or-create-branch", err)
+				return
+			}
+			sess.BranchID = &branch.ID
+			if updateErr := s.store.Update(sess); updateErr != nil {
+				markBroken("persist branch id", updateErr)
+				return
 			}
 		}
 
@@ -831,7 +832,10 @@ func (s *SessionService) handleTmuxClientSessionChanged(ctx context.Context, eve
 		return fmt.Errorf("unexpected event data type: %T", event.Data)
 	}
 
-	sessions, _ := s.store.List()
+	sessions, err := s.store.List()
+	if err != nil {
+		return fmt.Errorf("failed to list sessions while clearing attached flags: %w", err)
+	}
 	for _, sess := range sessions {
 		if sess.IsAttached {
 			sess.IsAttached = false
@@ -1002,6 +1006,12 @@ func (s *SessionService) ReconcileSession(ctx context.Context, id uint) (*Sessio
 	return sess, nil
 }
 
+func (s *SessionService) markSessionBroken(sess *Session, statusError string) error {
+	sess.Status = StatusBroken
+	sess.StatusError = statusError
+	return s.store.Update(sess)
+}
+
 func (s *SessionService) handlePRUpdated(ctx context.Context, event eventbus.Event) error {
 	data, ok := event.Data.(git.PRUpdatedEvent)
 	if !ok {
@@ -1066,6 +1076,7 @@ func (s *SessionService) maybeCreatePendingSession(ctx context.Context, data git
 		pr.HTMLURL,
 	)
 	reviewAction := &SessionAction{
+		Trigger: TriggerOnCreate,
 		Type:    SessionActionTypeClaude,
 		Options: marshalOptions(ClaudeActionOptions{Prompt: prompt}),
 	}

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -163,7 +163,7 @@ func (s *SessionService) findSessionByTmuxName(tmuxName string) (*Session, error
 	return s.store.GetByTmuxSessionID(ts.ID)
 }
 
-func (s *SessionService) CreateSession(ctx context.Context, session *Session, branchName string, baseBranchName string, createWorktree bool) error {
+func (s *SessionService) CreateSession(ctx context.Context, session *Session, branchName string, baseBranchName string, createWorktree bool, onCreateActions ...*SessionAction) error {
 	var ws *workspace.Workspace
 	if session.WorkspaceID != 0 {
 		var err error
@@ -178,7 +178,11 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, br
 		createWorktree = true
 	}
 
-	if ws != nil && ws.IsGitRepo && branchName != "" && baseBranchName == "" && (ws.IsBare || branchName != "main") {
+	if ws != nil && ws.IsBare {
+		createWorktree = true
+	}
+
+	if ws != nil && ws.IsGitRepo && branchName != "" && baseBranchName == "" && branchName != "main" {
 		createWorktree = true
 	}
 
@@ -211,6 +215,14 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, br
 
 	if err := s.store.Add(session); err != nil {
 		return err
+	}
+
+	for _, action := range onCreateActions {
+		action.SessionID = session.ID
+		action.Trigger = TriggerOnCreate
+		if err := s.sessionActionStore.Add(action); err != nil {
+			slog.Warn("failed to add on-create session action", "session", session.ID, "error", err)
+		}
 	}
 
 	if session.WorkspaceID != 0 {
@@ -998,20 +1010,9 @@ func (s *SessionService) maybeCreatePendingSession(ctx context.Context, data git
 		return
 	}
 
-	sessName := s.nameFromBranch(branch.Name)
-	tmuxName := BuildTmuxSessionName(ws.Name, sessName)
-
 	sess := &Session{
-		Name:        sessName,
 		WorkspaceID: ws.ID,
 		BranchID:    pr.HeadBranchID,
-		Status:      StatusCreating,
-		LastUsedAt:  time.Now(),
-	}
-
-	if err := s.store.Add(sess); err != nil {
-		slog.Warn("failed to create session for PR", "pr", pr.Number, "error", err)
-		return
 	}
 
 	prompt := fmt.Sprintf(
@@ -1022,18 +1023,17 @@ func (s *SessionService) maybeCreatePendingSession(ctx context.Context, data git
 			"The final report should just reflect the final state of feedback and should not reference any initial feedback that was dismissed by the subagents or make any reference at all to the process.",
 		pr.HTMLURL,
 	)
-	action := &SessionAction{
-		SessionID: sess.ID,
-		Trigger:   TriggerOnCreate,
-		Type:      SessionActionTypeClaude,
-		Options:   marshalOptions(ClaudeActionOptions{Prompt: prompt}),
+	reviewAction := &SessionAction{
+		Type:    SessionActionTypeClaude,
+		Options: marshalOptions(ClaudeActionOptions{Prompt: prompt}),
 	}
-	if err := s.sessionActionStore.Add(action); err != nil {
-		slog.Warn("failed to create session action for PR", "pr", pr.Number, "error", err)
+
+	if err := s.CreateSession(ctx, sess, branch.Name, "", false, reviewAction); err != nil {
+		slog.Warn("failed to create session for PR", "pr", pr.Number, "error", err)
+		return
 	}
 
 	slog.Info("activating session for assigned PR", "pr", pr.Number, "session", sess.ID, "branch", branch.Name)
-	go s.runSetup(sess.ID, ws, tmuxName, branch.Name, "", false)
 }
 
 func (s *SessionService) maybeCompleteSession(_ context.Context, pr *git.PullRequest) {

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -213,6 +213,12 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, br
 		session.LastUsedAt = time.Now()
 	}
 
+	if session.WorkspaceID != 0 && session.Name != "" {
+		if existing, err := s.store.GetByWorkspaceAndName(session.WorkspaceID, session.Name, StatusDeleted, StatusArchived); err == nil && existing != nil {
+			return fmt.Errorf("session %q already exists in workspace: %w", session.Name, ErrSessionAlreadyExists)
+		}
+	}
+
 	if err := s.store.Add(session); err != nil {
 		return err
 	}
@@ -267,7 +273,9 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace, tmuxN
 		} else {
 			sess.StatusError = fmt.Sprintf("%s failed: %v", stage, err)
 		}
-		s.store.Update(sess)
+		if updateErr := s.store.Update(sess); updateErr != nil {
+			slog.ErrorContext(ctx, "failed to persist broken status", "stage", stage, "error", updateErr)
+		}
 	}
 
 	var worktreeCreated bool
@@ -281,7 +289,9 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace, tmuxN
 			if errors.As(err, &w) {
 				setupWarning = w.Message
 				sess.StatusError = w.Message
-				s.store.Update(sess)
+				if updateErr := s.store.Update(sess); updateErr != nil {
+					slog.WarnContext(ctx, "failed to persist setup warning", "error", updateErr)
+				}
 			} else {
 				markBroken("branch setup", err)
 				return
@@ -300,7 +310,10 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace, tmuxN
 				slog.Warn("failed to create branch record", "branch", finalBranchName, "error", err)
 			} else {
 				sess.BranchID = &branch.ID
-				s.store.Update(sess)
+				if updateErr := s.store.Update(sess); updateErr != nil {
+					markBroken("persist branch id", updateErr)
+					return
+				}
 			}
 		}
 
@@ -328,7 +341,10 @@ func (s *SessionService) runSetup(sessionID uint, ws *workspace.Workspace, tmuxN
 	if setupWarning == "" {
 		sess.StatusError = ""
 	}
-	s.store.Update(sess)
+	if err := s.store.Update(sess); err != nil {
+		markBroken("persist active status", err)
+		return
+	}
 }
 
 func (s *SessionService) setupBranch(ctx context.Context, ws *workspace.Workspace, branchName string, baseBranchName string) error {
@@ -560,7 +576,9 @@ func (s *SessionService) RepairSession(ctx context.Context, id uint) (*Session, 
 
 	sess.Status = StatusCreating
 	sess.StatusError = ""
-	s.store.Update(sess)
+	if err := s.store.Update(sess); err != nil {
+		return nil, fmt.Errorf("failed to mark session for repair: %w", err)
+	}
 
 	var ws *workspace.Workspace
 	if sess.WorkspaceID != 0 {
@@ -667,9 +685,13 @@ func (s *SessionService) ActivateSession(ctx context.Context, id uint) (*Session
 			if existing.IsAttached {
 				slog.Info("clearing attached flag", "session", existing.ID)
 				existing.IsAttached = false
-				s.store.Update(&existing)
+				if updateErr := s.store.Update(&existing); updateErr != nil {
+					slog.Warn("failed to clear attached flag", "session", existing.ID, "error", updateErr)
+				}
 			}
 		}
+	} else {
+		slog.Warn("failed to list sessions while clearing attached flags", "error", err)
 	}
 
 	session.LastUsedAt = time.Now()
@@ -720,6 +742,7 @@ func (s *SessionService) DeleteSession(ctx context.Context, id uint, deleteBranc
 		if err := s.tmuxService.KillSession(*session.TmuxSessionID); err != nil {
 			slog.Warn("failed to kill tmux session", "error", err)
 		}
+		session.TmuxSessionID = nil
 	}
 
 	session.Status = StatusDeleted
@@ -956,7 +979,9 @@ func (s *SessionService) ReconcileSession(ctx context.Context, id uint) (*Sessio
 		}
 	}
 
-	s.store.Update(sess)
+	if err := s.store.Update(sess); err != nil {
+		return nil, fmt.Errorf("failed to persist reconciled session: %w", err)
+	}
 	return sess, nil
 }
 

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -232,7 +232,9 @@ func (s *SessionService) CreateSession(ctx context.Context, session *Session, br
 	}
 
 	if session.WorkspaceID != 0 {
-		s.workspaceService.Touch(ctx, session.WorkspaceID)
+		if err := s.workspaceService.Touch(ctx, session.WorkspaceID); err != nil {
+			slog.Warn("failed to touch workspace last-used timestamp", "workspace", session.WorkspaceID, "error", err)
+		}
 	}
 
 	go s.runSetup(session.ID, ws, tmuxName, branchName, baseBranchName, createWorktree)
@@ -702,13 +704,17 @@ func (s *SessionService) ActivateSession(ctx context.Context, id uint) (*Session
 	}
 
 	if session.WorkspaceID != 0 {
-		s.workspaceService.Touch(ctx, session.WorkspaceID)
+		if err := s.workspaceService.Touch(ctx, session.WorkspaceID); err != nil {
+			slog.Warn("failed to touch workspace last-used timestamp", "workspace", session.WorkspaceID, "error", err)
+		}
 	}
 
-	s.eventBus.Publish(ctx, eventbus.Event{
+	if err := s.eventBus.Publish(ctx, eventbus.Event{
 		Type: eventbus.SessionActivated,
 		Data: eventbus.SessionActivatedEvent{SessionName: tmuxName},
-	})
+	}); err != nil {
+		slog.Warn("failed to publish session activated event", "session", session.ID, "error", err)
+	}
 
 	return session, nil
 }
@@ -796,7 +802,9 @@ func (s *SessionService) handleTmuxSessionCreated(ctx context.Context, event eve
 		return nil
 	}
 
-	s.RefreshSession(ctx, sess.ID)
+	if _, err := s.RefreshSession(ctx, sess.ID); err != nil {
+		slog.Warn("failed to refresh session after tmux create", "session", sess.ID, "error", err)
+	}
 	return nil
 }
 
@@ -885,7 +893,9 @@ func (s *SessionService) reconcileTmuxState(ctx context.Context) {
 	}
 	for _, sess := range sessions {
 		if sess.Status != StatusDeleted {
-			s.RefreshSession(ctx, sess.ID)
+			if _, err := s.RefreshSession(ctx, sess.ID); err != nil {
+				slog.Warn("failed to refresh session during reconcile", "session", sess.ID, "error", err)
+			}
 		}
 	}
 }
@@ -902,12 +912,17 @@ func (s *SessionService) ArchiveSession(ctx context.Context, id uint) (*Session,
 	if sess.BranchID != nil && sess.GitBranch != nil {
 		ws, _ := s.workspaceService.GetWorkspace(ctx, sess.WorkspaceID)
 		if ws != nil {
-			s.gitService.CleanupBranch(ctx, sess.GitBranch, ws.Path, false)
+			if err := s.gitService.CleanupBranch(ctx, sess.GitBranch, ws.Path, false); err != nil {
+				slog.Warn("failed to cleanup branch during archive", "session", sess.ID, "error", err)
+			}
 		}
 	}
 
 	if sess.TmuxSessionID != nil {
-		s.tmuxService.KillSession(*sess.TmuxSessionID)
+		if err := s.tmuxService.KillSession(*sess.TmuxSessionID); err != nil {
+			slog.Warn("failed to kill tmux session during archive", "session", sess.ID, "error", err)
+		}
+		sess.TmuxSessionID = nil
 	}
 
 	sess.Status = StatusArchived
@@ -930,10 +945,12 @@ func (s *SessionService) DismissSession(ctx context.Context, id uint) error {
 	if sess.BranchID != nil && s.dismissedPRStore != nil {
 		prs := s.gitService.GetPRsForBranch(*sess.BranchID)
 		for _, pr := range prs {
-			s.dismissedPRStore.Add(&DismissedPR{
+			if err := s.dismissedPRStore.Add(&DismissedPR{
 				PullRequestID: pr.ID,
 				DismissedAt:   time.Now(),
-			})
+			}); err != nil {
+				slog.Warn("failed to record dismissed PR", "pr", pr.ID, "error", err)
+			}
 		}
 	}
 

--- a/internal/session/sessionservice_pr_test.go
+++ b/internal/session/sessionservice_pr_test.go
@@ -34,7 +34,7 @@ func setupPRTestEnv(t *testing.T) *prTestEnv {
 
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	database.Migrate(
+	require.NoError(t, database.Migrate(
 		&workspace.Workspace{},
 		&git.Repo{},
 		&git.Branch{},
@@ -45,8 +45,12 @@ func setupPRTestEnv(t *testing.T) *prTestEnv {
 		&DismissedPR{},
 		&claude.ClaudeSession{},
 		&SessionAction{},
-	)
-	t.Cleanup(func() { database.Close() })
+	))
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	bus := eventbus.NewEventBus()
 	sessionStore := NewSessionStore(database)

--- a/internal/session/sessionservice_pr_test.go
+++ b/internal/session/sessionservice_pr_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/eleonorayaya/utena/internal/claude"
 	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/eleonorayaya/utena/internal/eventbus"
 	"github.com/eleonorayaya/utena/internal/git"
 	utmux "github.com/eleonorayaya/utena/internal/tmux"
@@ -32,9 +33,7 @@ type prTestEnv struct {
 func setupPRTestEnv(t *testing.T) *prTestEnv {
 	t.Helper()
 
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(
+	database := testdb.New(t,
 		&workspace.Workspace{},
 		&git.Repo{},
 		&git.Branch{},
@@ -45,12 +44,7 @@ func setupPRTestEnv(t *testing.T) *prTestEnv {
 		&DismissedPR{},
 		&claude.ClaudeSession{},
 		&SessionAction{},
-	))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	)
 
 	bus := eventbus.NewEventBus()
 	sessionStore := NewSessionStore(database)

--- a/internal/session/sessionservice_pr_test.go
+++ b/internal/session/sessionservice_pr_test.go
@@ -3,6 +3,9 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -413,6 +416,83 @@ func TestHandlePRDiscovered_SkipsDismissed(t *testing.T) {
 
 	_, err = env.sessionStore.GetByBranchID(env.branch.ID)
 	require.Error(t, err)
+}
+
+func TestHandlePRUpdated_BareWorkspace_CreatesWorktree(t *testing.T) {
+	repoPath := initTestRepo(t)
+	branchName := "feature/pr-branch"
+
+	worktreeStaging := filepath.Join(repoPath, ".worktrees", "feature-pr-branch")
+	cmd := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branchName, worktreeStaging, "main")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "pre-create branch failed: %s", string(out))
+
+	pushCmd := exec.Command("git", "-C", worktreeStaging, "push", "-u", "origin", branchName)
+	out, err = pushCmd.CombinedOutput()
+	require.NoError(t, err, "push branch failed: %s", string(out))
+
+	rmWtCmd := exec.Command("git", "-C", repoPath, "worktree", "remove", "--force", worktreeStaging)
+	out, err = rmWtCmd.CombinedOutput()
+	require.NoError(t, err, "remove staging worktree failed: %s", string(out))
+
+	database := setupTestDB(t)
+	ctx := context.Background()
+	gitService := git.NewGitService(database)
+	require.NoError(t, gitService.MigrateToBare(ctx, repoPath))
+
+	repo := &git.Repo{Path: repoPath, FullName: "test/repo"}
+	require.NoError(t, database.Create(repo).Error)
+
+	bus := eventbus.NewEventBus()
+	sessionStore := NewSessionStore(database)
+	workspaceStore := workspace.NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
+	repoID := repo.ID
+	wsGit := &workspace.Workspace{Name: "git-repo", Path: repoPath, IsGitRepo: true, IsBare: true, RepoID: &repoID}
+	require.NoError(t, workspaceStore.Add(wsGit))
+
+	branch := &git.Branch{Name: branchName, RepoID: repo.ID, ExistsRemote: true}
+	require.NoError(t, database.Create(branch).Error)
+
+	mock := utmux.NewMockRunner()
+	tmuxService := createTmuxService(t, database, mock, bus)
+	workspaceService := workspace.NewWorkspaceService(workspaceStore)
+	dismissedPRStore := NewDismissedPRStore(database)
+	sessionActionStore := NewSessionActionStore(database)
+	service := NewSessionService(sessionStore, dismissedPRStore, sessionActionStore, workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir())
+
+	branchID := branch.ID
+	event := eventbus.Event{
+		Type: git.EventPRUpdated,
+		Data: git.PRUpdatedEvent{
+			PullRequest: &git.PullRequest{
+				RepoID:         repo.ID,
+				Number:         42,
+				HeadBranchID:   &branchID,
+				Title:          "Test PR",
+				State:          git.PRStateOpen,
+				IsAssignedToMe: true,
+			},
+			Previous: nil,
+			Repo:     repo,
+		},
+	}
+
+	require.NoError(t, service.handlePRUpdated(ctx, event))
+
+	sess, err := sessionStore.GetByBranchID(branchID)
+	require.NoError(t, err)
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 10*time.Second)
+
+	expectedWorktree := filepath.Join(repoPath, "feature-pr-branch")
+	info, err := os.Stat(expectedWorktree)
+	require.NoError(t, err, "worktree should be created at %s", expectedWorktree)
+	require.True(t, info.IsDir())
+
+	tmuxName := BuildTmuxSessionName(wsGit.Name, sess.Name)
+	require.True(t, mock.HasSessionByName(tmuxName), "tmux session %s should exist", tmuxName)
+	ts, err := tmuxService.GetSessionByName(tmuxName)
+	require.NoError(t, err)
+	require.Equal(t, expectedWorktree, ts.StartDir, "tmux session should start in the worktree, not the bare workspace root")
 }
 
 func TestHandlePRUpdated_NewAssignedPR_CreatesSessionAction(t *testing.T) {

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/eleonorayaya/utena/internal/eventbus"
 	"github.com/eleonorayaya/utena/internal/git"
 	utmux "github.com/eleonorayaya/utena/internal/tmux"
@@ -41,14 +42,7 @@ func setupSessionService(t *testing.T) (*SessionService, *SessionStore, *workspa
 	mock := utmux.NewMockRunner()
 	tmuxService := createTmuxService(t, database, mock, bus)
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
-	gitDB, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, gitDB.Migrate(&git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
-	t.Cleanup(func() {
-		if err := gitDB.Close(); err != nil {
-			t.Logf("close gitDB: %v", err)
-		}
-	})
+	gitDB := testdb.New(t, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
 	gitService := git.NewGitService(gitDB)
 	dismissedPRStore := NewDismissedPRStore(database)
 	sessionActionStore := NewSessionActionStore(database)
@@ -691,14 +685,7 @@ func TestSessionService_CreateSession_NonGitWorkspace_SkipsWorktree(t *testing.T
 	mock := utmux.NewMockRunner()
 	tmuxService := createTmuxService(t, database, mock, bus)
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
-	gitDB, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, gitDB.Migrate(&git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
-	t.Cleanup(func() {
-		if err := gitDB.Close(); err != nil {
-			t.Logf("close gitDB: %v", err)
-		}
-	})
+	gitDB := testdb.New(t, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
 	gitService := git.NewGitService(gitDB)
 	dismissedPRStore := NewDismissedPRStore(database)
 	sessionActionStore := NewSessionActionStore(database)
@@ -710,8 +697,7 @@ func TestSessionService_CreateSession_NonGitWorkspace_SkipsWorktree(t *testing.T
 	}
 
 	ctx := context.Background()
-	err = service.CreateSession(ctx, session, "", "main", false)
-	require.NoError(t, err)
+	require.NoError(t, service.CreateSession(ctx, session, "", "main", false))
 
 	waitForStatus(t, sessionStore, session.ID, StatusActive, 2*time.Second)
 }

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -35,16 +35,20 @@ func setupSessionService(t *testing.T) (*SessionService, *SessionStore, *workspa
 
 	ws1 := &workspace.Workspace{Name: "utena", Path: "/tmp/utena"}
 	ws2 := &workspace.Workspace{Name: "other", Path: "/tmp/other"}
-	workspaceStore.Add(ws1)
-	workspaceStore.Add(ws2)
+	require.NoError(t, workspaceStore.Add(ws1))
+	require.NoError(t, workspaceStore.Add(ws2))
 
 	mock := utmux.NewMockRunner()
 	tmuxService := createTmuxService(t, database, mock, bus)
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitDB, err := db.OpenInMemory()
 	require.NoError(t, err)
-	gitDB.Migrate(&git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
-	t.Cleanup(func() { gitDB.Close() })
+	require.NoError(t, gitDB.Migrate(&git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
+	t.Cleanup(func() {
+		if err := gitDB.Close(); err != nil {
+			t.Logf("close gitDB: %v", err)
+		}
+	})
 	gitService := git.NewGitService(gitDB)
 	dismissedPRStore := NewDismissedPRStore(database)
 	sessionActionStore := NewSessionActionStore(database)
@@ -113,8 +117,8 @@ func TestSessionService_ListSessions(t *testing.T) {
 	now := time.Now()
 	session1 := &Session{Name: "session-1", WorkspaceID: ws1ID, Status: StatusActive, LastUsedAt: now.Add(-1 * time.Hour)}
 	session2 := &Session{Name: "session-2", WorkspaceID: ws2ID, Status: StatusActive, LastUsedAt: now}
-	sessionStore.Add(session1)
-	sessionStore.Add(session2)
+	require.NoError(t, sessionStore.Add(session1))
+	require.NoError(t, sessionStore.Add(session2))
 
 	ctx := context.Background()
 	sessions, err := service.ListSessions(ctx)
@@ -131,9 +135,9 @@ func TestSessionService_ListSessionsByWorkspace(t *testing.T) {
 	session1 := &Session{Name: "session-1", WorkspaceID: ws1ID, Status: StatusActive, LastUsedAt: now.Add(-1 * time.Hour)}
 	session2 := &Session{Name: "session-2", WorkspaceID: ws2ID, Status: StatusActive, LastUsedAt: now}
 	session3 := &Session{Name: "session-3", WorkspaceID: ws1ID, Status: StatusActive, LastUsedAt: now}
-	sessionStore.Add(session1)
-	sessionStore.Add(session2)
-	sessionStore.Add(session3)
+	require.NoError(t, sessionStore.Add(session1))
+	require.NoError(t, sessionStore.Add(session2))
+	require.NoError(t, sessionStore.Add(session3))
 
 	ctx := context.Background()
 	sessions, err := service.ListSessionsByWorkspace(ctx, ws1ID)
@@ -166,7 +170,7 @@ func TestSessionService_GetSession(t *testing.T) {
 		Status:      StatusActive,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	ctx := context.Background()
 	retrieved, err := service.GetSession(ctx, session.ID)
@@ -290,7 +294,7 @@ func TestSessionService_UpdateSession(t *testing.T) {
 		Status:      StatusActive,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	session.IsAttached = true
 	ctx := context.Background()
@@ -310,7 +314,7 @@ func TestSessionService_UpdateSession_InvalidWorkspace(t *testing.T) {
 		WorkspaceID: ws1ID,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	session.WorkspaceID = 99999
 	ctx := context.Background()
@@ -444,7 +448,7 @@ func setupWorktreeSessionServiceFull(t *testing.T, repoPath string, configDir st
 	sessionStore := NewSessionStore(database)
 	workspaceStore := workspace.NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
 	wsGit := &workspace.Workspace{Name: "git-repo", Path: repoPath, IsGitRepo: true}
-	workspaceStore.Add(wsGit)
+	require.NoError(t, workspaceStore.Add(wsGit))
 
 	mock := utmux.NewMockRunner()
 	tmuxService := createTmuxService(t, database, mock, bus)
@@ -682,15 +686,19 @@ func TestSessionService_CreateSession_NonGitWorkspace_SkipsWorktree(t *testing.T
 	sessionStore := NewSessionStore(database)
 	workspaceStore := workspace.NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
 	wsNoGit := &workspace.Workspace{Name: "plain", Path: "/tmp/plain", IsGitRepo: false}
-	workspaceStore.Add(wsNoGit)
+	require.NoError(t, workspaceStore.Add(wsNoGit))
 
 	mock := utmux.NewMockRunner()
 	tmuxService := createTmuxService(t, database, mock, bus)
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	gitDB, err := db.OpenInMemory()
 	require.NoError(t, err)
-	gitDB.Migrate(&git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
-	t.Cleanup(func() { gitDB.Close() })
+	require.NoError(t, gitDB.Migrate(&git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
+	t.Cleanup(func() {
+		if err := gitDB.Close(); err != nil {
+			t.Logf("close gitDB: %v", err)
+		}
+	})
 	gitService := git.NewGitService(gitDB)
 	dismissedPRStore := NewDismissedPRStore(database)
 	sessionActionStore := NewSessionActionStore(database)
@@ -735,7 +743,7 @@ func TestSessionService_ActivateSession_TouchesWorkspace(t *testing.T) {
 		Status:      StatusActive,
 		LastUsedAt:  time.Now().Add(-1 * time.Hour),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	ctx := context.Background()
 	_, err := service.ActivateSession(ctx, session.ID)
@@ -755,7 +763,7 @@ func TestSessionService_ActivateSession_RejectsBrokenSession(t *testing.T) {
 		Status:      StatusBroken,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	ctx := context.Background()
 	_, err := service.ActivateSession(ctx, session.ID)
@@ -814,7 +822,7 @@ func TestSessionService_ActivateSession_RecreatesMissingTmux(t *testing.T) {
 		Status:      StatusActive,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	ctx := context.Background()
 	result, err := service.ActivateSession(ctx, session.ID)
@@ -838,7 +846,7 @@ func TestSessionService_RefreshSession_DetectsMissingTmux(t *testing.T) {
 	waitForStatus(t, sessionStore, session.ID, StatusActive, 2*time.Second)
 
 	tmux.RemoveSession("utena-session-1")
-	service.tmuxService.HandleSessionClosed(ctx, "utena-session-1")
+	require.NoError(t, service.tmuxService.HandleSessionClosed(ctx, "utena-session-1"))
 
 	refreshed, err := service.RefreshSession(ctx, session.ID)
 	require.NoError(t, err)
@@ -872,7 +880,7 @@ func TestSessionService_RepairSession_RecoversBroken(t *testing.T) {
 		Status:      StatusBroken,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	ctx := context.Background()
 	result, err := service.RepairSession(ctx, session.ID)
@@ -897,7 +905,7 @@ func TestSessionService_RepairSession_StillFailing(t *testing.T) {
 		Status:      StatusBroken,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	ctx := context.Background()
 	result, err := service.RepairSession(ctx, session.ID)
@@ -922,7 +930,7 @@ func TestSessionService_RepairSession_AlreadyReady(t *testing.T) {
 		Status:      StatusBroken,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	ctx := context.Background()
 	result, err := service.RepairSession(ctx, session.ID)
@@ -942,7 +950,7 @@ func TestSessionService_RepairSession_NotBroken(t *testing.T) {
 		Status:      StatusActive,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	ctx := context.Background()
 	_, err := service.RepairSession(ctx, session.ID)
@@ -968,7 +976,7 @@ func TestSessionService_Reconcile_MarksMissingTmuxBroken(t *testing.T) {
 	require.NotNil(t, retrieved.TmuxSessionID)
 
 	tmux.RemoveSession("utena-session-1")
-	service.tmuxService.HandleSessionClosed(ctx, "utena-session-1")
+	require.NoError(t, service.tmuxService.HandleSessionClosed(ctx, "utena-session-1"))
 
 	service.reconcileTmuxState(ctx)
 
@@ -1006,7 +1014,7 @@ func TestSessionService_Reconcile_SkipsDeleted(t *testing.T) {
 		Status:      StatusDeleted,
 		LastUsedAt:  time.Now(),
 	}
-	sessionStore.Add(session)
+	require.NoError(t, sessionStore.Add(session))
 
 	ctx := context.Background()
 	service.reconcileTmuxState(ctx)
@@ -1254,7 +1262,7 @@ func setupBareWorktreeSessionService(t *testing.T, configDir string) (*SessionSe
 	sessionStore := NewSessionStore(database)
 	workspaceStore := workspace.NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
 	wsGit := &workspace.Workspace{Name: "git-repo", Path: repoPath, IsGitRepo: true, IsBare: true}
-	workspaceStore.Add(wsGit)
+	require.NoError(t, workspaceStore.Add(wsGit))
 
 	mock := utmux.NewMockRunner()
 	tmuxService := createTmuxService(t, database, mock, bus)

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -209,6 +209,41 @@ func TestSessionService_CreateSession(t *testing.T) {
 	require.True(t, tmux.HasSessionByName("utena-session-1"))
 }
 
+func TestSessionService_CreateSession_DuplicateNameInWorkspace_Errors(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, ws2ID := setupSessionService(t)
+
+	ctx := context.Background()
+	first := &Session{Name: "dup", WorkspaceID: ws1ID}
+	require.NoError(t, service.CreateSession(ctx, first, "", "", false))
+	waitForStatus(t, sessionStore, first.ID, StatusActive, 2*time.Second)
+
+	second := &Session{Name: "dup", WorkspaceID: ws1ID}
+	err := service.CreateSession(ctx, second, "", "", false)
+	require.ErrorIs(t, err, ErrSessionAlreadyExists)
+	require.Zero(t, second.ID, "duplicate session should not be persisted")
+
+	otherWorkspace := &Session{Name: "dup", WorkspaceID: ws2ID}
+	require.NoError(t, service.CreateSession(ctx, otherWorkspace, "", "", false), "same name in a different workspace must be allowed")
+}
+
+func TestSessionService_CreateSession_DuplicateNameAfterDelete_Allowed(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, _ := setupSessionService(t)
+
+	ctx := context.Background()
+	first := &Session{Name: "reusable", WorkspaceID: ws1ID}
+	require.NoError(t, service.CreateSession(ctx, first, "", "", false))
+	waitForStatus(t, sessionStore, first.ID, StatusActive, 2*time.Second)
+	require.NoError(t, service.DeleteSession(ctx, first.ID, false, false))
+
+	deleted, err := sessionStore.GetByID(first.ID)
+	require.NoError(t, err)
+	require.Nil(t, deleted.TmuxSessionID, "deleted session should not retain tmux_session_id")
+
+	second := &Session{Name: "reusable", WorkspaceID: ws1ID}
+	require.NoError(t, service.CreateSession(ctx, second, "", "", false))
+	waitForStatus(t, sessionStore, second.ID, StatusActive, 2*time.Second)
+}
+
 func TestSessionService_CreateSession_TmuxFails(t *testing.T) {
 	service, sessionStore, _, tmux, ws1ID, _ := setupSessionService(t)
 	tmux.SetCreateErr(fmt.Errorf("connection refused"))

--- a/internal/session/sessionstore.go
+++ b/internal/session/sessionstore.go
@@ -97,9 +97,9 @@ func (s *SessionStore) Delete(id uint) error {
 
 func (s *SessionStore) GetByWorkspaceAndName(workspaceID uint, name string, excludeStatuses ...SessionStatus) (*Session, error) {
 	var session Session
-	q := s.db.Joins("Workspace").Joins("GitBranch").Joins("TmuxSession").Where("sessions.workspace_id = ? AND sessions.name = ?", workspaceID, name)
+	q := s.db.Where("workspace_id = ? AND name = ?", workspaceID, name)
 	if len(excludeStatuses) > 0 {
-		q = q.Where("sessions.status NOT IN ?", excludeStatuses)
+		q = q.Where("status NOT IN ?", excludeStatuses)
 	}
 	if err := q.First(&session).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/session/sessionstore.go
+++ b/internal/session/sessionstore.go
@@ -95,6 +95,21 @@ func (s *SessionStore) Delete(id uint) error {
 	return s.db.Delete(&Session{}, "id = ?", id).Error
 }
 
+func (s *SessionStore) GetByWorkspaceAndName(workspaceID uint, name string, excludeStatuses ...SessionStatus) (*Session, error) {
+	var session Session
+	q := s.db.Joins("Workspace").Joins("GitBranch").Joins("TmuxSession").Where("sessions.workspace_id = ? AND sessions.name = ?", workspaceID, name)
+	if len(excludeStatuses) > 0 {
+		q = q.Where("sessions.status NOT IN ?", excludeStatuses)
+	}
+	if err := q.First(&session).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrSessionNotFound
+		}
+		return nil, err
+	}
+	return &session, nil
+}
+
 func (s *SessionStore) GetByBranchID(branchID uint) (*Session, error) {
 	var session Session
 	if err := s.db.Joins("Workspace").Joins("GitBranch").Joins("TmuxSession").First(&session, "sessions.branch_id = ?", branchID).Error; err != nil {

--- a/internal/session/sessionstore_test.go
+++ b/internal/session/sessionstore_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/eleonorayaya/utena/internal/claude"
 	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/eleonorayaya/utena/internal/git"
 	utmux "github.com/eleonorayaya/utena/internal/tmux"
 	"github.com/eleonorayaya/utena/internal/workspace"
@@ -17,18 +18,7 @@ import (
 )
 
 func setupTestDB(t *testing.T) db.Database {
-	t.Helper()
-	database, err := db.OpenInMemory()
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.NoError(t, database.Migrate(&workspace.Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}, &utmux.TmuxSession{}, &Session{}, &claude.ClaudeSession{}, &SessionAction{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
-	return database
+	return testdb.New(t, &workspace.Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}, &utmux.TmuxSession{}, &Session{}, &claude.ClaudeSession{}, &SessionAction{})
 }
 
 func setupSessionStore(t *testing.T) (*SessionStore, uint, uint) {
@@ -321,16 +311,7 @@ func TestSessionStore_OnAppEnd(t *testing.T) {
 
 func setupTestDBWithGitAndTmux(t *testing.T) (db.Database, uint, *git.Branch, *utmux.TmuxSession) {
 	t.Helper()
-	database, err := db.OpenInMemory()
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.NoError(t, database.Migrate(&workspace.Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}, &utmux.TmuxSession{}, &Session{}, &claude.ClaudeSession{}, &SessionAction{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	database := testdb.New(t, &workspace.Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}, &utmux.TmuxSession{}, &Session{}, &claude.ClaudeSession{}, &SessionAction{})
 
 	ws := &workspace.Workspace{Name: "utena", Path: "/tmp/utena"}
 	database.Create(ws)

--- a/internal/session/sessionstore_test.go
+++ b/internal/session/sessionstore_test.go
@@ -22,8 +22,12 @@ func setupTestDB(t *testing.T) db.Database {
 	if err != nil {
 		t.Fatal(err)
 	}
-	database.Migrate(&workspace.Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}, &utmux.TmuxSession{}, &Session{}, &claude.ClaudeSession{}, &SessionAction{})
-	t.Cleanup(func() { database.Close() })
+	require.NoError(t, database.Migrate(&workspace.Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}, &utmux.TmuxSession{}, &Session{}, &claude.ClaudeSession{}, &SessionAction{}))
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 	return database
 }
 
@@ -106,7 +110,7 @@ func TestSessionStore_GetByID(t *testing.T) {
 		LastUsedAt:  time.Now(),
 	}
 
-	store.Add(session)
+	require.NoError(t, store.Add(session))
 
 	retrieved, err := store.GetByID(session.ID)
 	require.NoError(t, err)
@@ -132,9 +136,9 @@ func TestSessionStore_List(t *testing.T) {
 	session2 := &Session{Name: "session-2", WorkspaceID: ws2ID, LastUsedAt: now}
 	session3 := &Session{Name: "session-3", WorkspaceID: ws1ID, LastUsedAt: now.Add(-1 * time.Hour)}
 
-	store.Add(session1)
-	store.Add(session2)
-	store.Add(session3)
+	require.NoError(t, store.Add(session1))
+	require.NoError(t, store.Add(session2))
+	require.NoError(t, store.Add(session3))
 
 	list, _ := store.List()
 	require.Len(t, list, 3)
@@ -158,9 +162,9 @@ func TestSessionStore_ListByWorkspace(t *testing.T) {
 	session2 := &Session{Name: "session-2", WorkspaceID: ws2ID, LastUsedAt: now}
 	session3 := &Session{Name: "session-3", WorkspaceID: ws1ID, LastUsedAt: now.Add(-1 * time.Hour)}
 
-	store.Add(session1)
-	store.Add(session2)
-	store.Add(session3)
+	require.NoError(t, store.Add(session1))
+	require.NoError(t, store.Add(session2))
+	require.NoError(t, store.Add(session3))
 
 	ws1Sessions, err := store.ListByWorkspace(ws1ID)
 	require.NoError(t, err)
@@ -196,7 +200,7 @@ func TestSessionStore_Update(t *testing.T) {
 		LastUsedAt:  time.Now(),
 	}
 
-	store.Add(session)
+	require.NoError(t, store.Add(session))
 
 	session.IsAttached = true
 	session.LastUsedAt = time.Now().Add(1 * time.Hour)
@@ -238,7 +242,7 @@ func TestSessionStore_Delete(t *testing.T) {
 	store, ws1ID, _ := setupSessionStore(t)
 
 	session := &Session{Name: "session-1", WorkspaceID: ws1ID, LastUsedAt: time.Now()}
-	store.Add(session)
+	require.NoError(t, store.Add(session))
 
 	err := store.Delete(session.ID)
 	require.NoError(t, err)
@@ -279,7 +283,7 @@ func TestSessionStore_ConcurrentAccess(t *testing.T) {
 				WorkspaceID: ws1ID,
 				LastUsedAt:  time.Now(),
 			}
-			store.Add(session)
+			require.NoError(t, store.Add(session))
 		}(i)
 	}
 
@@ -321,8 +325,12 @@ func setupTestDBWithGitAndTmux(t *testing.T) (db.Database, uint, *git.Branch, *u
 	if err != nil {
 		t.Fatal(err)
 	}
-	database.Migrate(&workspace.Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}, &utmux.TmuxSession{}, &Session{}, &claude.ClaudeSession{}, &SessionAction{})
-	t.Cleanup(func() { database.Close() })
+	require.NoError(t, database.Migrate(&workspace.Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}, &utmux.TmuxSession{}, &Session{}, &claude.ClaudeSession{}, &SessionAction{}))
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	ws := &workspace.Workspace{Name: "utena", Path: "/tmp/utena"}
 	database.Create(ws)

--- a/internal/tmux/tmuxmodule_test.go
+++ b/internal/tmux/tmuxmodule_test.go
@@ -11,7 +11,11 @@ import (
 func TestTmuxModule_Models(t *testing.T) {
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	t.Cleanup(func() { database.Close() })
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	bus := eventbus.NewEventBus()
 	mock := NewMockRunner()
@@ -25,7 +29,11 @@ func TestTmuxModule_Models(t *testing.T) {
 func TestTmuxModule_InitializesWithoutError(t *testing.T) {
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	t.Cleanup(func() { database.Close() })
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	bus := eventbus.NewEventBus()
 	mock := NewMockRunner()

--- a/internal/tmux/tmuxmodule_test.go
+++ b/internal/tmux/tmuxmodule_test.go
@@ -3,19 +3,13 @@ package tmux
 import (
 	"testing"
 
-	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/eleonorayaya/utena/internal/eventbus"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTmuxModule_Models(t *testing.T) {
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	database := testdb.New(t)
 
 	bus := eventbus.NewEventBus()
 	mock := NewMockRunner()
@@ -27,13 +21,7 @@ func TestTmuxModule_Models(t *testing.T) {
 }
 
 func TestTmuxModule_InitializesWithoutError(t *testing.T) {
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	database := testdb.New(t)
 
 	bus := eventbus.NewEventBus()
 	mock := NewMockRunner()

--- a/internal/tmux/tmuxservice.go
+++ b/internal/tmux/tmuxservice.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"sync"
 
 	"github.com/eleonorayaya/utena/internal/eventbus"
@@ -191,7 +192,9 @@ func (t *TmuxService) HandleSessionCreated(ctx context.Context, tmuxName string)
 	ts, err := t.store.GetByName(tmuxName)
 	if err == nil {
 		ts.IsAlive = true
-		t.store.Update(ts)
+		if updateErr := t.store.Update(ts); updateErr != nil {
+			slog.Warn("failed to mark tmux session alive", "tmux", tmuxName, "error", updateErr)
+		}
 	}
 	return t.eventBus.Publish(ctx, eventbus.Event{
 		Type: eventbus.TmuxSessionCreated,
@@ -203,7 +206,9 @@ func (t *TmuxService) HandleSessionClosed(ctx context.Context, tmuxName string) 
 	ts, err := t.store.GetByName(tmuxName)
 	if err == nil {
 		ts.IsAlive = false
-		t.store.Update(ts)
+		if updateErr := t.store.Update(ts); updateErr != nil {
+			slog.Warn("failed to mark tmux session dead", "tmux", tmuxName, "error", updateErr)
+		}
 	}
 	delete(t.windowsBySession, tmuxName)
 	return t.eventBus.Publish(ctx, eventbus.Event{

--- a/internal/tmux/tmuxservice_test.go
+++ b/internal/tmux/tmuxservice_test.go
@@ -60,7 +60,11 @@ func TestTmuxService_LockNameDoesNotBlockDifferentNames(t *testing.T) {
 func TestTmuxService_ConcurrentKillCreateNoOverlap(t *testing.T) {
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	t.Cleanup(func() { database.Close() })
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 	require.NoError(t, database.Migrate(&TmuxSession{}))
 
 	bus := eventbus.NewEventBus()

--- a/internal/tmux/tmuxservice_test.go
+++ b/internal/tmux/tmuxservice_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/eleonorayaya/utena/internal/eventbus"
 	"github.com/stretchr/testify/require"
 )
@@ -58,14 +58,7 @@ func TestTmuxService_LockNameDoesNotBlockDifferentNames(t *testing.T) {
 }
 
 func TestTmuxService_ConcurrentKillCreateNoOverlap(t *testing.T) {
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
-	require.NoError(t, database.Migrate(&TmuxSession{}))
+	database := testdb.New(t, &TmuxSession{})
 
 	bus := eventbus.NewEventBus()
 	mock := NewMockRunner()

--- a/internal/tmux/tmuxstore_test.go
+++ b/internal/tmux/tmuxstore_test.go
@@ -5,21 +5,13 @@ import (
 	"testing"
 
 	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func setupTestDB(t *testing.T) db.Database {
-	t.Helper()
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(&TmuxSession{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
-	return database
+	return testdb.New(t, &TmuxSession{})
 }
 
 func TestAddAndGetByID(t *testing.T) {

--- a/internal/tmux/tmuxstore_test.go
+++ b/internal/tmux/tmuxstore_test.go
@@ -14,7 +14,11 @@ func setupTestDB(t *testing.T) db.Database {
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
 	require.NoError(t, database.Migrate(&TmuxSession{}))
-	t.Cleanup(func() { database.Close() })
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 	return database
 }
 

--- a/internal/todo/todocontroller.go
+++ b/internal/todo/todocontroller.go
@@ -29,7 +29,7 @@ func (c *TodoController) ListTodos(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := NewTodoListResponse(todos)
-	render.Render(w, r, response)
+	common.RenderResponse(w, r, response)
 }
 
 func (c *TodoController) CreateTodo(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +48,7 @@ func (c *TodoController) CreateTodo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	render.Status(r, http.StatusCreated)
-	render.Render(w, r, NewTodoResponse(t))
+	common.RenderResponse(w, r, NewTodoResponse(t))
 }
 
 func (c *TodoController) DeleteTodo(w http.ResponseWriter, r *http.Request) {

--- a/internal/todo/todorouter_test.go
+++ b/internal/todo/todorouter_test.go
@@ -22,8 +22,8 @@ func setupTodoRouter(t *testing.T) (*TodoRouter, *TodoStore, *workspace.Workspac
 
 	ws1 := &workspace.Workspace{Name: "utena", Path: "/tmp/utena"}
 	ws2 := &workspace.Workspace{Name: "other", Path: "/tmp/other"}
-	workspaceStore.Add(ws1)
-	workspaceStore.Add(ws2)
+	require.NoError(t, workspaceStore.Add(ws1))
+	require.NoError(t, workspaceStore.Add(ws2))
 
 	workspaceService := workspace.NewWorkspaceService(workspaceStore)
 	service := NewTodoService(todoStore, workspaceService)
@@ -162,7 +162,7 @@ func TestTodoRouter_DeleteTodo(t *testing.T) {
 	router.Routes().ServeHTTP(createW, createReq)
 
 	var created TodoResponse
-	json.Unmarshal(createW.Body.Bytes(), &created)
+	require.NoError(t, json.Unmarshal(createW.Body.Bytes(), &created))
 
 	req := httptest.NewRequest("DELETE", fmt.Sprintf("/%d", created.ID), nil)
 	w := httptest.NewRecorder()
@@ -175,7 +175,7 @@ func TestTodoRouter_DeleteTodo(t *testing.T) {
 	router.Routes().ServeHTTP(listW, listReq)
 
 	var listResp TodoListResponse
-	json.Unmarshal(listW.Body.Bytes(), &listResp)
+	require.NoError(t, json.Unmarshal(listW.Body.Bytes(), &listResp))
 	require.Empty(t, listResp.Todos)
 }
 

--- a/internal/todo/todoservice_test.go
+++ b/internal/todo/todoservice_test.go
@@ -24,7 +24,7 @@ func setupTodoService(t *testing.T) (*TodoService, *TodoStore, *workspace.Worksp
 func TestTodoService_Create(t *testing.T) {
 	service, _, workspaceStore := setupTodoService(t)
 	ws := &workspace.Workspace{Name: "utena", Path: "/tmp/utena"}
-	workspaceStore.Add(ws)
+	require.NoError(t, workspaceStore.Add(ws))
 
 	ctx := context.Background()
 	td, err := service.Create(ctx, "fix bug", "fix the login bug", &ws.ID)
@@ -63,11 +63,13 @@ func TestTodoService_Create_InvalidWorkspace(t *testing.T) {
 func TestTodoService_List(t *testing.T) {
 	service, _, workspaceStore := setupTodoService(t)
 	ws := &workspace.Workspace{Name: "utena", Path: "/tmp/utena"}
-	workspaceStore.Add(ws)
+	require.NoError(t, workspaceStore.Add(ws))
 
 	ctx := context.Background()
-	service.Create(ctx, "task 1", "", &ws.ID)
-	service.Create(ctx, "task 2", "", nil)
+	_, err := service.Create(ctx, "task 1", "", &ws.ID)
+	require.NoError(t, err)
+	_, err = service.Create(ctx, "task 2", "", nil)
+	require.NoError(t, err)
 
 	todos, err := service.List(ctx)
 	require.NoError(t, err)
@@ -77,10 +79,11 @@ func TestTodoService_List(t *testing.T) {
 func TestTodoService_List_ResolvesWorkspaceNames(t *testing.T) {
 	service, _, workspaceStore := setupTodoService(t)
 	ws := &workspace.Workspace{Name: "utena", Path: "/tmp/utena"}
-	workspaceStore.Add(ws)
+	require.NoError(t, workspaceStore.Add(ws))
 
 	ctx := context.Background()
-	service.Create(ctx, "task 1", "", &ws.ID)
+	_, err := service.Create(ctx, "task 1", "", &ws.ID)
+	require.NoError(t, err)
 
 	todos, err := service.List(ctx)
 	require.NoError(t, err)
@@ -93,13 +96,16 @@ func TestTodoService_ListByWorkspace(t *testing.T) {
 	service, _, workspaceStore := setupTodoService(t)
 	ws1 := &workspace.Workspace{Name: "utena", Path: "/tmp/utena"}
 	ws2 := &workspace.Workspace{Name: "other", Path: "/tmp/other"}
-	workspaceStore.Add(ws1)
-	workspaceStore.Add(ws2)
+	require.NoError(t, workspaceStore.Add(ws1))
+	require.NoError(t, workspaceStore.Add(ws2))
 
 	ctx := context.Background()
-	service.Create(ctx, "task 1", "", &ws1.ID)
-	service.Create(ctx, "task 2", "", &ws2.ID)
-	service.Create(ctx, "task 3", "", &ws1.ID)
+	_, err := service.Create(ctx, "task 1", "", &ws1.ID)
+	require.NoError(t, err)
+	_, err = service.Create(ctx, "task 2", "", &ws2.ID)
+	require.NoError(t, err)
+	_, err = service.Create(ctx, "task 3", "", &ws1.ID)
+	require.NoError(t, err)
 
 	ws1Todos, err := service.ListByWorkspace(ctx, ws1.ID)
 	require.NoError(t, err)
@@ -117,7 +123,7 @@ func TestTodoService_ListByWorkspace(t *testing.T) {
 func TestTodoService_Delete(t *testing.T) {
 	service, _, workspaceStore := setupTodoService(t)
 	ws := &workspace.Workspace{Name: "utena", Path: "/tmp/utena"}
-	workspaceStore.Add(ws)
+	require.NoError(t, workspaceStore.Add(ws))
 
 	ctx := context.Background()
 	td, _ := service.Create(ctx, "task", "", &ws.ID)

--- a/internal/todo/todostore_test.go
+++ b/internal/todo/todostore_test.go
@@ -20,10 +20,14 @@ func setupTestDB(t *testing.T) db.Database {
 	if err != nil {
 		t.Fatal(err)
 	}
-	database.Migrate(&workspace.Workspace{}, &Todo{})
+	require.NoError(t, database.Migrate(&workspace.Workspace{}, &Todo{}))
 	t.Cleanup(func() {
-		database.Close()
-		os.Remove(dbPath)
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+		if err := os.Remove(dbPath); err != nil {
+			t.Logf("remove db file: %v", err)
+		}
 	})
 	return database
 }
@@ -85,7 +89,7 @@ func TestTodoStore_GetByID(t *testing.T) {
 		Name:        "fix bug",
 		WorkspaceID: &ws1ID,
 	}
-	store.Add(td)
+	require.NoError(t, store.Add(td))
 
 	retrieved, err := store.GetByID(td.ID)
 	require.NoError(t, err)
@@ -105,7 +109,7 @@ func TestTodoStore_GetByID_ReturnsCopy(t *testing.T) {
 	store, _, _ := setupTodoStore(t)
 
 	td := &Todo{Name: "original"}
-	store.Add(td)
+	require.NoError(t, store.Add(td))
 
 	retrieved, _ := store.GetByID(td.ID)
 	retrieved.Name = "modified"
@@ -121,9 +125,9 @@ func TestTodoStore_List(t *testing.T) {
 	td2 := &Todo{Name: "newest"}
 	td3 := &Todo{Name: "middle"}
 
-	store.Add(td1)
-	store.Add(td2)
-	store.Add(td3)
+	require.NoError(t, store.Add(td1))
+	require.NoError(t, store.Add(td2))
+	require.NoError(t, store.Add(td3))
 
 	list := store.List()
 	require.Len(t, list, 3)
@@ -146,9 +150,9 @@ func TestTodoStore_ListByWorkspaceID(t *testing.T) {
 	td2 := &Todo{Name: "ws2", WorkspaceID: &ws2ID}
 	td3 := &Todo{Name: "ws1-new", WorkspaceID: &ws1ID}
 
-	store.Add(td1)
-	store.Add(td2)
-	store.Add(td3)
+	require.NoError(t, store.Add(td1))
+	require.NoError(t, store.Add(td2))
+	require.NoError(t, store.Add(td3))
 
 	ws1Todos := store.ListByWorkspaceID(ws1ID)
 	require.Len(t, ws1Todos, 2)
@@ -176,7 +180,7 @@ func TestTodoStore_Delete(t *testing.T) {
 	store, _, _ := setupTodoStore(t)
 
 	td := &Todo{Name: "test"}
-	store.Add(td)
+	require.NoError(t, store.Add(td))
 
 	err := store.Delete(td.ID)
 	require.NoError(t, err)
@@ -208,7 +212,7 @@ func TestTodoStore_Persistence(t *testing.T) {
 
 	store1 := NewTodoStore(database)
 	td := &Todo{Name: "persist me", WorkspaceID: &ws1ID}
-	store1.Add(td)
+	require.NoError(t, store1.Add(td))
 
 	store2 := NewTodoStore(database)
 
@@ -231,7 +235,7 @@ func TestTodoStore_ConcurrentAccess(t *testing.T) {
 			td := &Todo{
 				Name: "concurrent",
 			}
-			store.Add(td)
+			require.NoError(t, store.Add(td))
 		}(i)
 	}
 

--- a/internal/workspace/workspacecontroller.go
+++ b/internal/workspace/workspacecontroller.go
@@ -35,7 +35,7 @@ func (c *WorkspaceController) ListWorkspaces(w http.ResponseWriter, r *http.Requ
 	}
 
 	response := NewWorkspaceListResponse(workspaces)
-	render.Render(w, r, response)
+	common.RenderResponse(w, r, response)
 }
 
 func (c *WorkspaceController) GetWorkspaceByID(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +54,7 @@ func (c *WorkspaceController) GetWorkspaceByID(w http.ResponseWriter, r *http.Re
 	}
 
 	response := NewWorkspaceResponse(workspace)
-	render.Render(w, r, response)
+	common.RenderResponse(w, r, response)
 }
 
 func (c *WorkspaceController) AddWorkspace(w http.ResponseWriter, r *http.Request) {
@@ -74,10 +74,14 @@ func (c *WorkspaceController) AddWorkspace(w http.ResponseWriter, r *http.Reques
 
 	render.Status(r, http.StatusCreated)
 	if ws != nil {
-		render.Render(w, r, NewWorkspaceListResponse([]Workspace{*ws}))
+		common.RenderResponse(w, r, NewWorkspaceListResponse([]Workspace{*ws}))
 	} else {
-		workspaces, _ := c.service.ListWorkspaces(ctx)
-		render.Render(w, r, NewWorkspaceListResponse(workspaces))
+		workspaces, listErr := c.service.ListWorkspaces(ctx)
+		if listErr != nil {
+			common.RenderError(w, r, listErr)
+			return
+		}
+		common.RenderResponse(w, r, NewWorkspaceListResponse(workspaces))
 	}
 }
 

--- a/internal/workspace/workspacerouter_test.go
+++ b/internal/workspace/workspacerouter_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/eleonorayaya/utena/internal/git"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
@@ -20,14 +20,7 @@ import (
 func setupWorkspaceRouter(t *testing.T) (*WorkspaceRouter, *WorkspaceStore) {
 	t.Helper()
 
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(&Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	database := testdb.New(t, &Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
 
 	store := NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
 
@@ -82,8 +75,7 @@ func TestWorkspaceRouter_GetWorkspaceByID(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 
 	var response WorkspaceResponse
-	err = json.Unmarshal(w.Body.Bytes(), &response)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 	require.Equal(t, ws.ID, response.ID)
 	require.Equal(t, "utena", response.Name)
 	require.Equal(t, "/path/to/utena", response.Path)
@@ -109,14 +101,7 @@ func TestWorkspaceRouter_AddWorkspace(t *testing.T) {
 	require.NoError(t, fs.MkdirAll(configDir, 0755))
 	require.NoError(t, afero.WriteFile(fs, filepath.Join(configDir, "config.json"), []byte(`{}`), 0644))
 
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(&Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	database := testdb.New(t, &Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
 
 	store := NewWorkspaceStore(database, fs, configDir)
 
@@ -137,8 +122,7 @@ func TestWorkspaceRouter_AddWorkspace(t *testing.T) {
 	require.Equal(t, http.StatusCreated, w.Code)
 
 	var response WorkspaceListResponse
-	err = json.Unmarshal(w.Body.Bytes(), &response)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 	require.Len(t, response.Workspaces, 1)
 	require.Equal(t, wsDir, response.Workspaces[0].Path)
 }
@@ -165,14 +149,7 @@ func initTestRepo(t *testing.T) string {
 func TestWorkspaceRouter_ListBranches(t *testing.T) {
 	repoPath := initTestRepo(t)
 
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(&Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	database := testdb.New(t, &Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
 
 	store := NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
 	wsGit := &Workspace{Name: "git-repo", Path: repoPath, IsGitRepo: true}
@@ -191,8 +168,7 @@ func TestWorkspaceRouter_ListBranches(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 
 	var response BranchListResponse
-	err = json.Unmarshal(w.Body.Bytes(), &response)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 	require.Contains(t, response.Branches, "main")
 	require.Contains(t, response.Branches, "develop")
 	require.Equal(t, "main", response.Branches[0])
@@ -323,14 +299,7 @@ func runCmd(t *testing.T, dir string, name string, args ...string) {
 func setupBranchRouter(t *testing.T, repoPath string) (*WorkspaceRouter, *Workspace) {
 	t.Helper()
 
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(&Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	database := testdb.New(t, &Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
 
 	store := NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
 	ws := &Workspace{Name: "git-repo", Path: repoPath, IsGitRepo: true}

--- a/internal/workspace/workspacerouter_test.go
+++ b/internal/workspace/workspacerouter_test.go
@@ -22,15 +22,19 @@ func setupWorkspaceRouter(t *testing.T) (*WorkspaceRouter, *WorkspaceStore) {
 
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	database.Migrate(&Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
-	t.Cleanup(func() { database.Close() })
+	require.NoError(t, database.Migrate(&Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	store := NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
 
 	ws1 := &Workspace{Name: "utena", Path: "/path/to/utena", IsGitRepo: true}
 	ws2 := &Workspace{Name: "example-project", Path: "/path/to/example", IsGitRepo: false}
-	store.Add(ws1)
-	store.Add(ws2)
+	require.NoError(t, store.Add(ws1))
+	require.NoError(t, store.Add(ws2))
 
 	service := NewWorkspaceService(store)
 	gitService := git.NewGitService(database)
@@ -102,13 +106,17 @@ func TestWorkspaceRouter_AddWorkspace(t *testing.T) {
 	configDir := filepath.Join(tmpDir, "config")
 
 	fs := afero.NewOsFs()
-	fs.MkdirAll(configDir, 0755)
-	afero.WriteFile(fs, filepath.Join(configDir, "config.json"), []byte(`{}`), 0644)
+	require.NoError(t, fs.MkdirAll(configDir, 0755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(configDir, "config.json"), []byte(`{}`), 0644))
 
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	database.Migrate(&Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
-	t.Cleanup(func() { database.Close() })
+	require.NoError(t, database.Migrate(&Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	store := NewWorkspaceStore(database, fs, configDir)
 
@@ -159,12 +167,16 @@ func TestWorkspaceRouter_ListBranches(t *testing.T) {
 
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	database.Migrate(&Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
-	t.Cleanup(func() { database.Close() })
+	require.NoError(t, database.Migrate(&Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	store := NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
 	wsGit := &Workspace{Name: "git-repo", Path: repoPath, IsGitRepo: true}
-	store.Add(wsGit)
+	require.NoError(t, store.Add(wsGit))
 
 	service := NewWorkspaceService(store)
 	gitService := git.NewGitService(database)
@@ -313,14 +325,18 @@ func setupBranchRouter(t *testing.T, repoPath string) (*WorkspaceRouter, *Worksp
 
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	database.Migrate(&Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
-	t.Cleanup(func() { database.Close() })
+	require.NoError(t, database.Migrate(&Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}))
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	store := NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
 	ws := &Workspace{Name: "git-repo", Path: repoPath, IsGitRepo: true}
-	store.Add(ws)
+	require.NoError(t, store.Add(ws))
 	notGit := &Workspace{Name: "plain", Path: "/plain", IsGitRepo: false}
-	store.Add(notGit)
+	require.NoError(t, store.Add(notGit))
 
 	service := NewWorkspaceService(store)
 	gitService := git.NewGitService(database)

--- a/internal/workspace/workspaceservice_test.go
+++ b/internal/workspace/workspaceservice_test.go
@@ -45,8 +45,8 @@ func TestWorkspaceService_ListWorkspaces(t *testing.T) {
 
 	ws1 := &Workspace{Name: "test1", Path: "/path1"}
 	ws2 := &Workspace{Name: "test2", Path: "/path2"}
-	store.Add(ws1)
-	store.Add(ws2)
+	require.NoError(t, store.Add(ws1))
+	require.NoError(t, store.Add(ws2))
 
 	ctx := context.Background()
 	workspaces, err := service.ListWorkspaces(ctx)
@@ -69,7 +69,7 @@ func TestWorkspaceService_GetWorkspace(t *testing.T) {
 		Path:      "/path/to/test",
 		IsGitRepo: true,
 	}
-	store.Add(ws)
+	require.NoError(t, store.Add(ws))
 
 	ctx := context.Background()
 	retrieved, err := service.GetWorkspace(ctx, ws.ID)
@@ -95,7 +95,7 @@ func TestWorkspaceService_GetWorkspaceByPath(t *testing.T) {
 		Name: "test",
 		Path: "/unique/path",
 	}
-	store.Add(ws)
+	require.NoError(t, store.Add(ws))
 
 	ctx := context.Background()
 	retrieved, err := service.GetWorkspaceByPath(ctx, "/unique/path")
@@ -118,13 +118,17 @@ func setupWorkspaceServiceWithConfig(t *testing.T) (*WorkspaceService, *Workspac
 	configDir := filepath.Join(tmpDir, "config")
 
 	fs := afero.NewOsFs()
-	fs.MkdirAll(configDir, 0755)
-	afero.WriteFile(fs, filepath.Join(configDir, "config.json"), []byte(`{}`), 0644)
+	require.NoError(t, fs.MkdirAll(configDir, 0755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(configDir, "config.json"), []byte(`{}`), 0644))
 
 	database, err := db.OpenInMemory()
 	require.NoError(t, err)
-	database.Migrate(&Workspace{})
-	t.Cleanup(func() { database.Close() })
+	require.NoError(t, database.Migrate(&Workspace{}))
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 
 	store := NewWorkspaceStore(database, fs, configDir)
 	service := NewWorkspaceService(store)
@@ -145,7 +149,7 @@ func TestWorkspaceService_AddWorkspace(t *testing.T) {
 func TestWorkspaceService_AddWorkspaceAsRoot(t *testing.T) {
 	service, _ := setupWorkspaceServiceWithConfig(t)
 	rootDir := t.TempDir()
-	os.MkdirAll(filepath.Join(rootDir, "project-a"), 0755)
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "project-a"), 0755))
 
 	ctx := context.Background()
 	ws, err := service.AddWorkspace(ctx, rootDir, true)
@@ -160,7 +164,7 @@ func TestWorkspaceService_SetWorkspaceHidden(t *testing.T) {
 	service, store := setupWorkspaceService(t)
 
 	ws := &Workspace{Name: "test", Path: "/path"}
-	store.Add(ws)
+	require.NoError(t, store.Add(ws))
 
 	ctx := context.Background()
 	err := service.SetWorkspaceHidden(ctx, ws.ID, true)
@@ -184,7 +188,7 @@ func TestWorkspaceService_DeleteWorkspace(t *testing.T) {
 	service, store := setupWorkspaceService(t)
 
 	ws := &Workspace{Name: "test", Path: "/path"}
-	store.Add(ws)
+	require.NoError(t, store.Add(ws))
 
 	ctx := context.Background()
 	err := service.DeleteWorkspace(ctx, ws.ID)
@@ -208,7 +212,7 @@ func TestWorkspaceService_Touch(t *testing.T) {
 	service, store := setupWorkspaceService(t)
 
 	ws := &Workspace{Name: "test", Path: "/path"}
-	store.Add(ws)
+	require.NoError(t, store.Add(ws))
 
 	before := time.Now()
 	ctx := context.Background()

--- a/internal/workspace/workspaceservice_test.go
+++ b/internal/workspace/workspaceservice_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
@@ -121,14 +121,7 @@ func setupWorkspaceServiceWithConfig(t *testing.T) (*WorkspaceService, *Workspac
 	require.NoError(t, fs.MkdirAll(configDir, 0755))
 	require.NoError(t, afero.WriteFile(fs, filepath.Join(configDir, "config.json"), []byte(`{}`), 0644))
 
-	database, err := db.OpenInMemory()
-	require.NoError(t, err)
-	require.NoError(t, database.Migrate(&Workspace{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
+	database := testdb.New(t, &Workspace{})
 
 	store := NewWorkspaceStore(database, fs, configDir)
 	service := NewWorkspaceService(store)

--- a/internal/workspace/workspacestore.go
+++ b/internal/workspace/workspacestore.go
@@ -169,7 +169,9 @@ func (s *WorkspaceStore) RemoveWorkspaceFromConfig(path string) {
 
 	if len(filtered) != len(cfg.Workspaces) {
 		cfg.Workspaces = filtered
-		s.saveConfig(cfg)
+		if err := s.saveConfig(cfg); err != nil {
+			slog.Warn("failed to persist workspace config after removal", "path", path, "error", err)
+		}
 	}
 }
 

--- a/internal/workspace/workspacestore_test.go
+++ b/internal/workspace/workspacestore_test.go
@@ -11,24 +11,14 @@ import (
 	"time"
 
 	"github.com/eleonorayaya/utena/internal/db"
+	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/eleonorayaya/utena/internal/git"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
 
 func setupTestDB(t *testing.T) db.Database {
-	t.Helper()
-	database, err := db.OpenInMemory()
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.NoError(t, database.Migrate(&git.Repo{}, &Workspace{}))
-	t.Cleanup(func() {
-		if err := database.Close(); err != nil {
-			t.Logf("close database: %v", err)
-		}
-	})
-	return database
+	return testdb.New(t, &git.Repo{}, &Workspace{})
 }
 
 func setupWorkspaceStore(t *testing.T) *WorkspaceStore {

--- a/internal/workspace/workspacestore_test.go
+++ b/internal/workspace/workspacestore_test.go
@@ -22,8 +22,12 @@ func setupTestDB(t *testing.T) db.Database {
 	if err != nil {
 		t.Fatal(err)
 	}
-	database.Migrate(&git.Repo{}, &Workspace{})
-	t.Cleanup(func() { database.Close() })
+	require.NoError(t, database.Migrate(&git.Repo{}, &Workspace{}))
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Logf("close database: %v", err)
+		}
+	})
 	return database
 }
 
@@ -109,7 +113,7 @@ func TestWorkspaceStore_GetByID(t *testing.T) {
 		IsGitRepo: false,
 	}
 
-	store.Add(ws)
+	require.NoError(t, store.Add(ws))
 
 	retrieved, err := store.GetByID(ws.ID)
 	require.NoError(t, err)
@@ -135,7 +139,7 @@ func TestWorkspaceStore_GetByPath(t *testing.T) {
 		Path: "/unique/path",
 	}
 
-	store.Add(ws)
+	require.NoError(t, store.Add(ws))
 
 	retrieved, err := store.GetByPath("/unique/path")
 	require.NoError(t, err)
@@ -156,8 +160,8 @@ func TestWorkspaceStore_List(t *testing.T) {
 	ws1 := &Workspace{Name: "test1", Path: "/path1"}
 	ws2 := &Workspace{Name: "test2", Path: "/path2"}
 
-	store.Add(ws1)
-	store.Add(ws2)
+	require.NoError(t, store.Add(ws1))
+	require.NoError(t, store.Add(ws2))
 
 	list := store.List()
 	require.Len(t, list, 2)
@@ -175,9 +179,9 @@ func TestWorkspaceStore_List(t *testing.T) {
 func TestWorkspaceStore_List_SortedAlphabetically(t *testing.T) {
 	store := setupWorkspaceStore(t)
 
-	store.Add(&Workspace{Name: "charlie", Path: "/path3"})
-	store.Add(&Workspace{Name: "alpha", Path: "/path1"})
-	store.Add(&Workspace{Name: "bravo", Path: "/path2"})
+	require.NoError(t, store.Add(&Workspace{Name: "charlie", Path: "/path3"}))
+	require.NoError(t, store.Add(&Workspace{Name: "alpha", Path: "/path1"}))
+	require.NoError(t, store.Add(&Workspace{Name: "bravo", Path: "/path2"}))
 
 	list := store.List()
 	require.Len(t, list, 3)
@@ -190,9 +194,9 @@ func TestWorkspaceStore_List_SortedByLastUsedAt(t *testing.T) {
 	store := setupWorkspaceStore(t)
 
 	now := time.Now()
-	store.Add(&Workspace{Name: "alpha", Path: "/path1", LastUsedAt: now.Add(-2 * time.Hour)})
-	store.Add(&Workspace{Name: "bravo", Path: "/path2", LastUsedAt: now})
-	store.Add(&Workspace{Name: "charlie", Path: "/path3"})
+	require.NoError(t, store.Add(&Workspace{Name: "alpha", Path: "/path1", LastUsedAt: now.Add(-2 * time.Hour)}))
+	require.NoError(t, store.Add(&Workspace{Name: "bravo", Path: "/path2", LastUsedAt: now}))
+	require.NoError(t, store.Add(&Workspace{Name: "charlie", Path: "/path3"}))
 
 	list := store.List()
 	require.Len(t, list, 3)
@@ -221,7 +225,7 @@ func TestWorkspaceStore_ConcurrentAccess(t *testing.T) {
 				Name: fmt.Sprintf("concurrent-%d", id),
 				Path: fmt.Sprintf("/path/%d", id),
 			}
-			store.Add(ws)
+			require.NoError(t, store.Add(ws))
 		}(i)
 	}
 
@@ -244,8 +248,8 @@ func TestWorkspaceStore_ConcurrentAccess(t *testing.T) {
 func TestWorkspaceStore_OnAppStart_WithConfig(t *testing.T) {
 	rootDir := t.TempDir()
 
-	os.MkdirAll(filepath.Join(rootDir, "project-alpha", ".git"), 0755)
-	os.MkdirAll(filepath.Join(rootDir, "project-beta"), 0755)
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "project-alpha", ".git"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "project-beta"), 0755))
 
 	store, _ := setupWorkspaceStoreWithConfig(t, []string{rootDir})
 
@@ -292,8 +296,8 @@ func TestWorkspaceStore_OnAppStart_MultipleRoots(t *testing.T) {
 	root1 := t.TempDir()
 	root2 := t.TempDir()
 
-	os.MkdirAll(filepath.Join(root1, "project-a", ".git"), 0755)
-	os.MkdirAll(filepath.Join(root2, "project-b"), 0755)
+	require.NoError(t, os.MkdirAll(filepath.Join(root1, "project-a", ".git"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root2, "project-b"), 0755))
 
 	store, _ := setupWorkspaceStoreWithConfig(t, []string{root1, root2})
 
@@ -314,8 +318,8 @@ func TestWorkspaceStore_OnAppStart_MultipleRoots(t *testing.T) {
 func TestWorkspaceStore_OnAppStart_SkipsFiles(t *testing.T) {
 	rootDir := t.TempDir()
 
-	os.MkdirAll(filepath.Join(rootDir, "real-project"), 0755)
-	os.WriteFile(filepath.Join(rootDir, "not-a-dir.txt"), []byte("hello"), 0644)
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "real-project"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "not-a-dir.txt"), []byte("hello"), 0644))
 
 	store, _ := setupWorkspaceStoreWithConfig(t, []string{rootDir})
 
@@ -331,7 +335,7 @@ func TestWorkspaceStore_OnAppStart_SkipsFiles(t *testing.T) {
 func TestWorkspaceStore_OnAppStart_InvalidRootSkipped(t *testing.T) {
 	rootDir := t.TempDir()
 
-	os.MkdirAll(filepath.Join(rootDir, "good-project"), 0755)
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "good-project"), 0755))
 
 	store, _ := setupWorkspaceStoreWithConfig(t, []string{"/nonexistent/root", rootDir})
 
@@ -346,7 +350,7 @@ func TestWorkspaceStore_OnAppStart_InvalidRootSkipped(t *testing.T) {
 
 func TestWorkspaceStore_OnAppStart_StableIDs(t *testing.T) {
 	rootDir := t.TempDir()
-	os.MkdirAll(filepath.Join(rootDir, "my-project"), 0755)
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "my-project"), 0755))
 
 	store1, _ := setupWorkspaceStoreWithConfig(t, []string{rootDir})
 	ctx := context.Background()
@@ -392,10 +396,10 @@ func TestIsGitRepository(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	gitDir := filepath.Join(tmpDir, "git-project")
-	os.MkdirAll(filepath.Join(gitDir, ".git"), 0755)
+	require.NoError(t, os.MkdirAll(filepath.Join(gitDir, ".git"), 0755))
 
 	nonGitDir := filepath.Join(tmpDir, "non-git-project")
-	os.MkdirAll(nonGitDir, 0755)
+	require.NoError(t, os.MkdirAll(nonGitDir, 0755))
 
 	database := setupTestDB(t)
 	store := NewWorkspaceStore(database, afero.NewOsFs(), tmpDir)
@@ -428,8 +432,8 @@ func setupWorkspaceStoreWithFullConfig(t *testing.T, roots []string, workspaces 
 func TestWorkspaceStore_OnAppStart_WithAdHocWorkspaces(t *testing.T) {
 	rootDir := t.TempDir()
 	adHocDir := t.TempDir()
-	os.MkdirAll(filepath.Join(rootDir, "from-root"), 0755)
-	os.MkdirAll(filepath.Join(adHocDir, ".git"), 0755)
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "from-root"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(adHocDir, ".git"), 0755))
 
 	store, _ := setupWorkspaceStoreWithFullConfig(t, []string{rootDir}, []string{adHocDir})
 
@@ -465,7 +469,7 @@ func TestWorkspaceStore_SaveConfig(t *testing.T) {
 
 func TestWorkspaceStore_AddWorkspace(t *testing.T) {
 	wsDir := t.TempDir()
-	os.MkdirAll(filepath.Join(wsDir, ".git"), 0755)
+	require.NoError(t, os.MkdirAll(filepath.Join(wsDir, ".git"), 0755))
 
 	store, _ := setupWorkspaceStoreWithFullConfig(t, nil, nil)
 
@@ -504,8 +508,8 @@ func TestWorkspaceStore_AddWorkspace_AlreadyExists(t *testing.T) {
 
 func TestWorkspaceStore_AddWorkspaceRoot(t *testing.T) {
 	rootDir := t.TempDir()
-	os.MkdirAll(filepath.Join(rootDir, "proj-a", ".git"), 0755)
-	os.MkdirAll(filepath.Join(rootDir, "proj-b"), 0755)
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "proj-a", ".git"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "proj-b"), 0755))
 
 	store, _ := setupWorkspaceStoreWithFullConfig(t, nil, nil)
 
@@ -532,7 +536,7 @@ func TestWorkspaceStore_Update(t *testing.T) {
 	store := setupWorkspaceStore(t)
 
 	ws := &Workspace{Name: "test", Path: "/path"}
-	store.Add(ws)
+	require.NoError(t, store.Add(ws))
 
 	now := time.Now()
 	ws.LastUsedAt = now
@@ -587,7 +591,7 @@ func TestWorkspaceStore_Persistence(t *testing.T) {
 
 	now := time.Now()
 	ws := &Workspace{Name: "test", Path: "/path", LastUsedAt: now}
-	store.Add(ws)
+	require.NoError(t, store.Add(ws))
 
 	store2 := NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
 
@@ -621,7 +625,7 @@ func TestWorkspaceStore_Delete(t *testing.T) {
 	store := setupWorkspaceStore(t)
 
 	ws := &Workspace{Name: "test", Path: "/path/to/test"}
-	store.Add(ws)
+	require.NoError(t, store.Add(ws))
 
 	err := store.Delete(ws.ID)
 	require.NoError(t, err)
@@ -650,7 +654,7 @@ func TestWorkspaceStore_SetHidden(t *testing.T) {
 	store := setupWorkspaceStore(t)
 
 	ws := &Workspace{Name: "test", Path: "/path/to/test"}
-	store.Add(ws)
+	require.NoError(t, store.Add(ws))
 	require.False(t, ws.IsHidden)
 
 	err := store.SetHidden(ws.ID, true)
@@ -698,7 +702,7 @@ func TestWorkspaceStore_RemoveWorkspaceFromConfig_NotInConfig(t *testing.T) {
 
 func TestWorkspaceStore_OnAppStart_MergesDiscoveredWithPersisted(t *testing.T) {
 	rootDir := t.TempDir()
-	os.MkdirAll(filepath.Join(rootDir, "project-alpha"), 0755)
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "project-alpha"), 0755))
 
 	store, _ := setupWorkspaceStoreWithConfig(t, []string{rootDir})
 
@@ -712,7 +716,7 @@ func TestWorkspaceStore_OnAppStart_MergesDiscoveredWithPersisted(t *testing.T) {
 
 	now := time.Now()
 	workspaces[0].LastUsedAt = now
-	store.Update(&workspaces[0])
+	require.NoError(t, store.Update(&workspaces[0]))
 
 	err = store.OnAppStart(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Fixes a bug where PR-assigned sessions stuck in "creating" forever for bare workspaces — root cause was a silent `s.store.Update` failure on the `tmux_session_id` unique constraint after the deleted session retained its tmux ID.
- Adds API-level uniqueness check: `CreateSession` returns 409 when a session with the same name already exists in the workspace.
- Refactors PR-auto-create flow to go through `CreateSession` (variadic on-create actions) instead of duplicating its internals.
- Adds golangci-lint (errcheck + staticcheck + others) wired into `task lint`, sweeps every flagged silent error drop across non-TUI code (TUI excluded — deprecation pending).
- Extracts shared helpers: `internal/db/testdb.New(t, models...)` collapses ~20 test setup helpers, and `SessionService.markSessionBroken` shared by recovery and runSetup.

## Test plan

- [ ] `task test` — full suite green
- [ ] `task lint` — `0 issues`
- [ ] Manual: create a session in a bare workspace via TUI, confirm it lands in the worktree (not bare repo root)
- [ ] Manual: try to create a second session with the same name — expect a 409 conflict
- [ ] Manual: delete a session, recreate with same name — expect success (no tmux_session_id collision)
