### PR TITLE
feat(claudesettings): re-merge full defaults each call; allow-write .bare

### DIFF
--- a/internal/claudesettings/claudesettings.go
+++ b/internal/claudesettings/claudesettings.go
@@ -18,9 +18,16 @@ type settingsLocal struct {
 	} `json:"sandbox"`
 }
 
+func defaultAllowWritePaths(workspacePath string) []string {
+	return []string{
+		filepath.Join(workspacePath, ".git"),
+		filepath.Join(workspacePath, ".bare"),
+	}
+}
+
 func defaultSettingsJSON(workspacePath string) ([]byte, error) {
 	var s settingsLocal
-	s.Sandbox.Filesystem.AllowWrite = []string{filepath.Join(workspacePath, ".git")}
+	s.Sandbox.Filesystem.AllowWrite = defaultAllowWritePaths(workspacePath)
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal settings: %w", err)
@@ -39,7 +46,7 @@ func settingsFileExists(path string) (bool, error) {
 	return false, fmt.Errorf("stat %s: %w", filepath.Base(path), err)
 }
 
-func mergeAllowWrite(data []byte, gitPath string) ([]byte, bool, error) {
+func mergeAllowWrite(data []byte, paths []string) ([]byte, bool, error) {
 	var raw map[string]any
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, false, fmt.Errorf("parse settings: %w", err)
@@ -55,12 +62,27 @@ func mergeAllowWrite(data []byte, gitPath string) ([]byte, bool, error) {
 		sandbox["filesystem"] = filesystem
 	}
 	allowWrite, _ := filesystem["allowWrite"].([]any)
+
+	existing := make(map[string]struct{}, len(allowWrite))
 	for _, entry := range allowWrite {
-		if s, ok := entry.(string); ok && s == gitPath {
-			return nil, false, nil
+		if s, ok := entry.(string); ok {
+			existing[s] = struct{}{}
 		}
 	}
-	filesystem["allowWrite"] = append(allowWrite, gitPath)
+
+	changed := false
+	for _, p := range paths {
+		if _, ok := existing[p]; ok {
+			continue
+		}
+		allowWrite = append(allowWrite, p)
+		existing[p] = struct{}{}
+		changed = true
+	}
+	if !changed {
+		return nil, false, nil
+	}
+	filesystem["allowWrite"] = allowWrite
 	out, err := json.MarshalIndent(raw, "", "  ")
 	if err != nil {
 		return nil, false, fmt.Errorf("marshal settings: %w", err)
@@ -78,13 +100,12 @@ func EnsureWorkspaceRoot(workspacePath string) error {
 	if err != nil {
 		return err
 	}
-	gitPath := filepath.Join(workspacePath, ".git")
 	if exists {
 		data, err := os.ReadFile(settingsPath)
 		if err != nil {
 			return fmt.Errorf("read %s: %w", settingsFileName, err)
 		}
-		merged, changed, err := mergeAllowWrite(data, gitPath)
+		merged, changed, err := mergeAllowWrite(data, defaultAllowWritePaths(workspacePath))
 		if err != nil || !changed {
 			return err
 		}

--- a/internal/claudesettings/claudesettings_test.go
+++ b/internal/claudesettings/claudesettings_test.go
@@ -14,19 +14,29 @@ func TestEnsureWorkspaceRoot_CreatesFileWhenMissing(t *testing.T) {
 		t.Fatalf("EnsureWorkspaceRoot: %v", err)
 	}
 
-	got, err := os.ReadFile(filepath.Join(root, ".claude", "settings.local.json"))
+	raw, err := os.ReadFile(filepath.Join(root, ".claude", "settings.local.json"))
 	if err != nil {
 		t.Fatalf("read settings.local.json: %v", err)
 	}
-	if len(got) == 0 {
-		t.Fatalf("expected non-empty settings.local.json")
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("parse result: %v", err)
 	}
-	want, err := defaultSettingsJSON(root)
-	if err != nil {
-		t.Fatalf("defaultSettingsJSON: %v", err)
-	}
-	if string(got) != string(want) {
-		t.Fatalf("contents do not match expected:\ngot:  %s\nwant: %s", got, want)
+	sandbox, _ := out["sandbox"].(map[string]any)
+	fs, _ := sandbox["filesystem"].(map[string]any)
+	allowWrite, _ := fs["allowWrite"].([]any)
+	wantPaths := []string{filepath.Join(root, ".git"), filepath.Join(root, ".bare")}
+	for _, want := range wantPaths {
+		found := false
+		for _, v := range allowWrite {
+			if v == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("allowWrite missing %q; got %v", want, allowWrite)
+		}
 	}
 }
 
@@ -58,15 +68,18 @@ func TestEnsureWorkspaceRoot_MergesIntoExistingSettings(t *testing.T) {
 	sandbox, _ := out["sandbox"].(map[string]any)
 	fs, _ := sandbox["filesystem"].(map[string]any)
 	allowWrite, _ := fs["allowWrite"].([]any)
-	gitPath := filepath.Join(root, ".git")
-	found := false
-	for _, v := range allowWrite {
-		if v == gitPath {
-			found = true
+	wantPaths := []string{filepath.Join(root, ".git"), filepath.Join(root, ".bare")}
+	for _, want := range wantPaths {
+		found := false
+		for _, v := range allowWrite {
+			if v == want {
+				found = true
+				break
+			}
 		}
-	}
-	if !found {
-		t.Fatalf("allowWrite missing %q; got %v", gitPath, allowWrite)
+		if !found {
+			t.Fatalf("allowWrite missing %q; got %v", want, allowWrite)
+		}
 	}
 }
 
@@ -90,15 +103,78 @@ func TestEnsureWorkspaceRoot_DoesNotDuplicateAllowWrite(t *testing.T) {
 	sandbox, _ := out["sandbox"].(map[string]any)
 	fs, _ := sandbox["filesystem"].(map[string]any)
 	allowWrite, _ := fs["allowWrite"].([]any)
-	gitPath := filepath.Join(root, ".git")
-	count := 0
-	for _, v := range allowWrite {
-		if v == gitPath {
-			count++
+	wantPaths := []string{filepath.Join(root, ".git"), filepath.Join(root, ".bare")}
+	for _, want := range wantPaths {
+		count := 0
+		for _, v := range allowWrite {
+			if v == want {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Fatalf("expected %q once in allowWrite, got %d times", want, count)
 		}
 	}
-	if count != 1 {
-		t.Fatalf("expected git path once in allowWrite, got %d times", count)
+}
+
+func TestEnsureWorkspaceRoot_AddsNewDefaultsToExistingSettings(t *testing.T) {
+	root := t.TempDir()
+	claudeDir := filepath.Join(root, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+	gitPath := filepath.Join(root, ".git")
+	barePath := filepath.Join(root, ".bare")
+	initial := map[string]any{
+		"custom": true,
+		"sandbox": map[string]any{
+			"filesystem": map[string]any{
+				"allowWrite": []any{gitPath},
+			},
+		},
+	}
+	initialBytes, err := json.MarshalIndent(initial, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, initialBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureWorkspaceRoot(root); err != nil {
+		t.Fatalf("EnsureWorkspaceRoot: %v", err)
+	}
+
+	raw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings.local.json: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if out["custom"] != true {
+		t.Fatalf("existing key 'custom' was removed")
+	}
+	sandbox, _ := out["sandbox"].(map[string]any)
+	fs, _ := sandbox["filesystem"].(map[string]any)
+	allowWrite, _ := fs["allowWrite"].([]any)
+
+	gitCount, bareCount := 0, 0
+	for _, v := range allowWrite {
+		switch v {
+		case gitPath:
+			gitCount++
+		case barePath:
+			bareCount++
+		}
+	}
+	if gitCount != 1 {
+		t.Fatalf("expected %q once in allowWrite, got %d times: %v", gitPath, gitCount, allowWrite)
+	}
+	if bareCount != 1 {
+		t.Fatalf("expected %q once in allowWrite (newly added), got %d times: %v", barePath, bareCount, allowWrite)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Centralize the desired `.claude/settings.local.json` defaults for bare workspaces in a single `defaultAllowWritePaths` slice; both create-from-scratch and merge-into-existing paths now consume it. Future defaults auto-propagate to existing bare workspaces on the next session creation, since `EnsureWorkspaceRoot` already runs on every bare worktree creation.
- Add `<workspace>/.bare` to that default list. In a bare layout `<workspace>/.git` is just a pointer file (`gitdir: ./.bare`); the real git data lives under `.bare/`, so allow-write needs to cover it.
- `mergeAllowWrite` is generalized from "add one path" to "ensure all desired paths are present" — still deduped, still preserves unknown top-level keys, still a no-op when nothing changes.

## Test plan
- [x] `task test` — full Go suite green, including the new `TestEnsureWorkspaceRoot_AddsNewDefaultsToExistingSettings` upgrade test (pre-populates `allowWrite` with only `.git` plus a custom top-level field, calls `EnsureWorkspaceRoot`, reads back from disk, asserts `.bare` was appended, `.git` not duplicated, custom field preserved).
- [x] Existing tests updated: create-when-missing now asserts `allowWrite` contains both paths by name (no longer a tautology vs `defaultSettingsJSON`); merge-into-existing and dedupe checks both extended to cover both default paths.
- [ ] Manual check after merge: in a real bare workspace, create a new session and verify `<workspace>/.claude/settings.local.json` contains both `.git` and `.bare` in `sandbox.filesystem.allowWrite`.
