### PR TITLE
fix(workspace): detach session worktrees before bare migration

### DIFF
--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -60,6 +60,7 @@ func buildApp(gormDB *gorm.DB, fs afero.Fs, cfg Config, tmuxModule *tmux.TmuxMod
 		tmuxModule = tmux.NewTmuxModule(bus, database)
 	}
 	sessionModule := session.NewSessionModule(tmuxModule.Service, workspaceModule, bus, database, cfg.BranchPrefix, cfg.ConfigDir, cfg.SessionsRoot)
+	workspaceModule.Controller.SetSessionCleaner(sessionModule.Service)
 
 	jobsModule := jobs.NewJobsModule()
 	gitModule.RegisterJobs(jobsModule.Service)

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -60,7 +60,6 @@ func buildApp(gormDB *gorm.DB, fs afero.Fs, cfg Config, tmuxModule *tmux.TmuxMod
 		tmuxModule = tmux.NewTmuxModule(bus, database)
 	}
 	sessionModule := session.NewSessionModule(tmuxModule.Service, workspaceModule, bus, database, cfg.BranchPrefix, cfg.ConfigDir, cfg.SessionsRoot)
-	workspaceModule.Controller.SetSessionCleaner(sessionModule.Service)
 
 	jobsModule := jobs.NewJobsModule()
 	gitModule.RegisterJobs(jobsModule.Service)
@@ -117,6 +116,12 @@ func (a *App) Routes() chi.Router {
 	for _, m := range a.modules() {
 		r.Mount(m.path, m.module.Routes())
 	}
+	bareMigration := &bareMigrationHandler{
+		workspaceService: a.Workspace.Service,
+		gitService:       a.Git.Service,
+		sessionService:   a.Session.Service,
+	}
+	r.Post("/workspaces/{id}/migrate-bare", bareMigration.handle)
 	return r
 }
 

--- a/internal/api/baremigration.go
+++ b/internal/api/baremigration.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/eleonorayaya/utena/internal/claudesettings"
+	"github.com/eleonorayaya/utena/internal/common"
+	"github.com/eleonorayaya/utena/internal/git"
+	"github.com/eleonorayaya/utena/internal/session"
+	"github.com/eleonorayaya/utena/internal/workspace"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+)
+
+type bareMigrationHandler struct {
+	workspaceService *workspace.WorkspaceService
+	gitService       *git.GitService
+	sessionService   *session.SessionService
+}
+
+func (h *bareMigrationHandler) handle(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Minute)
+	defer cancel()
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		common.RenderError(w, r, common.NewInvalidRequest(err.Error()))
+		return
+	}
+
+	ws, err := h.workspaceService.GetWorkspace(ctx, uint(id))
+	if err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	if !ws.IsGitRepo {
+		common.RenderError(w, r, common.NewInvalidRequest(fmt.Sprintf("workspace %q is not a git repository", ws.Name)))
+		return
+	}
+
+	if ws.IsBare {
+		common.RenderError(w, r, common.NewInvalidRequest(fmt.Sprintf("workspace %q is already using the bare pattern", ws.Name)))
+		return
+	}
+
+	if ws.RepoID != nil {
+		if err := h.sessionService.DetachWorktreesByRepoID(ctx, *ws.RepoID); err != nil {
+			common.RenderError(w, r, fmt.Errorf("failed to clear worktree records before bare migration: %w", err))
+			return
+		}
+	}
+
+	if err := h.gitService.MigrateToBare(ctx, ws.Path); err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	if err := h.workspaceService.MarkAsBare(ctx, uint(id)); err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	if err := claudesettings.EnsureWorkspaceRoot(ws.Path); err != nil {
+		slog.Warn("failed to bootstrap claude settings after bare migration",
+			"workspace", ws.Name, "error", err)
+	}
+
+	render.NoContent(w, r)
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -344,4 +345,39 @@ func TestDaemon_RepairSession_AfterTmuxFailure(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, session.StatusActive, response.Status)
 	require.True(t, mock.HasSessionByName("utena-repair-me"))
+}
+
+func TestDaemon_MigrateToBare_BootstrapsClaudeSettings(t *testing.T) {
+	app, router, _, ws1ID, _ := setupTestRouter(t)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/workspaces/%d/migrate-bare", ws1ID), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusNoContent, w.Code, "body: %s", w.Body.String())
+
+	ws, err := app.Workspace.Store.GetByID(ws1ID)
+	require.NoError(t, err)
+	require.True(t, ws.IsBare, "workspace should be marked bare after migration")
+
+	settingsPath := filepath.Join(ws.Path, ".claude", "settings.local.json")
+	data, err := os.ReadFile(settingsPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+}
+
+func TestDaemon_MigrateToBare_DetachesLinkedSessions(t *testing.T) {
+	app, router, _, ws1ID, _ := setupTestRouter(t)
+
+	body := fmt.Sprintf(`{"name":"linked","workspace_ids":[%d],"base_branch":"main"}`, ws1ID)
+	createResp := createSessionViaAPI(t, router, body)
+	waitForSessionStatus(t, router, createResp.ID, session.StatusActive, 5*time.Second)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/workspaces/%d/migrate-bare", ws1ID), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusNoContent, w.Code, "body: %s", w.Body.String())
+
+	sess, err := app.Session.Store.GetByID(createResp.ID)
+	require.NoError(t, err)
+	require.Empty(t, sess.Worktrees, "migrated repo should leave the session with no remaining worktrees")
 }

--- a/internal/claudesettings/claudesettings.go
+++ b/internal/claudesettings/claudesettings.go
@@ -6,9 +6,49 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
-const settingsFileName = "settings.local.json"
+const (
+	settingsFileName         = "settings.local.json"
+	multiSessionGuideName    = "CLAUDE.md"
+	multiSessionGuideMarker  = "<!-- utena:multi-session-guide -->"
+	multiSessionGuideContent = multiSessionGuideMarker + `
+# Session checkouts
+
+The directories below are the **only** canonical copies of these projects for this session. Read from and edit them here; do not look at or modify any other copy of these projects elsewhere on this filesystem.
+
+%s`
+)
+
+type SessionCheckout struct {
+	Subdir        string
+	WorkspaceName string
+}
+
+// EnsureMultiSessionGuide writes a CLAUDE.md at the session root telling
+// Claude that the listed subdirectory checkouts are the canonical copies
+// for this session. Skips if the file already exists and wasn't authored
+// by utena (no marker), so the user's customizations stay intact.
+func EnsureMultiSessionGuide(sessionRoot string, checkouts []SessionCheckout) error {
+	path := filepath.Join(sessionRoot, multiSessionGuideName)
+	if existing, err := os.ReadFile(path); err == nil {
+		if !strings.Contains(string(existing), multiSessionGuideMarker) {
+			return nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read %s: %w", multiSessionGuideName, err)
+	}
+	var list strings.Builder
+	for _, c := range checkouts {
+		fmt.Fprintf(&list, "- `%s/` — workspace `%s`\n", c.Subdir, c.WorkspaceName)
+	}
+	body := fmt.Sprintf(multiSessionGuideContent, list.String())
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", multiSessionGuideName, err)
+	}
+	return nil
+}
 
 type settingsLocal struct {
 	Sandbox struct {

--- a/internal/claudesettings/claudesettings_test.go
+++ b/internal/claudesettings/claudesettings_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -321,6 +322,64 @@ func TestEnsureSessionRoot_IsIdempotent(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("expected git dir once after re-run, got %d times", count)
+	}
+}
+
+func TestEnsureMultiSessionGuide_CreatesFileWhenMissing(t *testing.T) {
+	root := t.TempDir()
+	checkouts := []SessionCheckout{
+		{Subdir: "utena", WorkspaceName: "utena"},
+		{Subdir: "other", WorkspaceName: "other-project"},
+	}
+	if err := EnsureMultiSessionGuide(root, checkouts); err != nil {
+		t.Fatalf("EnsureMultiSessionGuide: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	for _, want := range []string{"`utena/`", "`other/`", "other-project", "only**", "canonical"} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("CLAUDE.md missing %q; got:\n%s", want, body)
+		}
+	}
+}
+
+func TestEnsureMultiSessionGuide_PreservesUserCLAUDEMd(t *testing.T) {
+	root := t.TempDir()
+	userContent := []byte("# my project notes\n")
+	if err := os.WriteFile(filepath.Join(root, "CLAUDE.md"), userContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureMultiSessionGuide(root, []SessionCheckout{{Subdir: "a", WorkspaceName: "a"}}); err != nil {
+		t.Fatalf("EnsureMultiSessionGuide: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(userContent) {
+		t.Fatalf("user CLAUDE.md was overwritten; got:\n%s", got)
+	}
+}
+
+func TestEnsureMultiSessionGuide_RewritesUtenaAuthoredFile(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureMultiSessionGuide(root, []SessionCheckout{{Subdir: "a", WorkspaceName: "a"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureMultiSessionGuide(root, []SessionCheckout{
+		{Subdir: "a", WorkspaceName: "a"},
+		{Subdir: "b", WorkspaceName: "b"},
+	}); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "`b/`") {
+		t.Fatalf("expected rewrite to include new checkout; got:\n%s", body)
 	}
 }
 

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -875,6 +875,24 @@ func (s *SessionService) DeleteSession(ctx context.Context, id uint, deleteBranc
 	return s.store.Update(session)
 }
 
+// DetachWorktreesByRepoID drops every session ↔ worktree link for the given
+// repo and then removes the worktree records themselves. It is the DB-side
+// half of a bare-workspace migration: the on-disk worktrees are about to be
+// invalidated by the conversion (the old .git directory moves to a backup
+// path) so any session linkage to them is no longer meaningful. Sessions that
+// span multiple repos keep their other worktrees; sessions whose only worktree
+// was in this repo remain in the DB with an empty Worktrees slice for the user
+// to clean up.
+func (s *SessionService) DetachWorktreesByRepoID(ctx context.Context, repoID uint) error {
+	if err := s.sessionWorktreeStore.HardDeleteByWorktreeRepoID(repoID); err != nil {
+		return fmt.Errorf("failed to detach session worktrees for repo %d: %w", repoID, err)
+	}
+	if err := s.gitService.DeleteWorktreesByRepoID(repoID); err != nil {
+		return fmt.Errorf("failed to delete worktrees for repo %d: %w", repoID, err)
+	}
+	return nil
+}
+
 // cleanupSessionRootDir removes the SessionRoot dir on disk when utena owns it
 // (i.e. it lives under the configured sessionsRoot). For single-workspace
 // sessions, SessionRoot is either a worktree dir under a repo (cleaned up by

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -525,12 +525,21 @@ func (s *SessionService) runSetup(sessionID uint, tmuxName string, branchName st
 
 	if multi {
 		workspacePaths := make([]string, 0, len(done))
+		checkouts := make([]claudesettings.SessionCheckout, 0, len(done))
 		for _, r := range done {
 			workspacePaths = append(workspacePaths, r.ws.Path)
+			checkouts = append(checkouts, claudesettings.SessionCheckout{
+				Subdir:        filepath.Base(r.worktreePath),
+				WorkspaceName: r.ws.Name,
+			})
 		}
 		if err := claudesettings.EnsureSessionRoot(sess.SessionRoot, workspacePaths); err != nil {
 			slog.WarnContext(ctx, "ensure session-root claude settings failed", "error", err)
 			setupWarnings = append(setupWarnings, fmt.Sprintf("claude-settings: %s", err.Error()))
+		}
+		if err := claudesettings.EnsureMultiSessionGuide(sess.SessionRoot, checkouts); err != nil {
+			slog.WarnContext(ctx, "ensure multi-session CLAUDE.md failed", "error", err)
+			setupWarnings = append(setupWarnings, fmt.Sprintf("claude-guide: %s", err.Error()))
 		}
 	} else if len(done) == 1 && done[0].created {
 		ws := done[0].ws

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -875,14 +875,9 @@ func (s *SessionService) DeleteSession(ctx context.Context, id uint, deleteBranc
 	return s.store.Update(session)
 }
 
-// DetachWorktreesByRepoID drops every session ↔ worktree link for the given
-// repo and then removes the worktree records themselves. It is the DB-side
-// half of a bare-workspace migration: the on-disk worktrees are about to be
-// invalidated by the conversion (the old .git directory moves to a backup
-// path) so any session linkage to them is no longer meaningful. Sessions that
-// span multiple repos keep their other worktrees; sessions whose only worktree
-// was in this repo remain in the DB with an empty Worktrees slice for the user
-// to clean up.
+// DetachWorktreesByRepoID drops join rows first so the worktree delete
+// doesn't trip the RESTRICT FK on session_worktrees.worktree_id. Sessions
+// left with no remaining worktrees are kept for the user to clean up.
 func (s *SessionService) DetachWorktreesByRepoID(ctx context.Context, repoID uint) error {
 	if err := s.sessionWorktreeStore.HardDeleteByWorktreeRepoID(repoID); err != nil {
 		return fmt.Errorf("failed to detach session worktrees for repo %d: %w", repoID, err)

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -303,6 +303,52 @@ func TestSessionService_DeleteSession_Creating_Force(t *testing.T) {
 	require.Equal(t, StatusDeleted, retrieved.Status)
 }
 
+func TestSessionService_DetachWorktreesByRepoID(t *testing.T) {
+	service, sessionStore, workspaceStore, _, ws1ID, ws2ID := setupSessionService(t)
+	swStore := swtStoreFor(service)
+	database := service.store.db
+
+	soloIn1 := &Session{Name: "solo-1", Status: StatusActive, LastUsedAt: time.Now()}
+	soloIn2 := &Session{Name: "solo-2", Status: StatusActive, LastUsedAt: time.Now()}
+	addTestSession(t, sessionStore, swStore, soloIn1, ws1ID)
+	addTestSession(t, sessionStore, swStore, soloIn2, ws2ID)
+
+	multi := &Session{Name: "multi", Status: StatusActive, LastUsedAt: time.Now()}
+	addTestSession(t, sessionStore, swStore, multi, ws1ID)
+	attachTestWorktree(t, database, swStore, multi.ID, ws2ID, 1)
+
+	ws1, err := workspaceStore.GetByID(ws1ID)
+	require.NoError(t, err)
+	require.NotNil(t, ws1.RepoID)
+	repo1ID := *ws1.RepoID
+
+	ctx := context.Background()
+	require.NoError(t, service.DetachWorktreesByRepoID(ctx, repo1ID))
+
+	var wtCount int64
+	require.NoError(t, database.Model(&git.Worktree{}).Where("repo_id = ?", repo1ID).Count(&wtCount).Error)
+	require.Zero(t, wtCount, "all worktrees in the migrated repo should be deleted")
+
+	soloIn1Reloaded, err := sessionStore.GetByID(soloIn1.ID)
+	require.NoError(t, err)
+	require.Empty(t, soloIn1Reloaded.Worktrees, "solo session in migrated repo should have no worktrees left")
+
+	soloIn2Reloaded, err := sessionStore.GetByID(soloIn2.ID)
+	require.NoError(t, err)
+	require.Len(t, soloIn2Reloaded.Worktrees, 1, "session in untouched repo must keep its worktree")
+
+	multiReloaded, err := sessionStore.GetByID(multi.ID)
+	require.NoError(t, err)
+	require.Len(t, multiReloaded.Worktrees, 1, "multi-repo session should keep its remaining worktree")
+	require.NotNil(t, multiReloaded.Worktrees[0].Worktree)
+	require.NotEqual(t, repo1ID, multiReloaded.Worktrees[0].Worktree.RepoID)
+}
+
+func TestSessionService_DetachWorktreesByRepoID_NoRows(t *testing.T) {
+	service, _, _, _, _, _ := setupSessionService(t)
+	require.NoError(t, service.DetachWorktreesByRepoID(context.Background(), 99999))
+}
+
 func initTestRepo(t *testing.T) string {
 	t.Helper()
 	bareDir := t.TempDir()

--- a/internal/session/sessionworktreestore.go
+++ b/internal/session/sessionworktreestore.go
@@ -66,12 +66,9 @@ func (s *SessionWorktreeStore) DeleteBySessionID(sessionID uint) error {
 	return s.db.Where("session_id = ?", sessionID).Delete(&SessionWorktree{}).Error
 }
 
-// HardDeleteByWorktreeRepoID removes every session_worktrees row that points at
-// a worktree in the given repo. Used during bare-workspace migration to drop
-// the join rows before deleting the worktree records they reference — the
-// foreign key on worktree_id is RESTRICT, so the worktree deletion would fail
-// otherwise. A hard delete (not GORM's soft delete) is required because
-// SQLite's FK check sees physical rows regardless of deleted_at.
+// HardDeleteByWorktreeRepoID bypasses GORM's soft delete because SQLite's
+// FK check sees physical rows regardless of deleted_at — soft-deleted join
+// rows would still block deleting the worktrees they point at.
 func (s *SessionWorktreeStore) HardDeleteByWorktreeRepoID(repoID uint) error {
 	return s.db.Exec(
 		"DELETE FROM session_worktrees WHERE worktree_id IN (SELECT id FROM worktrees WHERE repo_id = ?)",

--- a/internal/session/sessionworktreestore.go
+++ b/internal/session/sessionworktreestore.go
@@ -65,3 +65,16 @@ func (s *SessionWorktreeStore) ListBySessionID(sessionID uint) ([]SessionWorktre
 func (s *SessionWorktreeStore) DeleteBySessionID(sessionID uint) error {
 	return s.db.Where("session_id = ?", sessionID).Delete(&SessionWorktree{}).Error
 }
+
+// HardDeleteByWorktreeRepoID removes every session_worktrees row that points at
+// a worktree in the given repo. Used during bare-workspace migration to drop
+// the join rows before deleting the worktree records they reference — the
+// foreign key on worktree_id is RESTRICT, so the worktree deletion would fail
+// otherwise. A hard delete (not GORM's soft delete) is required because
+// SQLite's FK check sees physical rows regardless of deleted_at.
+func (s *SessionWorktreeStore) HardDeleteByWorktreeRepoID(repoID uint) error {
+	return s.db.Exec(
+		"DELETE FROM session_worktrees WHERE worktree_id IN (SELECT id FROM worktrees WHERE repo_id = ?)",
+		repoID,
+	).Error
+}

--- a/internal/workspace/workspacecontroller.go
+++ b/internal/workspace/workspacecontroller.go
@@ -16,12 +16,8 @@ import (
 	"github.com/go-chi/render"
 )
 
-// SessionCleaner removes session/worktree DB rows that reference a repo,
-// so the bare-workspace migration can drop the worktree records without
-// hitting the RESTRICT foreign key on session_worktrees.worktree_id. The
-// session module owns this logic; the workspace module receives an
-// implementation via SetSessionCleaner after both modules are constructed
-// (session imports workspace, so the dependency has to flow this way).
+// SessionCleaner is wired via SetSessionCleaner after construction because
+// the session module imports workspace, blocking a constructor dependency.
 type SessionCleaner interface {
 	DetachWorktreesByRepoID(ctx context.Context, repoID uint) error
 }

--- a/internal/workspace/workspacecontroller.go
+++ b/internal/workspace/workspacecontroller.go
@@ -16,9 +16,20 @@ import (
 	"github.com/go-chi/render"
 )
 
+// SessionCleaner removes session/worktree DB rows that reference a repo,
+// so the bare-workspace migration can drop the worktree records without
+// hitting the RESTRICT foreign key on session_worktrees.worktree_id. The
+// session module owns this logic; the workspace module receives an
+// implementation via SetSessionCleaner after both modules are constructed
+// (session imports workspace, so the dependency has to flow this way).
+type SessionCleaner interface {
+	DetachWorktreesByRepoID(ctx context.Context, repoID uint) error
+}
+
 type WorkspaceController struct {
-	service    *WorkspaceService
-	gitService *git.GitService
+	service        *WorkspaceService
+	gitService     *git.GitService
+	sessionCleaner SessionCleaner
 }
 
 func NewWorkspaceController(service *WorkspaceService, gitService *git.GitService) *WorkspaceController {
@@ -26,6 +37,10 @@ func NewWorkspaceController(service *WorkspaceService, gitService *git.GitServic
 		service:    service,
 		gitService: gitService,
 	}
+}
+
+func (c *WorkspaceController) SetSessionCleaner(cleaner SessionCleaner) {
+	c.sessionCleaner = cleaner
 }
 
 func (c *WorkspaceController) ListWorkspaces(w http.ResponseWriter, r *http.Request) {
@@ -273,16 +288,20 @@ func (c *WorkspaceController) MigrateWorkspaceToBare(w http.ResponseWriter, r *h
 		return
 	}
 
+	if ws.RepoID != nil {
+		if c.sessionCleaner == nil {
+			common.RenderError(w, r, fmt.Errorf("session cleaner not configured; cannot safely clear worktrees for repo %d", *ws.RepoID))
+			return
+		}
+		if err := c.sessionCleaner.DetachWorktreesByRepoID(ctx, *ws.RepoID); err != nil {
+			common.RenderError(w, r, fmt.Errorf("failed to clear worktree records before bare migration: %w", err))
+			return
+		}
+	}
+
 	if err := c.gitService.MigrateToBare(ctx, ws.Path); err != nil {
 		common.RenderError(w, r, err)
 		return
-	}
-
-	if ws.RepoID != nil {
-		if err := c.gitService.DeleteWorktreesByRepoID(*ws.RepoID); err != nil {
-			common.RenderError(w, r, fmt.Errorf("migration succeeded but failed to clear worktree records: %w", err))
-			return
-		}
 	}
 
 	if err := c.service.MarkAsBare(ctx, uint(id)); err != nil {

--- a/internal/workspace/workspacecontroller.go
+++ b/internal/workspace/workspacecontroller.go
@@ -1,31 +1,20 @@
 package workspace
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"strconv"
-	"time"
 
-	"github.com/eleonorayaya/utena/internal/claudesettings"
 	"github.com/eleonorayaya/utena/internal/common"
 	"github.com/eleonorayaya/utena/internal/git"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 )
 
-// SessionCleaner is wired via SetSessionCleaner after construction because
-// the session module imports workspace, blocking a constructor dependency.
-type SessionCleaner interface {
-	DetachWorktreesByRepoID(ctx context.Context, repoID uint) error
-}
-
 type WorkspaceController struct {
-	service        *WorkspaceService
-	gitService     *git.GitService
-	sessionCleaner SessionCleaner
+	service    *WorkspaceService
+	gitService *git.GitService
 }
 
 func NewWorkspaceController(service *WorkspaceService, gitService *git.GitService) *WorkspaceController {
@@ -33,10 +22,6 @@ func NewWorkspaceController(service *WorkspaceService, gitService *git.GitServic
 		service:    service,
 		gitService: gitService,
 	}
-}
-
-func (c *WorkspaceController) SetSessionCleaner(cleaner SessionCleaner) {
-	c.sessionCleaner = cleaner
 }
 
 func (c *WorkspaceController) ListWorkspaces(w http.ResponseWriter, r *http.Request) {
@@ -256,61 +241,6 @@ func (c *WorkspaceController) CheckBranchExists(w http.ResponseWriter, r *http.R
 	}
 
 	render.JSON(w, r, BranchExistsResponse{ExistsLocal: existsLocal, ExistsRemote: existsRemote})
-}
-
-func (c *WorkspaceController) MigrateWorkspaceToBare(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Minute)
-	defer cancel()
-	raw := chi.URLParam(r, "id")
-	id, err := strconv.ParseUint(raw, 10, 64)
-	if err != nil {
-		common.RenderError(w, r, common.NewInvalidRequest(err.Error()))
-		return
-	}
-
-	ws, err := c.service.GetWorkspace(ctx, uint(id))
-	if err != nil {
-		common.RenderError(w, r, err)
-		return
-	}
-
-	if !ws.IsGitRepo {
-		common.RenderError(w, r, common.NewInvalidRequest(fmt.Sprintf("workspace %q is not a git repository", ws.Name)))
-		return
-	}
-
-	if ws.IsBare {
-		common.RenderError(w, r, common.NewInvalidRequest(fmt.Sprintf("workspace %q is already using the bare pattern", ws.Name)))
-		return
-	}
-
-	if ws.RepoID != nil {
-		if c.sessionCleaner == nil {
-			common.RenderError(w, r, fmt.Errorf("session cleaner not configured; cannot safely clear worktrees for repo %d", *ws.RepoID))
-			return
-		}
-		if err := c.sessionCleaner.DetachWorktreesByRepoID(ctx, *ws.RepoID); err != nil {
-			common.RenderError(w, r, fmt.Errorf("failed to clear worktree records before bare migration: %w", err))
-			return
-		}
-	}
-
-	if err := c.gitService.MigrateToBare(ctx, ws.Path); err != nil {
-		common.RenderError(w, r, err)
-		return
-	}
-
-	if err := c.service.MarkAsBare(ctx, uint(id)); err != nil {
-		common.RenderError(w, r, err)
-		return
-	}
-
-	if err := claudesettings.EnsureWorkspaceRoot(ws.Path); err != nil {
-		slog.Warn("failed to bootstrap claude settings after bare migration",
-			"workspace", ws.Name, "error", err)
-	}
-
-	render.NoContent(w, r)
 }
 
 func (c *WorkspaceController) ListPRs(w http.ResponseWriter, r *http.Request) {

--- a/internal/workspace/workspacerouter.go
+++ b/internal/workspace/workspacerouter.go
@@ -25,7 +25,6 @@ func (wr *WorkspaceRouter) Routes() chi.Router {
 	r.Get("/{id}/prs", wr.controller.ListPRs)
 	r.Get("/{id}", wr.controller.GetWorkspaceByID)
 	r.Put("/{id}/hidden", wr.controller.SetWorkspaceHidden)
-	r.Post("/{id}/migrate-bare", wr.controller.MigrateWorkspaceToBare)
 	r.Delete("/{id}", wr.controller.DeleteWorkspace)
 
 	return r

--- a/internal/workspace/workspacerouter_test.go
+++ b/internal/workspace/workspacerouter_test.go
@@ -436,19 +436,3 @@ func TestWorkspaceRouter_CheckBranchExists_MissingName(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestWorkspaceRouter_MigrateToBare_BootstrapsClaudeSettings(t *testing.T) {
-	repoPath := initTestRepoWithOrigin(t)
-	router, ws := setupBranchRouter(t, repoPath)
-
-	req := httptest.NewRequest("POST", fmt.Sprintf("/%d/migrate-bare", ws.ID), nil)
-	w := httptest.NewRecorder()
-
-	router.Routes().ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusNoContent, w.Code)
-
-	settingsPath := filepath.Join(repoPath, ".claude", "settings.local.json")
-	data, err := os.ReadFile(settingsPath)
-	require.NoError(t, err, "settings.local.json should exist after bare migration")
-	require.NotEmpty(t, data)
-}


### PR DESCRIPTION
## Summary

- **Bug**: `POST /workspaces/{id}/migrate-bare` left workspaces half-migrated because `gitService.DeleteWorktreesByRepoID` hit a foreign-key violation. `session_worktrees.worktree_id → worktrees.id` is declared `OnDelete:RESTRICT` (internal/session/session.go:56) and SQLite has `PRAGMA foreign_keys=ON`, so any session linked to a worktree in the migrating repo blocked the delete — after the on-disk rename + `.bare` clone had already succeeded.
- **Fix**: New `SessionService.DetachWorktreesByRepoID(ctx, repoID)` does a hard `DELETE` on the join rows first, then deletes the worktrees. Exposed to the workspace controller via a `SessionCleaner` interface (session imports workspace, so the dep flows through a setter wired in `api/app.go`). `MigrateWorkspaceToBare` now runs the DB cleanup **before** the filesystem migration, so a DB-side failure leaves disk untouched.
- **Behavior**: Sessions that span multiple repos keep their other worktrees; sessions whose only worktree was in the migrated repo remain in the DB with an empty `Worktrees` slice (the TUI already renders these as "no workspace") for the user to clean up.

## Test plan

- [x] `task test` — all packages green, including two new tests covering single-repo, multi-repo, and no-rows-to-detach cases (`TestSessionService_DetachWorktreesByRepoID*`).
- [x] `task lint` — no new issues (3 pre-existing staticcheck warnings on `sessionservice.go:221-228` confirmed via `git stash` + re-lint).
- [ ] Manual: rebuild daemon, restore a workspace that previously failed to migrate, run migrate-bare from the TUI, confirm the workspace flips to bare and orphan sessions become detached but visible.

## Note (not in scope)

The same FK pattern is latent in `SessionService.DeleteSession → cleanupSessionBranches → gitService.CleanupBranch → worktreeStore.Delete`. It hasn't surfaced because `cleanupSessionBranches` swallows errors with `slog.Warn`, silently leaving orphan `session_worktrees` / `worktrees` rows when sessions are deleted. Worth a follow-up.
