### PR TITLE
fix(session): keep sessions alive on branch change; stop deleting worktree dirs

### DIFF
--- a/internal/git/gitcli.go
+++ b/internal/git/gitcli.go
@@ -216,21 +216,10 @@ func (s *gitCLI) hasBranch(ctx context.Context, repoPath string, branch string) 
 	return true, nil
 }
 
-func (s *gitCLI) validateWorktree(ctx context.Context, worktreePath string, expectedBranch string) (bool, error) {
+func (s *gitCLI) validateWorktree(worktreePath string) (bool, error) {
 	info, err := os.Stat(worktreePath)
 	if err != nil || !info.IsDir() {
 		return false, nil
-	}
-
-	currentBranch, err := s.currentBranch(ctx, worktreePath)
-	if err != nil {
-		return false, fmt.Errorf("worktree exists at %s but failed to read branch: %w", worktreePath, err)
-	}
-	if currentBranch == "" {
-		return true, nil
-	}
-	if currentBranch != expectedBranch {
-		return false, fmt.Errorf("worktree at %s has branch %q, expected %q", worktreePath, currentBranch, expectedBranch)
 	}
 	return true, nil
 }

--- a/internal/git/gitcli_test.go
+++ b/internal/git/gitcli_test.go
@@ -154,7 +154,21 @@ func TestGitCLI_ValidateWorktree_DetachedHead(t *testing.T) {
 
 	run(t, worktreePath, "git", "checkout", "--detach")
 
-	exists, err := svc.validateWorktree(context.Background(), worktreePath, "eqt/my-feature")
+	exists, err := svc.validateWorktree(worktreePath)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestGitCLI_ValidateWorktree_DifferentBranch(t *testing.T) {
+	repo := initTestRepo(t)
+
+	svc := newGitCLI()
+	worktreePath, err := svc.createWorktree(context.Background(), repo, "eqt/my-feature", "main", "")
+	require.NoError(t, err)
+
+	run(t, worktreePath, "git", "checkout", "-b", "eqt/something-else")
+
+	exists, err := svc.validateWorktree(worktreePath)
 	require.NoError(t, err)
 	require.True(t, exists)
 }

--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -104,7 +104,7 @@ func (s *GitService) SetupWorktreeAt(ctx context.Context, repoPath string, branc
 		wtPath = s.cli.worktreePath(repoPath, branchName)
 	}
 
-	alreadyExists, err := s.cli.validateWorktree(ctx, wtPath, branchName)
+	alreadyExists, err := s.cli.validateWorktree(wtPath)
 	if err != nil {
 		return false, "", err
 	}
@@ -234,8 +234,8 @@ func (s *GitService) HasBranch(ctx context.Context, repoPath string, branch stri
 	return s.cli.hasBranch(ctx, repoPath, branch)
 }
 
-func (s *GitService) ValidateWorktree(ctx context.Context, worktreePath string, expectedBranch string) (bool, error) {
-	return s.cli.validateWorktree(ctx, worktreePath, expectedBranch)
+func (s *GitService) ValidateWorktree(worktreePath string) (bool, error) {
+	return s.cli.validateWorktree(worktreePath)
 }
 
 func (s *GitService) WorktreePath(repoPath string, branch string) string {
@@ -373,7 +373,7 @@ func (s *GitService) IsHealthy(ctx context.Context, branch *Branch, repoPath str
 	if err != nil {
 		return false
 	}
-	valid, err := s.cli.validateWorktree(ctx, wt.Path, branch.Name)
+	valid, err := s.cli.validateWorktree(wt.Path)
 	if err != nil || !valid {
 		return false
 	}
@@ -403,7 +403,7 @@ func (s *GitService) SyncBranch(ctx context.Context, branch *Branch, repoPath st
 	}
 
 	if existsLocal {
-		if valid, err := s.cli.validateWorktree(ctx, checkPath, branch.Name); err != nil {
+		if valid, err := s.cli.validateWorktree(checkPath); err != nil {
 			slog.Warn("failed to validate worktree", "path", checkPath, "error", err)
 		} else if valid {
 			if errors.Is(wtErr, ErrWorktreeNotFound) {
@@ -443,18 +443,6 @@ func (s *GitService) SyncBranch(ctx context.Context, branch *Branch, repoPath st
 }
 
 func (s *GitService) CleanupBranch(ctx context.Context, branch *Branch, repoPath string, deleteBranch bool) error {
-	wt, err := s.worktreeStore.GetByBranchID(branch.ID)
-	if err != nil && !errors.Is(err, ErrWorktreeNotFound) {
-		return fmt.Errorf("failed to look up worktree: %w", err)
-	}
-	if wt != nil && branch.Name != s.cli.defaultBranch(ctx, repoPath) {
-		if err := s.cli.removeWorktree(ctx, repoPath, wt.Path); err != nil {
-			return err
-		}
-		if err := s.worktreeStore.Delete(wt.ID); err != nil {
-			return fmt.Errorf("failed to delete worktree record: %w", err)
-		}
-	}
 	if deleteBranch {
 		if err := s.cli.deleteBranch(ctx, repoPath, branch.Name); err != nil {
 			return err

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -37,6 +37,11 @@ const (
 
 const defaultSetupTimeout = 5 * time.Minute
 
+const (
+	gitUnhealthyError    = "worktree or branch is unhealthy"
+	orphanedSessionError = "session predates multi-workspace migration — please recreate"
+)
+
 func traceOp(ctx context.Context, op string, fn func() error, attrs ...any) error {
 	opAttrs := append([]any{"op", op}, attrs...)
 	slog.InfoContext(ctx, "setup op: start", opAttrs...)
@@ -119,7 +124,7 @@ func (s *SessionService) markOrphanedSessionsBroken(sessions []Session) {
 		if len(sess.Worktrees) > 0 {
 			continue
 		}
-		if err := s.markSessionBroken(sess, "session predates multi-workspace migration — please recreate"); err != nil {
+		if err := s.markSessionBroken(sess, orphanedSessionError); err != nil {
 			slog.Warn("orphan check: failed to mark session broken", "session", sess.ID, "error", err)
 		}
 	}
@@ -373,25 +378,7 @@ func (s *SessionService) runSetup(sessionID uint, tmuxName string, branchName st
 	var setupWarnings []string
 	wsCache := make(map[uint]*workspace.Workspace)
 
-	rollback := func() {
-		for i := len(done) - 1; i >= 0; i-- {
-			r := done[i]
-			if r.worktreePath == "" {
-				continue
-			}
-			if err := s.gitService.RemoveWorktree(ctx, r.ws.Path, r.worktreePath); err != nil {
-				slog.WarnContext(ctx, "rollback: failed to remove worktree", "workspace", r.ws.Name, "path", r.worktreePath, "error", err)
-			}
-		}
-		if multi && sess.SessionRoot != "" {
-			if err := os.RemoveAll(sess.SessionRoot); err != nil {
-				slog.WarnContext(ctx, "rollback: failed to remove session root", "path", sess.SessionRoot, "error", err)
-			}
-		}
-	}
-
 	markBroken := func(stage string, err error) {
-		rollback()
 		msg := fmt.Sprintf("%s failed: %v", stage, err)
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			msg = fmt.Sprintf("%s timed out after %s", stage, s.setupTimeout)
@@ -870,7 +857,6 @@ func (s *SessionService) DeleteSession(ctx context.Context, id uint, deleteBranc
 	}
 
 	s.cleanupSessionBranches(ctx, session, deleteBranch)
-	s.cleanupSessionRootDir(session)
 
 	if session.TmuxSessionID != nil {
 		if err := s.tmuxService.KillSession(*session.TmuxSessionID); err != nil {
@@ -895,24 +881,6 @@ func (s *SessionService) DetachWorktreesByRepoID(ctx context.Context, repoID uin
 		return fmt.Errorf("failed to delete worktrees for repo %d: %w", repoID, err)
 	}
 	return nil
-}
-
-// cleanupSessionRootDir removes the SessionRoot dir on disk when utena owns it
-// (i.e. it lives under the configured sessionsRoot). For single-workspace
-// sessions, SessionRoot is either a worktree dir under a repo (cleaned up by
-// gitService.CleanupBranch) or the workspace path itself when no worktree was
-// created — neither lives under sessionsRoot, so this helper is a no-op.
-func (s *SessionService) cleanupSessionRootDir(sess *Session) {
-	if sess.SessionRoot == "" || s.sessionsRoot == "" {
-		return
-	}
-	rel, err := filepath.Rel(s.sessionsRoot, sess.SessionRoot)
-	if err != nil || rel == "" || rel == "." || strings.HasPrefix(rel, "..") {
-		return
-	}
-	if err := os.RemoveAll(sess.SessionRoot); err != nil {
-		slog.Warn("failed to remove session root", "path", sess.SessionRoot, "error", err)
-	}
 }
 
 func (s *SessionService) cleanupSessionBranches(ctx context.Context, session *Session, deleteBranch bool) {
@@ -1063,9 +1031,6 @@ func (s *SessionService) ArchiveSession(ctx context.Context, id uint) (*Session,
 		return nil, fmt.Errorf("cannot archive session in status %s", sess.Status)
 	}
 
-	s.cleanupSessionBranches(ctx, sess, false)
-	s.cleanupSessionRootDir(sess)
-
 	if sess.TmuxSessionID != nil {
 		if err := s.tmuxService.KillSession(*sess.TmuxSessionID); err != nil {
 			slog.Warn("failed to kill tmux session during archive", "session", sess.ID, "error", err)
@@ -1132,16 +1097,20 @@ func (s *SessionService) reconcileLoadedSession(ctx context.Context, sess *Sessi
 
 	prevStatus := sess.Status
 	prevError := sess.StatusError
+	canRecoverFromBroken := sess.Status == StatusBroken && sess.StatusError == gitUnhealthyError
+
 	if !gitHealthy {
 		sess.Status = StatusBroken
-		sess.StatusError = "worktree or branch is unhealthy"
+		sess.StatusError = gitUnhealthyError
 	} else if !tmuxAlive {
-		if sess.Status == StatusActive {
+		if sess.Status == StatusActive || canRecoverFromBroken {
 			sess.Status = StatusInactive
+			sess.StatusError = ""
 		}
 	} else {
-		if sess.Status == StatusInactive {
+		if sess.Status == StatusInactive || canRecoverFromBroken {
 			sess.Status = StatusActive
+			sess.StatusError = ""
 		}
 	}
 

--- a/internal/session/sessionservice_multi.go
+++ b/internal/session/sessionservice_multi.go
@@ -126,7 +126,7 @@ func (s *SessionService) CreateMultiSession(ctx context.Context, input CreateMul
 		SessionRoot: sessionRoot,
 	}
 	if err := s.store.Add(sess); err != nil {
-		_ = os.RemoveAll(sessionRoot)
+		slog.WarnContext(ctx, "session create failed; session root preserved", "path", sessionRoot, "error", err)
 		return nil, err
 	}
 
@@ -135,7 +135,7 @@ func (s *SessionService) CreateMultiSession(ctx context.Context, input CreateMul
 			if delErr := s.store.Delete(sess.ID); delErr != nil {
 				slog.ErrorContext(ctx, "failed to delete session after worktree creation failure", "session", sess.ID, "error", delErr)
 			}
-			_ = os.RemoveAll(sessionRoot)
+			slog.WarnContext(ctx, "session worktree create failed; session root preserved", "path", sessionRoot, "workspace", w.workspace.ID, "error", err)
 			return nil, fmt.Errorf("eager create worktree for workspace %d: %w", w.workspace.ID, err)
 		}
 	}
@@ -153,7 +153,7 @@ func (s *SessionService) CreateMultiSession(ctx context.Context, input CreateMul
 		if delErr := s.store.Delete(sess.ID); delErr != nil {
 			slog.WarnContext(ctx, "failed to roll back session after tmux registration failure", "session", sess.ID, "error", delErr)
 		}
-		_ = os.RemoveAll(sessionRoot)
+		slog.WarnContext(ctx, "tmux registration failed; session root preserved", "path", sessionRoot, "error", err)
 		return nil, fmt.Errorf("register tmux session %q: %w", tmuxName, err)
 	}
 	sess.TmuxSessionID = &tmuxRecord.ID

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -83,6 +83,46 @@ func TestSessionService_OnAppStart(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSessionService_Reconcile_RecoversBrokenSessionOnceGitHealthy(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, _ := setupSessionService(t)
+	ctx := context.Background()
+
+	sess := &Session{
+		Name:        "previously-broken",
+		Status:      StatusBroken,
+		StatusError: gitUnhealthyError,
+		LastUsedAt:  time.Now(),
+	}
+	addTestSession(t, sessionStore, swtStoreFor(service), sess, ws1ID)
+
+	require.NoError(t, service.OnAppStart(ctx))
+
+	loaded, err := sessionStore.GetByID(sess.ID)
+	require.NoError(t, err)
+	require.NotEqual(t, StatusBroken, loaded.Status, "broken-by-git-mismatch session should auto-revive once worktree is healthy again")
+	require.Empty(t, loaded.StatusError)
+}
+
+func TestSessionService_Reconcile_LeavesOrphanedBrokenSessionAlone(t *testing.T) {
+	service, sessionStore, _, _, _, _ := setupSessionService(t)
+	ctx := context.Background()
+
+	orphan := &Session{
+		Name:        "orphan-broken",
+		Status:      StatusBroken,
+		StatusError: orphanedSessionError,
+		LastUsedAt:  time.Now(),
+	}
+	require.NoError(t, sessionStore.Add(orphan))
+
+	require.NoError(t, service.OnAppStart(ctx))
+
+	loaded, err := sessionStore.GetByID(orphan.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusBroken, loaded.Status, "orphan-marked broken sessions must not auto-revive")
+	require.Contains(t, loaded.StatusError, "predates")
+}
+
 func TestSessionService_OnAppStart_RecoversStuckCreatingSessions(t *testing.T) {
 	service, sessionStore, _, _, ws1ID, _ := setupSessionService(t)
 	ctx := context.Background()
@@ -239,6 +279,27 @@ func TestSessionService_UpdateSession(t *testing.T) {
 	retrieved, err := sessionStore.GetByID(session.ID)
 	require.NoError(t, err)
 	require.True(t, retrieved.IsAttached)
+}
+
+func TestSessionService_DeleteSession_PreservesWorktreeDirOnDisk(t *testing.T) {
+	repoPath := initTestRepo(t)
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	session := &Session{Name: "keep-me"}
+	ctx := context.Background()
+	require.NoError(t, service.CreateSession(ctx, session, wsGitID, "", "main"))
+	waitForStatus(t, sessionStore, session.ID, StatusActive, 5*time.Second)
+
+	worktreePath := filepath.Join(repoPath, ".worktrees", "eqt-keep-me")
+	info, err := os.Stat(worktreePath)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+
+	require.NoError(t, service.DeleteSession(ctx, session.ID, true, false))
+
+	info, err = os.Stat(worktreePath)
+	require.NoError(t, err, "worktree dir must survive DeleteSession")
+	require.True(t, info.IsDir())
 }
 
 func TestSessionService_DeleteSession(t *testing.T) {

--- a/internal/workspace/workspacerouter_test.go
+++ b/internal/workspace/workspacerouter_test.go
@@ -435,4 +435,3 @@ func TestWorkspaceRouter_CheckBranchExists_MissingName(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
-


### PR DESCRIPTION
## Summary
- Drop the strict `currentBranch == expectedBranch` check in `validateWorktree` so healthy/active sessions don't get marked broken when Claude (or anyone) switches branches inside the worktree. The expected branch becomes informational; the worktree dir's existence is the only health gate.
- Add a Broken → Active/Inactive recovery path in `reconcileLoadedSession`, gated on `StatusError == gitUnhealthyError` so it only auto-revives sessions broken by this check (orphan / stuck-creating sessions stay broken).
- Stop every automatic worktree-directory deletion: `DeleteSession`, `ArchiveSession`, multi-session creation rollback, `runSetup` rollback, and `CleanupBranch` no longer touch the filesystem. Worktree dirs and session roots survive both explicit deletion and creation failures, so Claude work in progress isn't destroyed.

## Test plan
- [x] `task test` — full suite green, including 4 new regression tests:
  - `TestGitCLI_ValidateWorktree_DifferentBranch` — branch mismatch returns valid
  - `TestSessionService_Reconcile_RecoversBrokenSessionOnceGitHealthy` — broken-by-git-mismatch session auto-revives
  - `TestSessionService_Reconcile_LeavesOrphanedBrokenSessionAlone` — orphan-marker sessions stay broken
  - `TestSessionService_DeleteSession_PreservesWorktreeDirOnDisk` — integration: real worktree survives DeleteSession
- [ ] Manual: create a session on `feature/foo`, run `git checkout main` in the worktree, restart daemon, verify session stays Active.
- [ ] Manual: delete a session from the TUI, verify the worktree dir is still on disk and `git -C <worktree> status` works.

## Known consequences
- `DeleteSession(deleteBranch=true)` will silently no-op the branch delete when the worktree dir is still checked out at that branch (`git branch -D` refuses). Logged as a warning. This is the deliberate tradeoff for "always keep worktree dir".
- TUI session detail still renders `Worktree.Branch.Name` (the originally stored branch) — after Claude switches branches, this shows stale until the next session creation re-syncs. Live-refresh is a follow-up.
