### PR TITLE
fix: concurrent map crash in TmuxService + session re-creation after delete

### DIFF
--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -288,9 +288,6 @@ func (s *SessionService) CreateSession(ctx context.Context, input CreateSessionI
 	}
 
 	sessionRoot := filepath.Join(s.sessionsRoot, SanitizeSessionName(name))
-	if _, err := os.Stat(sessionRoot); err == nil {
-		return nil, common.NewInvalidRequest(fmt.Sprintf("session root %q already exists on disk", sessionRoot))
-	}
 
 	for _, sl := range slots {
 		if existing, err := s.store.GetByWorkspaceAndName(sl.ws.ID, name, StatusDeleted, StatusArchived, StatusCompleted); err == nil && existing != nil {

--- a/internal/tmux/tmuxservice.go
+++ b/internal/tmux/tmuxservice.go
@@ -16,6 +16,7 @@ type TmuxService struct {
 	store            *TmuxStore
 	eventBus         eventbus.EventBus
 	windowsBySession map[string][]Window
+	windowsMu        sync.RWMutex
 	nameLocks        sync.Map
 }
 
@@ -221,6 +222,8 @@ func (t *TmuxService) GetSession(id uint) (*TmuxSession, error) {
 	if err != nil {
 		return nil, err
 	}
+	t.windowsMu.RLock()
+	defer t.windowsMu.RUnlock()
 	ts.Windows = t.windowsBySession[ts.Name]
 	return ts, nil
 }
@@ -230,6 +233,8 @@ func (t *TmuxService) GetSessionByName(name string) (*TmuxSession, error) {
 	if err != nil {
 		return nil, err
 	}
+	t.windowsMu.RLock()
+	defer t.windowsMu.RUnlock()
 	ts.Windows = t.windowsBySession[ts.Name]
 	return ts, nil
 }
@@ -278,7 +283,9 @@ func (t *TmuxService) HandleSessionClosed(ctx context.Context, tmuxName string) 
 			slog.Warn("failed to mark tmux session inactive", "tmux", tmuxName, "error", updateErr)
 		}
 	}
+	t.windowsMu.Lock()
 	delete(t.windowsBySession, tmuxName)
+	t.windowsMu.Unlock()
 	return t.eventBus.Publish(ctx, eventbus.Event{
 		Type: eventbus.TmuxSessionClosed,
 		Data: eventbus.TmuxHookEvent{TmuxSessionName: tmuxName},
@@ -314,9 +321,13 @@ func (t *TmuxService) SpawnWindow(sessionName, startDir, command string) error {
 }
 
 func (t *TmuxService) SyncWindows(ctx context.Context, tmuxName string, windows []Window) {
+	t.windowsMu.Lock()
+	defer t.windowsMu.Unlock()
 	t.windowsBySession[tmuxName] = windows
 }
 
 func (t *TmuxService) GetWindows(ctx context.Context, tmuxName string) []Window {
+	t.windowsMu.RLock()
+	defer t.windowsMu.RUnlock()
 	return t.windowsBySession[tmuxName]
 }


### PR DESCRIPTION
## Summary
- Fix `fatal error: concurrent map writes` crash in `TmuxService`: `windowsBySession` was accessed from concurrent goroutines (HTTP handler + background job) without synchronization — protected with `sync.RWMutex`
- Fix session creation failing with "session root already exists" after deleting a failed session: removed the overly-aggressive `os.Stat` guard in `CreateSession`; the DB duplicate-name check is the real protection, and deleted sessions intentionally preserve their directories on disk

## Test plan
- [ ] Create a session in marin workspace — should succeed
- [ ] Delete the session, then create a new one with the same name — should succeed without "already exists" error
- [ ] Confirm daemon no longer crashes on concurrent sync-windows + session cleanup
