### PR TITLE
feat(workspace): clone from URL and auto-register via TUI

### DIFF
--- a/internal/git/gitcli.go
+++ b/internal/git/gitcli.go
@@ -300,25 +300,94 @@ func (s *gitCLI) migrateToBare(ctx context.Context, workspacePath string) error 
 		return fmt.Errorf("failed to create workspace directory (backup at %s): %w", backupPath, err)
 	}
 
-	barePath := filepath.Join(workspacePath, ".bare")
-	cmd := exec.CommandContext(ctx, "git", "clone", "--bare", remoteURL, barePath)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git clone --bare failed (backup at %s): %s: %w", backupPath, strings.TrimSpace(string(output)), err)
+	if err := s.runBareClone(ctx, remoteURL, workspacePath); err != nil {
+		return fmt.Errorf("%w (backup at %s)", err, backupPath)
 	}
 
-	if err := os.WriteFile(gitDir, []byte("gitdir: ./.bare\n"), 0644); err != nil {
-		return fmt.Errorf("failed to write .git file (backup at %s): %w", backupPath, err)
+	if err := writeBareMarker(workspacePath); err != nil {
+		return fmt.Errorf("%w (backup at %s)", err, backupPath)
 	}
 
-	cmd = exec.CommandContext(ctx, "git", "-C", workspacePath, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to set fetch refspec (backup at %s): %s: %w", backupPath, strings.TrimSpace(string(output)), err)
+	if err := s.configureBareFetchRefspec(ctx, workspacePath); err != nil {
+		return fmt.Errorf("%w (backup at %s)", err, backupPath)
 	}
 
 	return nil
 }
 
+func (s *gitCLI) cloneBareWorkspace(ctx context.Context, remoteURL, workspacePath string) error {
+	remoteURL = strings.TrimSpace(remoteURL)
+	if remoteURL == "" {
+		return fmt.Errorf("remote URL is required")
+	}
+
+	if info, err := os.Stat(workspacePath); err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("target path exists and is not a directory: %s", workspacePath)
+		}
+		entries, readErr := os.ReadDir(workspacePath)
+		if readErr != nil {
+			return fmt.Errorf("failed to read target directory %s: %w", workspacePath, readErr)
+		}
+		if len(entries) > 0 {
+			return fmt.Errorf("target directory is not empty: %s", workspacePath)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to inspect target path %s: %w", workspacePath, err)
+	}
+
+	if err := os.MkdirAll(workspacePath, 0755); err != nil {
+		return fmt.Errorf("failed to create workspace directory %s: %w", workspacePath, err)
+	}
+
+	if err := s.runBareClone(ctx, remoteURL, workspacePath); err != nil {
+		_ = os.RemoveAll(workspacePath)
+		return err
+	}
+
+	if err := writeBareMarker(workspacePath); err != nil {
+		_ = os.RemoveAll(workspacePath)
+		return err
+	}
+
+	if err := s.configureBareFetchRefspec(ctx, workspacePath); err != nil {
+		_ = os.RemoveAll(workspacePath)
+		return err
+	}
+
+	return nil
+}
+
+func (s *gitCLI) runBareClone(ctx context.Context, remoteURL, workspacePath string) error {
+	barePath := filepath.Join(workspacePath, ".bare")
+	cmd := exec.CommandContext(ctx, "git", "clone", "--bare", remoteURL, barePath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git clone --bare failed: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+func writeBareMarker(workspacePath string) error {
+	gitDir := filepath.Join(workspacePath, ".git")
+	if err := os.WriteFile(gitDir, []byte("gitdir: ./.bare\n"), 0644); err != nil {
+		return fmt.Errorf("failed to write .git file: %w", err)
+	}
+	return nil
+}
+
+func (s *gitCLI) configureBareFetchRefspec(ctx context.Context, workspacePath string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", workspacePath, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to set fetch refspec: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
 func (s *gitCLI) parseRepoFullName(remoteURL string) (owner string, repo string, err error) {
+	return ParseRepoFullName(remoteURL)
+}
+
+func ParseRepoFullName(remoteURL string) (owner string, repo string, err error) {
 	remoteURL = strings.TrimSpace(remoteURL)
 
 	if strings.HasPrefix(remoteURL, "git@") {

--- a/internal/git/gitcli_test.go
+++ b/internal/git/gitcli_test.go
@@ -323,3 +323,83 @@ func TestGitCLI_ParseRepoFullName_InvalidURL(t *testing.T) {
 	_, _, err = svc.parseRepoFullName("git@github.com:only-owner")
 	require.Error(t, err)
 }
+
+func TestGitCLI_CloneBareWorkspace_HappyPath(t *testing.T) {
+	source := initTestRepo(t)
+
+	parent := t.TempDir()
+	target := filepath.Join(parent, "cloned")
+
+	svc := newGitCLI()
+	err := svc.cloneBareWorkspace(context.Background(), source, target)
+	require.NoError(t, err)
+
+	gitInfo, err := os.Stat(filepath.Join(target, ".git"))
+	require.NoError(t, err)
+	require.False(t, gitInfo.IsDir(), ".git should be a file pointing at .bare")
+
+	bareInfo, err := os.Stat(filepath.Join(target, ".bare"))
+	require.NoError(t, err)
+	require.True(t, bareInfo.IsDir(), ".bare should be a directory")
+
+	contents, err := os.ReadFile(filepath.Join(target, ".git"))
+	require.NoError(t, err)
+	require.Equal(t, "gitdir: ./.bare\n", string(contents))
+
+	cmd := exec.Command("git", "-C", target, "config", "--get", "remote.origin.fetch")
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	require.Equal(t, "+refs/heads/*:refs/remotes/origin/*", trimOutput(out))
+
+	require.True(t, isBareWorkspace(target))
+}
+
+func TestGitCLI_CloneBareWorkspace_CreatesParents(t *testing.T) {
+	source := initTestRepo(t)
+
+	parent := t.TempDir()
+	target := filepath.Join(parent, "nested", "dirs", "cloned")
+
+	svc := newGitCLI()
+	err := svc.cloneBareWorkspace(context.Background(), source, target)
+	require.NoError(t, err)
+
+	require.True(t, isBareWorkspace(target))
+}
+
+func TestGitCLI_CloneBareWorkspace_RejectsNonEmptyTarget(t *testing.T) {
+	source := initTestRepo(t)
+
+	parent := t.TempDir()
+	target := filepath.Join(parent, "cloned")
+	require.NoError(t, os.MkdirAll(target, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(target, "stray"), []byte("x"), 0644))
+
+	svc := newGitCLI()
+	err := svc.cloneBareWorkspace(context.Background(), source, target)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not empty")
+
+	_, statErr := os.Stat(filepath.Join(target, "stray"))
+	require.NoError(t, statErr, "rejected clone must not delete user files")
+}
+
+func TestGitCLI_CloneBareWorkspace_RejectsEmptyURL(t *testing.T) {
+	svc := newGitCLI()
+	err := svc.cloneBareWorkspace(context.Background(), "", filepath.Join(t.TempDir(), "target"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "required")
+}
+
+func TestGitCLI_CloneBareWorkspace_CleansUpOnCloneFailure(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(parent, "cloned")
+
+	svc := newGitCLI()
+	err := svc.cloneBareWorkspace(context.Background(), filepath.Join(parent, "does-not-exist"), target)
+	require.Error(t, err)
+
+	_, statErr := os.Stat(target)
+	require.True(t, os.IsNotExist(statErr), "failed clone should clean up its target dir, got: %v", statErr)
+}

--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -254,6 +254,14 @@ func (s *GitService) MigrateToBare(ctx context.Context, workspacePath string) er
 	return s.cli.migrateToBare(ctx, workspacePath)
 }
 
+func (s *GitService) CloneBareWorkspace(ctx context.Context, remoteURL, workspacePath string) error {
+	return s.cli.cloneBareWorkspace(ctx, remoteURL, workspacePath)
+}
+
+func (s *GitService) ParseRepoFullName(remoteURL string) (owner string, repo string, err error) {
+	return s.cli.parseRepoFullName(remoteURL)
+}
+
 func (s *GitService) DeleteBranch(ctx context.Context, repoPath string, branchName string) error {
 	return s.cli.deleteBranch(ctx, repoPath, branchName)
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -16,6 +16,7 @@ import (
 	"github.com/eleonorayaya/utena/internal/tui/statusview"
 	"github.com/eleonorayaya/utena/internal/tui/todoform"
 	"github.com/eleonorayaya/utena/internal/tui/todolist"
+	"github.com/eleonorayaya/utena/internal/tui/workspacecloneform"
 	"github.com/eleonorayaya/utena/internal/tui/workspacedetail"
 	"github.com/eleonorayaya/utena/internal/tui/workspacelist"
 )
@@ -49,17 +50,18 @@ func NewApp(logPath, port string, initialView router.View, opts ...AppOption) Ap
 
 	baseURL := fmt.Sprintf("http://localhost:%s", port)
 	views := map[router.View]router.ViewEntry{
-		router.SessionListView:     &router.ViewAdapter[sessionlist.Model]{Model: sessionlist.New()},
-		router.SessionDetailView:   &router.ViewAdapter[sessiondetail.Model]{Model: sessiondetail.New()},
-		router.SessionFormView:     &router.ViewAdapter[sessionform.Model]{Model: sessionform.New()},
-		router.SessionProgressView: &router.ViewAdapter[sessionprogress.Model]{Model: sessionprogress.New()},
-		router.TodoListView:        &router.ViewAdapter[todolist.Model]{Model: todolist.New()},
-		router.TodoFormView:        &router.ViewAdapter[todoform.Model]{Model: todoform.New()},
-		router.DebugView:           &router.ViewAdapter[debug.Model]{Model: debug.New(logPath, baseURL)},
-		router.StatusView:          &router.ViewAdapter[statusview.Model]{Model: statusview.New()},
-		router.WorkspaceListView:   &router.ViewAdapter[workspacelist.Model]{Model: workspacelist.New()},
-		router.WorkspaceDetailView: &router.ViewAdapter[workspacedetail.Model]{Model: workspacedetail.New()},
-		router.PRListView:          &router.ViewAdapter[prlist.Model]{Model: prlist.New()},
+		router.SessionListView:        &router.ViewAdapter[sessionlist.Model]{Model: sessionlist.New()},
+		router.SessionDetailView:      &router.ViewAdapter[sessiondetail.Model]{Model: sessiondetail.New()},
+		router.SessionFormView:        &router.ViewAdapter[sessionform.Model]{Model: sessionform.New()},
+		router.SessionProgressView:    &router.ViewAdapter[sessionprogress.Model]{Model: sessionprogress.New()},
+		router.TodoListView:           &router.ViewAdapter[todolist.Model]{Model: todolist.New()},
+		router.TodoFormView:           &router.ViewAdapter[todoform.Model]{Model: todoform.New()},
+		router.DebugView:              &router.ViewAdapter[debug.Model]{Model: debug.New(logPath, baseURL)},
+		router.StatusView:             &router.ViewAdapter[statusview.Model]{Model: statusview.New()},
+		router.WorkspaceListView:      &router.ViewAdapter[workspacelist.Model]{Model: workspacelist.New()},
+		router.WorkspaceDetailView:    &router.ViewAdapter[workspacedetail.Model]{Model: workspacedetail.New()},
+		router.WorkspaceCloneFormView: &router.ViewAdapter[workspacecloneform.Model]{Model: workspacecloneform.New()},
+		router.PRListView:             &router.ViewAdapter[prlist.Model]{Model: prlist.New()},
 	}
 
 	return App{

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -463,6 +463,75 @@ func (c *client) addWorkspace(path string, asRoot bool) tea.Cmd {
 	}
 }
 
+func (c *client) cloneWorkspace(cloneURL, rootPath, dirName string) tea.Cmd {
+	return func() tea.Msg {
+		body := map[string]string{"clone_url": cloneURL}
+		if rootPath != "" {
+			body["root_path"] = rootPath
+		}
+		if dirName != "" {
+			body["dir_name"] = dirName
+		}
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return workspaceClonedMsg{err: err}
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/workspaces/clone", bytes.NewReader(jsonBody))
+		if err != nil {
+			return workspaceClonedMsg{err: err}
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		httpClient := &http.Client{}
+		res, err := httpClient.Do(req)
+		if err != nil {
+			log.Printf("[ERROR] clone workspace %q: %v", cloneURL, err)
+			return workspaceClonedMsg{err: err}
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusCreated {
+			apiErr := parseAPIError(res, "clone workspace")
+			return workspaceClonedMsg{err: apiErr.Err}
+		}
+
+		var resp workspace.WorkspaceResponse
+		if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+			return workspaceClonedMsg{err: err}
+		}
+		if resp.Workspace == nil {
+			return workspaceClonedMsg{err: fmt.Errorf("clone workspace: empty response")}
+		}
+		return workspaceClonedMsg{workspace: *resp.Workspace}
+	}
+}
+
+func (c *client) fetchWorkspaceRoots() tea.Cmd {
+	return func() tea.Msg {
+		res, err := c.httpClient.Get(c.baseURL + "/workspaces/roots")
+		if err != nil {
+			log.Printf("[ERROR] fetch workspace roots: %v", err)
+			return workspaceRootsMsg{err: err}
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			apiErr := parseAPIError(res, "fetch workspace roots")
+			return workspaceRootsMsg{err: apiErr.Err}
+		}
+
+		var resp workspace.WorkspaceRootsResponse
+		if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+			return workspaceRootsMsg{err: err}
+		}
+		return workspaceRootsMsg{roots: resp.Roots}
+	}
+}
+
 func (c *client) fetchTodos() tea.Cmd {
 	return func() tea.Msg {
 		res, err := c.httpClient.Get(c.baseURL + "/todos")

--- a/internal/tui/provider/workspacesprovider.go
+++ b/internal/tui/provider/workspacesprovider.go
@@ -74,6 +74,26 @@ func AddWorkspace(path string, asRoot bool) tea.Cmd {
 	return func() tea.Msg { return addWorkspaceIntentMsg{path: path, asRoot: asRoot} }
 }
 
+type WorkspaceClonedMsg struct {
+	Workspace workspace.Workspace
+	Err       error
+}
+
+type WorkspaceRootsMsg struct {
+	Roots []string
+	Err   error
+}
+
+func CloneWorkspace(cloneURL, rootPath, dirName string) tea.Cmd {
+	return func() tea.Msg {
+		return cloneWorkspaceIntentMsg{cloneURL: cloneURL, rootPath: rootPath, dirName: dirName}
+	}
+}
+
+func FetchWorkspaceRoots() tea.Cmd {
+	return func() tea.Msg { return fetchWorkspaceRootsIntentMsg{} }
+}
+
 type fetchWorkspacesIntentMsg struct{}
 type requestWorkspacesStateMsg struct{}
 
@@ -114,6 +134,24 @@ type setWorkspaceHiddenIntentMsg struct {
 type addWorkspaceIntentMsg struct {
 	path   string
 	asRoot bool
+}
+
+type cloneWorkspaceIntentMsg struct {
+	cloneURL string
+	rootPath string
+	dirName  string
+}
+
+type fetchWorkspaceRootsIntentMsg struct{}
+
+type workspaceClonedMsg struct {
+	workspace workspace.Workspace
+	err       error
+}
+
+type workspaceRootsMsg struct {
+	roots []string
+	err   error
 }
 
 type fetchPRsIntentMsg struct {
@@ -240,6 +278,30 @@ func (p workspacesProvider) Update(msg tea.Msg) (workspacesProvider, tea.Cmd) {
 
 	case workspaceMigratedToBareMsg:
 		return p, p.client.fetchWorkspaces()
+
+	case cloneWorkspaceIntentMsg:
+		return p, p.client.cloneWorkspace(msg.cloneURL, msg.rootPath, msg.dirName)
+
+	case workspaceClonedMsg:
+		ws := msg.workspace
+		err := msg.err
+		var refetch tea.Cmd
+		if err == nil {
+			refetch = p.client.fetchWorkspaces()
+		}
+		emit := func() tea.Msg { return WorkspaceClonedMsg{Workspace: ws, Err: err} }
+		if refetch == nil {
+			return p, emit
+		}
+		return p, tea.Batch(emit, refetch)
+
+	case fetchWorkspaceRootsIntentMsg:
+		return p, p.client.fetchWorkspaceRoots()
+
+	case workspaceRootsMsg:
+		roots := msg.roots
+		err := msg.err
+		return p, func() tea.Msg { return WorkspaceRootsMsg{Roots: roots, Err: err} }
 	}
 
 	return p, nil

--- a/internal/tui/router/view.go
+++ b/internal/tui/router/view.go
@@ -12,6 +12,7 @@ const (
 	StatusView
 	WorkspaceListView
 	WorkspaceDetailView
+	WorkspaceCloneFormView
 	PRListView
 	SessionDetailView
 )

--- a/internal/tui/workspacecloneform/keys.go
+++ b/internal/tui/workspacecloneform/keys.go
@@ -1,0 +1,34 @@
+package workspacecloneform
+
+import (
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+)
+
+type keyMap struct {
+	Submit    key.Binding
+	NextField key.Binding
+	PrevField key.Binding
+	NextRoot  key.Binding
+	PrevRoot  key.Binding
+	Back      key.Binding
+}
+
+func (k keyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Submit, k.NextField, k.PrevField, k.NextRoot, k.PrevRoot, k.Back}
+}
+
+func (k keyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{k.Submit, k.NextField, k.PrevField, k.NextRoot, k.PrevRoot, k.Back}}
+}
+
+var keys = keyMap{
+	Submit:    key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "clone")),
+	NextField: key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "next field")),
+	PrevField: key.NewBinding(key.WithKeys("shift+tab"), key.WithHelp("shift+tab", "prev field")),
+	NextRoot:  key.NewBinding(key.WithKeys("ctrl+n"), key.WithHelp("ctrl+n", "next root")),
+	PrevRoot:  key.NewBinding(key.WithKeys("ctrl+p"), key.WithHelp("ctrl+p", "prev root")),
+	Back:      key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+}
+
+var _ help.KeyMap = keys

--- a/internal/tui/workspacecloneform/model.go
+++ b/internal/tui/workspacecloneform/model.go
@@ -1,0 +1,248 @@
+package workspacecloneform
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/eleonorayaya/utena/internal/git"
+	"github.com/eleonorayaya/utena/internal/tui/provider"
+	"github.com/eleonorayaya/utena/internal/tui/router"
+	"github.com/eleonorayaya/utena/internal/tui/theme"
+)
+
+func titleStyle() lipgloss.Style { return lipgloss.NewStyle().Bold(true) }
+func errStyle() lipgloss.Style   { return lipgloss.NewStyle().Foreground(theme.Current.Error) }
+func pathStyle() lipgloss.Style  { return lipgloss.NewStyle().Foreground(theme.Current.Path) }
+func pendingStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(theme.Current.StatusPending)
+}
+func helpStyle() lipgloss.Style { return lipgloss.NewStyle().Foreground(theme.Current.StatusPending) }
+
+type focusTarget int
+
+const (
+	focusURL focusTarget = iota
+	focusDirName
+)
+
+type Model struct {
+	urlInput     textinput.Model
+	dirNameInput textinput.Model
+	roots        []string
+	rootsLoaded  bool
+	rootsErr     error
+	rootIndex    int
+	focus        focusTarget
+	cloning      bool
+	errMsg       string
+	width        int
+	height       int
+}
+
+func New() Model {
+	url := textinput.New()
+	url.Prompt = "Clone URL: "
+	url.Placeholder = "git@github.com:org/repo.git"
+	url.CharLimit = 512
+
+	dirName := textinput.New()
+	dirName.Prompt = "Directory name (optional): "
+	dirName.Placeholder = "derived from URL"
+	dirName.CharLimit = 128
+
+	return Model{urlInput: url, dirNameInput: dirName}
+}
+
+func (m Model) Init() (Model, tea.Cmd) {
+	m.urlInput.SetValue("")
+	m.dirNameInput.SetValue("")
+	m.roots = nil
+	m.rootsLoaded = false
+	m.rootsErr = nil
+	m.rootIndex = 0
+	m.focus = focusURL
+	m.cloning = false
+	m.errMsg = ""
+	return m, tea.Batch(m.urlInput.Focus(), provider.FetchWorkspaceRoots())
+}
+
+func (m *Model) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+func (m Model) Keys() help.KeyMap {
+	return keys
+}
+
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.SetSize(msg.Width, msg.Height)
+		return m, nil
+
+	case provider.WorkspaceRootsMsg:
+		m.rootsLoaded = true
+		if msg.Err != nil {
+			m.rootsErr = msg.Err
+			return m, nil
+		}
+		m.roots = msg.Roots
+		if m.rootIndex >= len(m.roots) {
+			m.rootIndex = 0
+		}
+		return m, nil
+
+	case provider.WorkspaceClonedMsg:
+		m.cloning = false
+		if msg.Err != nil {
+			m.errMsg = msg.Err.Error()
+			return m, nil
+		}
+		return m, router.Back()
+
+	case tea.KeyMsg:
+		return m.onKey(msg)
+	}
+
+	return m.routeInput(msg)
+}
+
+func (m Model) onKey(msg tea.KeyMsg) (Model, tea.Cmd) {
+	if m.cloning {
+		return m, nil
+	}
+	switch {
+	case key.Matches(msg, keys.Back):
+		return m, router.Back()
+	case key.Matches(msg, keys.Submit):
+		return m.submit()
+	case key.Matches(msg, keys.NextField), key.Matches(msg, keys.PrevField):
+		var cmd tea.Cmd
+		m, cmd = m.toggleFocus()
+		return m, cmd
+	case key.Matches(msg, keys.NextRoot):
+		if len(m.roots) > 1 {
+			m.rootIndex = (m.rootIndex + 1) % len(m.roots)
+		}
+		return m, nil
+	case key.Matches(msg, keys.PrevRoot):
+		if len(m.roots) > 1 {
+			m.rootIndex = (m.rootIndex - 1 + len(m.roots)) % len(m.roots)
+		}
+		return m, nil
+	}
+	return m.routeInput(msg)
+}
+
+func (m Model) routeInput(msg tea.Msg) (Model, tea.Cmd) {
+	var cmd tea.Cmd
+	switch m.focus {
+	case focusURL:
+		m.urlInput, cmd = m.urlInput.Update(msg)
+	case focusDirName:
+		m.dirNameInput, cmd = m.dirNameInput.Update(msg)
+	}
+	return m, cmd
+}
+
+func (m Model) toggleFocus() (Model, tea.Cmd) {
+	if m.focus == focusURL {
+		m.focus = focusDirName
+		m.urlInput.Blur()
+		return m, m.dirNameInput.Focus()
+	}
+	m.focus = focusURL
+	m.dirNameInput.Blur()
+	return m, m.urlInput.Focus()
+}
+
+func (m Model) submit() (Model, tea.Cmd) {
+	url := strings.TrimSpace(m.urlInput.Value())
+	if url == "" {
+		m.errMsg = "clone URL is required"
+		return m, nil
+	}
+	if !m.rootsLoaded {
+		m.errMsg = "still loading workspace roots…"
+		return m, nil
+	}
+	if len(m.roots) == 0 {
+		m.errMsg = "no workspace roots configured — add one to ~/.config/utena/config.json first"
+		return m, nil
+	}
+	rootPath := m.roots[m.rootIndex]
+	dirName := strings.TrimSpace(m.dirNameInput.Value())
+	m.errMsg = ""
+	m.cloning = true
+	return m, provider.CloneWorkspace(url, rootPath, dirName)
+}
+
+func (m Model) View() string {
+	var b strings.Builder
+	b.WriteString(titleStyle().Render("Clone workspace from URL"))
+	b.WriteString("\n\n")
+	b.WriteString(m.urlInput.View())
+	b.WriteString("\n")
+	b.WriteString(m.dirNameInput.View())
+	b.WriteString("\n\n")
+
+	switch {
+	case !m.rootsLoaded:
+		b.WriteString(pendingStyle().Render("Loading workspace roots…"))
+	case m.rootsErr != nil:
+		b.WriteString(errStyle().Render("Failed to load roots: " + m.rootsErr.Error()))
+	case len(m.roots) == 0:
+		b.WriteString(errStyle().Render("No workspace roots configured — add one to ~/.config/utena/config.json first"))
+	case len(m.roots) == 1:
+		b.WriteString("Target root: " + pathStyle().Render(m.roots[0]))
+		b.WriteString("\nWill clone into: " + pathStyle().Render(m.targetPreview(m.roots[0])))
+	default:
+		fmt.Fprintf(&b, "Target root (ctrl+n / ctrl+p to switch, %d/%d): ", m.rootIndex+1, len(m.roots))
+		b.WriteString(pathStyle().Render(m.roots[m.rootIndex]))
+		b.WriteString("\nWill clone into: " + pathStyle().Render(m.targetPreview(m.roots[m.rootIndex])))
+	}
+
+	if m.cloning {
+		b.WriteString("\n\n")
+		b.WriteString(pendingStyle().Render("Cloning… this can take a while for large repos."))
+	}
+
+	if m.errMsg != "" {
+		b.WriteString("\n\n")
+		b.WriteString(errStyle().Render(m.errMsg))
+	}
+
+	b.WriteString("\n\n")
+	b.WriteString(helpStyle().Render("tab/shift+tab switch fields · enter clone · esc back"))
+	return b.String()
+}
+
+func (m Model) targetPreview(rootPath string) string {
+	dirName := strings.TrimSpace(m.dirNameInput.Value())
+	if dirName == "" {
+		dirName = derivedName(m.urlInput.Value())
+	}
+	if dirName == "" {
+		dirName = "<repo-name>"
+	}
+	return filepath.Join(rootPath, dirName)
+}
+
+func derivedName(url string) string {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return ""
+	}
+	_, repo, err := git.ParseRepoFullName(url)
+	if err != nil {
+		return ""
+	}
+	return repo
+}

--- a/internal/tui/workspacelist/keys.go
+++ b/internal/tui/workspacelist/keys.go
@@ -7,6 +7,7 @@ import (
 
 type keyMap struct {
 	Select       key.Binding
+	CloneFromURL key.Binding
 	Delete       key.Binding
 	Hide         key.Binding
 	ToggleHidden key.Binding
@@ -14,15 +15,16 @@ type keyMap struct {
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Select, k.Hide, k.ToggleHidden, k.Delete, k.Back}
+	return []key.Binding{k.Select, k.CloneFromURL, k.Hide, k.ToggleHidden, k.Delete, k.Back}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.Select, k.Hide, k.ToggleHidden, k.Delete, k.Back}}
+	return [][]key.Binding{{k.Select, k.CloneFromURL, k.Hide, k.ToggleHidden, k.Delete, k.Back}}
 }
 
 var keys = keyMap{
 	Select:       key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+	CloneFromURL: key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "clone from URL")),
 	Delete:       key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
 	Hide:         key.NewBinding(key.WithKeys("h"), key.WithHelp("h", "hide")),
 	ToggleHidden: key.NewBinding(key.WithKeys("."), key.WithHelp(".", "show hidden")),

--- a/internal/tui/workspacelist/workspacelist.go
+++ b/internal/tui/workspacelist/workspacelist.go
@@ -122,6 +122,8 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 		}
 		m.pendingDeleteID = item.workspace.ID
 		return m, m.list.NewStatusMessage(fmt.Sprintf("press d again to delete %s", item.workspace.Name)), true
+	case key.Matches(msg, keys.CloneFromURL):
+		return m, router.NavigateTo(router.WorkspaceCloneFormView), true
 	case key.Matches(msg, keys.Back):
 		return m, router.Back(), true
 	}

--- a/internal/workspace/types.go
+++ b/internal/workspace/types.go
@@ -55,6 +55,23 @@ func (a *AddWorkspaceRequest) Bind(r *http.Request) error {
 	return nil
 }
 
+type CloneWorkspaceRequest struct {
+	CloneURL string `json:"clone_url"`
+	RootPath string `json:"root_path,omitempty"`
+	DirName  string `json:"dir_name,omitempty"`
+}
+
+func (a *CloneWorkspaceRequest) Bind(r *http.Request) error {
+	if a.CloneURL == "" {
+		return fmt.Errorf("clone_url is required")
+	}
+	return nil
+}
+
+type WorkspaceRootsResponse struct {
+	Roots []string `json:"roots"`
+}
+
 type SetHiddenRequest struct {
 	Hidden bool `json:"hidden"`
 }

--- a/internal/workspace/workspacecontroller.go
+++ b/internal/workspace/workspacecontroller.go
@@ -14,12 +14,14 @@ import (
 
 type WorkspaceController struct {
 	service    *WorkspaceService
+	store      *WorkspaceStore
 	gitService *git.GitService
 }
 
-func NewWorkspaceController(service *WorkspaceService, gitService *git.GitService) *WorkspaceController {
+func NewWorkspaceController(service *WorkspaceService, store *WorkspaceStore, gitService *git.GitService) *WorkspaceController {
 	return &WorkspaceController{
 		service:    service,
+		store:      store,
 		gitService: gitService,
 	}
 }
@@ -56,6 +58,15 @@ func (c *WorkspaceController) GetWorkspaceByID(w http.ResponseWriter, r *http.Re
 	common.RenderResponse(w, r, response)
 }
 
+func renderServiceError(w http.ResponseWriter, r *http.Request, fallback string, err error) {
+	var appErr *common.AppError
+	if errors.As(err, &appErr) {
+		common.RenderError(w, r, err)
+		return
+	}
+	common.RenderError(w, r, common.WrapInvalidRequest(fallback, err))
+}
+
 func (c *WorkspaceController) AddWorkspace(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -67,12 +78,7 @@ func (c *WorkspaceController) AddWorkspace(w http.ResponseWriter, r *http.Reques
 
 	ws, err := c.service.AddWorkspace(ctx, req.Path, req.AsRoot)
 	if err != nil {
-		var appErr *common.AppError
-		if errors.As(err, &appErr) {
-			common.RenderError(w, r, err)
-		} else {
-			common.RenderError(w, r, common.WrapInvalidRequest("add workspace failed", err))
-		}
+		renderServiceError(w, r, "add workspace failed", err)
 		return
 	}
 
@@ -87,6 +93,41 @@ func (c *WorkspaceController) AddWorkspace(w http.ResponseWriter, r *http.Reques
 		}
 		common.RenderResponse(w, r, NewWorkspaceListResponse(workspaces))
 	}
+}
+
+func (c *WorkspaceController) CloneWorkspace(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req CloneWorkspaceRequest
+	if err := render.Bind(r, &req); err != nil {
+		common.RenderError(w, r, common.NewInvalidRequest(err.Error()))
+		return
+	}
+
+	ws, err := c.service.CloneAndAddFromURL(ctx, CloneFromURLRequest{
+		CloneURL: req.CloneURL,
+		RootPath: req.RootPath,
+		DirName:  req.DirName,
+	})
+	if err != nil {
+		renderServiceError(w, r, "clone workspace failed", err)
+		return
+	}
+
+	render.Status(r, http.StatusCreated)
+	common.RenderResponse(w, r, NewWorkspaceResponse(ws))
+}
+
+func (c *WorkspaceController) ListRoots(w http.ResponseWriter, r *http.Request) {
+	if c.store == nil {
+		common.RenderError(w, r, fmt.Errorf("workspace store not configured"))
+		return
+	}
+	roots := c.store.ConfiguredRoots()
+	if roots == nil {
+		roots = []string{}
+	}
+	render.JSON(w, r, WorkspaceRootsResponse{Roots: roots})
 }
 
 func (c *WorkspaceController) SetWorkspaceHidden(w http.ResponseWriter, r *http.Request) {

--- a/internal/workspace/workspacemodule.go
+++ b/internal/workspace/workspacemodule.go
@@ -23,7 +23,7 @@ type WorkspaceModule struct {
 func NewWorkspaceModule(database db.Database, fs afero.Fs, configDir string, gitService *git.GitService) *WorkspaceModule {
 	store := NewWorkspaceStore(database, fs, configDir)
 	service := NewWorkspaceService(store, gitService)
-	controller := NewWorkspaceController(service, gitService)
+	controller := NewWorkspaceController(service, store, gitService)
 	router := NewWorkspaceRouter(controller)
 
 	return &WorkspaceModule{

--- a/internal/workspace/workspacerouter.go
+++ b/internal/workspace/workspacerouter.go
@@ -19,6 +19,8 @@ func (wr *WorkspaceRouter) Routes() chi.Router {
 
 	r.Get("/", wr.controller.ListWorkspaces)
 	r.Post("/", wr.controller.AddWorkspace)
+	r.Post("/clone", wr.controller.CloneWorkspace)
+	r.Get("/roots", wr.controller.ListRoots)
 	r.Get("/{id}/branches", wr.controller.ListBranches)
 	r.Post("/{id}/branches/fetch", wr.controller.FetchAndListBranches)
 	r.Get("/{id}/branches/exists", wr.controller.CheckBranchExists)

--- a/internal/workspace/workspacerouter_test.go
+++ b/internal/workspace/workspacerouter_test.go
@@ -31,7 +31,7 @@ func setupWorkspaceRouter(t *testing.T) (*WorkspaceRouter, *WorkspaceStore) {
 
 	gitService := git.NewGitService(database)
 	service := NewWorkspaceService(store, gitService)
-	controller := NewWorkspaceController(service, gitService)
+	controller := NewWorkspaceController(service, store, gitService)
 	router := NewWorkspaceRouter(controller)
 
 	return router, store
@@ -109,7 +109,7 @@ func TestWorkspaceRouter_AddWorkspace(t *testing.T) {
 
 	gitService := git.NewGitService(database)
 	service := NewWorkspaceService(store, gitService)
-	controller := NewWorkspaceController(service, gitService)
+	controller := NewWorkspaceController(service, store, gitService)
 	router := NewWorkspaceRouter(controller)
 
 	body := fmt.Sprintf(`{"path": %q, "as_root": false}`, wsDir)
@@ -164,7 +164,7 @@ func TestWorkspaceRouter_ListBranches(t *testing.T) {
 
 	gitService := git.NewGitService(database)
 	service := NewWorkspaceService(store, gitService)
-	controller := NewWorkspaceController(service, gitService)
+	controller := NewWorkspaceController(service, store, gitService)
 	router := NewWorkspaceRouter(controller)
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/%d/branches", wsGit.ID), nil)
@@ -324,7 +324,7 @@ func setupBranchRouter(t *testing.T, repoPath string) (*WorkspaceRouter, *Worksp
 
 	gitService := git.NewGitService(database)
 	service := NewWorkspaceService(store, gitService)
-	controller := NewWorkspaceController(service, gitService)
+	controller := NewWorkspaceController(service, store, gitService)
 	router := NewWorkspaceRouter(controller)
 
 	return router, ws
@@ -434,4 +434,130 @@ func TestWorkspaceRouter_CheckBranchExists_MissingName(t *testing.T) {
 	router.Routes().ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func setupCloneRouter(t *testing.T, roots []string) (*WorkspaceRouter, *WorkspaceStore) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+
+	cfgBytes, err := json.Marshal(config{WorkspaceRoots: roots})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.json"), cfgBytes, 0644))
+
+	database := testdb.New(t, &Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{})
+	store := NewWorkspaceStore(database, afero.NewOsFs(), configDir)
+	gitService := git.NewGitService(database)
+	service := NewWorkspaceService(store, gitService)
+	controller := NewWorkspaceController(service, store, gitService)
+	router := NewWorkspaceRouter(controller)
+	return router, store
+}
+
+func TestWorkspaceRouter_ListRoots(t *testing.T) {
+	root := t.TempDir()
+	router, _ := setupCloneRouter(t, []string{root})
+
+	req := httptest.NewRequest("GET", "/roots", nil)
+	w := httptest.NewRecorder()
+	router.Routes().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp WorkspaceRootsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, []string{root}, resp.Roots)
+}
+
+func TestWorkspaceRouter_ListRoots_Empty(t *testing.T) {
+	router, _ := setupCloneRouter(t, nil)
+
+	req := httptest.NewRequest("GET", "/roots", nil)
+	w := httptest.NewRecorder()
+	router.Routes().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp WorkspaceRootsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Empty(t, resp.Roots)
+}
+
+func TestWorkspaceRouter_CloneWorkspace_HappyPath(t *testing.T) {
+	root := t.TempDir()
+	router, store := setupCloneRouter(t, []string{root})
+
+	source := initTestRepo(t)
+
+	body := fmt.Sprintf(`{"clone_url": %q, "dir_name": "imported"}`, source)
+	req := httptest.NewRequest("POST", "/clone", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+
+	var resp WorkspaceResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, filepath.Join(root, "imported"), resp.Path)
+	require.True(t, resp.IsBare)
+
+	persisted, err := store.GetByPath(filepath.Join(root, "imported"))
+	require.NoError(t, err)
+	require.True(t, persisted.IsGitRepo)
+}
+
+func TestWorkspaceRouter_CloneWorkspace_MissingURL(t *testing.T) {
+	router, _ := setupCloneRouter(t, []string{t.TempDir()})
+
+	body := `{"dir_name": "x"}`
+	req := httptest.NewRequest("POST", "/clone", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestWorkspaceRouter_CloneWorkspace_NoRoots(t *testing.T) {
+	router, _ := setupCloneRouter(t, nil)
+	source := initTestRepo(t)
+
+	body := fmt.Sprintf(`{"clone_url": %q, "dir_name": "x"}`, source)
+	req := httptest.NewRequest("POST", "/clone", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+}
+
+func TestWorkspaceRouter_CloneWorkspace_MultipleRootsRequiresExplicit(t *testing.T) {
+	r1 := t.TempDir()
+	r2 := t.TempDir()
+	router, _ := setupCloneRouter(t, []string{r1, r2})
+	source := initTestRepo(t)
+
+	body := fmt.Sprintf(`{"clone_url": %q, "dir_name": "x"}`, source)
+	req := httptest.NewRequest("POST", "/clone", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+}
+
+func TestWorkspaceRouter_CloneWorkspace_TargetExists(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "imported"), 0755))
+	router, _ := setupCloneRouter(t, []string{root})
+	source := initTestRepo(t)
+
+	body := fmt.Sprintf(`{"clone_url": %q, "dir_name": "imported"}`, source)
+	req := httptest.NewRequest("POST", "/clone", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code)
 }

--- a/internal/workspace/workspaceservice.go
+++ b/internal/workspace/workspaceservice.go
@@ -4,11 +4,20 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/eleonorayaya/utena/internal/common"
 	"github.com/eleonorayaya/utena/internal/git"
 )
+
+type CloneFromURLRequest struct {
+	CloneURL string
+	RootPath string
+	DirName  string
+}
 
 type WorkspaceService struct {
 	store      *WorkspaceStore
@@ -126,6 +135,72 @@ func (s *WorkspaceService) AddWorkspace(ctx context.Context, path string, asRoot
 		}
 	}
 	return ws, nil
+}
+
+func (s *WorkspaceService) CloneAndAddFromURL(ctx context.Context, req CloneFromURLRequest) (*Workspace, error) {
+	cloneURL := strings.TrimSpace(req.CloneURL)
+	if cloneURL == "" {
+		return nil, common.NewInvalidRequest("clone_url is required")
+	}
+	if s.gitService == nil {
+		return nil, fmt.Errorf("git service not configured")
+	}
+
+	roots := s.store.ConfiguredRoots()
+	rootPath, err := resolveRootPath(req.RootPath, roots)
+	if err != nil {
+		return nil, err
+	}
+
+	dirName := strings.TrimSpace(req.DirName)
+	if dirName == "" {
+		_, repoName, parseErr := s.gitService.ParseRepoFullName(cloneURL)
+		if parseErr != nil {
+			return nil, common.WrapInvalidRequest("cannot derive directory name from clone URL", parseErr)
+		}
+		dirName = repoName
+	}
+	if strings.ContainsAny(dirName, "/\\") {
+		return nil, common.NewInvalidRequest(fmt.Sprintf("invalid directory name %q (must not contain path separators)", dirName))
+	}
+
+	targetPath := filepath.Join(rootPath, dirName)
+	if _, statErr := os.Stat(targetPath); statErr == nil {
+		return nil, common.NewConflict(fmt.Sprintf("target path already exists: %s", targetPath))
+	} else if !os.IsNotExist(statErr) {
+		return nil, fmt.Errorf("failed to inspect target path %s: %w", targetPath, statErr)
+	}
+
+	if err := s.gitService.CloneBareWorkspace(ctx, cloneURL, targetPath); err != nil {
+		return nil, common.WrapInvalidRequest("git clone failed", err)
+	}
+
+	ws, addErr := s.AddWorkspace(ctx, targetPath, false)
+	if addErr != nil {
+		_ = os.RemoveAll(targetPath)
+		return nil, addErr
+	}
+	return ws, nil
+}
+
+func resolveRootPath(requested string, configured []string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested != "" {
+		expanded := expandHome(requested)
+		for _, root := range configured {
+			if root == expanded {
+				return root, nil
+			}
+		}
+		return "", common.NewInvalidRequest(fmt.Sprintf("root_path %q is not a configured workspace root", requested))
+	}
+	if len(configured) == 0 {
+		return "", common.NewConflict("no workspace roots configured — add one before cloning from URL")
+	}
+	if len(configured) > 1 {
+		return "", common.NewConflict("multiple workspace roots configured — specify root_path")
+	}
+	return configured[0], nil
 }
 
 func (s *WorkspaceService) resolveRepoIDs(ctx context.Context, workspaces []Workspace) {

--- a/internal/workspace/workspaceservice_test.go
+++ b/internal/workspace/workspaceservice_test.go
@@ -2,12 +2,14 @@ package workspace
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/eleonorayaya/utena/internal/db/testdb"
+	"github.com/eleonorayaya/utena/internal/git"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
@@ -241,4 +243,150 @@ func TestWorkspaceService_Touch_NotFound(t *testing.T) {
 	err := service.Touch(ctx, 99999)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not found")
+}
+
+func setupServiceWithGitAndRoot(t *testing.T) (*WorkspaceService, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	rootDir := filepath.Join(tmpDir, "projects")
+	require.NoError(t, os.MkdirAll(rootDir, 0755))
+
+	configDir := filepath.Join(tmpDir, "config")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+	cfgBytes, err := json.Marshal(config{WorkspaceRoots: []string{rootDir}})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.json"), cfgBytes, 0644))
+
+	database := testdb.New(t, &Workspace{}, &git.Repo{})
+	store := NewWorkspaceStore(database, afero.NewOsFs(), configDir)
+	gitService := git.NewGitService(database)
+	service := NewWorkspaceService(store, gitService)
+	return service, rootDir
+}
+
+func setupServiceWithGitAndRoots(t *testing.T, rootCount int) (*WorkspaceService, []string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	roots := make([]string, 0, rootCount)
+	for i := range rootCount {
+		r := filepath.Join(tmpDir, "root", string(rune('a'+i)))
+		require.NoError(t, os.MkdirAll(r, 0755))
+		roots = append(roots, r)
+	}
+
+	configDir := filepath.Join(tmpDir, "config")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+	cfgBytes, err := json.Marshal(config{WorkspaceRoots: roots})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.json"), cfgBytes, 0644))
+
+	database := testdb.New(t, &Workspace{}, &git.Repo{})
+	store := NewWorkspaceStore(database, afero.NewOsFs(), configDir)
+	gitService := git.NewGitService(database)
+	service := NewWorkspaceService(store, gitService)
+	return service, roots
+}
+
+func TestWorkspaceService_CloneAndAddFromURL_HappyPath(t *testing.T) {
+	service, rootDir := setupServiceWithGitAndRoot(t)
+	source := initTestRepo(t)
+
+	ws, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{
+		CloneURL: source,
+		DirName:  "imported",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ws)
+	require.Equal(t, filepath.Join(rootDir, "imported"), ws.Path)
+	require.True(t, ws.IsBare)
+	require.True(t, ws.IsGitRepo)
+
+	bareInfo, err := os.Stat(filepath.Join(ws.Path, ".bare"))
+	require.NoError(t, err)
+	require.True(t, bareInfo.IsDir())
+}
+
+func TestWorkspaceService_CloneAndAddFromURL_DerivesDirNameFromURL(t *testing.T) {
+	service, rootDir := setupServiceWithGitAndRoot(t)
+
+	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{
+		CloneURL: "git@github.com:foo/bar.git",
+	})
+	require.Error(t, err, "expected clone to fail with unreachable remote so we can verify path derivation")
+
+	_, statErr := os.Stat(filepath.Join(rootDir, "bar"))
+	require.True(t, os.IsNotExist(statErr), "failed clone should clean up the derived target dir")
+}
+
+func TestWorkspaceService_CloneAndAddFromURL_RejectsEmptyURL(t *testing.T) {
+	service, _ := setupServiceWithGitAndRoot(t)
+	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "clone_url is required")
+}
+
+func TestWorkspaceService_CloneAndAddFromURL_RejectsTargetExists(t *testing.T) {
+	service, rootDir := setupServiceWithGitAndRoot(t)
+	existing := filepath.Join(rootDir, "imported")
+	require.NoError(t, os.MkdirAll(existing, 0755))
+
+	source := initTestRepo(t)
+	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{
+		CloneURL: source,
+		DirName:  "imported",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already exists")
+}
+
+func TestWorkspaceService_CloneAndAddFromURL_NoConfiguredRoots(t *testing.T) {
+	service, _ := setupServiceWithGitAndRoots(t, 0)
+	source := initTestRepo(t)
+
+	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{CloneURL: source, DirName: "x"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no workspace roots configured")
+}
+
+func TestWorkspaceService_CloneAndAddFromURL_MultipleRootsRequiresExplicit(t *testing.T) {
+	service, roots := setupServiceWithGitAndRoots(t, 2)
+	source := initTestRepo(t)
+
+	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{CloneURL: source, DirName: "x"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "multiple workspace roots")
+
+	ws, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{
+		CloneURL: source,
+		RootPath: roots[1],
+		DirName:  "x",
+	})
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(roots[1], "x"), ws.Path)
+}
+
+func TestWorkspaceService_CloneAndAddFromURL_RejectsUnknownRoot(t *testing.T) {
+	service, _ := setupServiceWithGitAndRoot(t)
+	source := initTestRepo(t)
+
+	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{
+		CloneURL: source,
+		RootPath: "/nope",
+		DirName:  "x",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a configured workspace root")
+}
+
+func TestWorkspaceService_CloneAndAddFromURL_RejectsPathSeparatorInDirName(t *testing.T) {
+	service, _ := setupServiceWithGitAndRoot(t)
+	source := initTestRepo(t)
+
+	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{
+		CloneURL: source,
+		DirName:  "weird/name",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid directory name")
 }

--- a/internal/workspace/workspacestore.go
+++ b/internal/workspace/workspacestore.go
@@ -426,3 +426,15 @@ func (s *WorkspaceStore) isGitRepository(path string) bool {
 	isGit, _ := s.detectRepoKind(path)
 	return isGit
 }
+
+func (s *WorkspaceStore) ConfiguredRoots() []string {
+	cfg, err := s.loadConfig()
+	if err != nil || cfg == nil {
+		return nil
+	}
+	roots := make([]string, 0, len(cfg.WorkspaceRoots))
+	for _, r := range cfg.WorkspaceRoots {
+		roots = append(roots, expandHome(r))
+	}
+	return roots
+}


### PR DESCRIPTION
## Summary

- New TUI flow: `c` on the workspace list opens a form to paste a git clone URL; utena clones into a configured `workspace_root` using the existing `.bare`/`.git`-pointer convention and registers the result. If multiple roots are configured, the form lets you cycle through them with `ctrl+n`/`ctrl+p`.
- Daemon endpoints: `POST /workspaces/clone` (orchestrates `git clone --bare` + workspace registration with cleanup on failure) and `GET /workspaces/roots` (so the TUI can build the picker).
- The bare-setup steps (`runBareClone`, `writeBareMarker`, `configureBareFetchRefspec`) are extracted from the existing `migrateToBare` so the new fresh-clone path and the existing migration path both produce identical on-disk layouts.

## Test plan

- [x] `task test` — 193 tests passing in the touched packages (5 new git-CLI tests, 7 new service tests, 6 new router tests).
- [x] Manual end-to-end against a real daemon with a `file://` source repo:
  - `POST /workspaces/clone` returns 201 + workspace JSON with `is_bare: true`.
  - On disk: `<root>/<name>/.git` is a file containing `gitdir: ./.bare`, `<root>/<name>/.bare/` is a real bare repo, `git -C <root>/<name> config remote.origin.fetch` is `+refs/heads/*:refs/remotes/origin/*`.
  - `git -C <root>/<name> worktree add ../<name>-wt main` succeeds (proves the bare convention is wired).
  - Re-submitting the same URL returns 409 (target exists).
  - Missing `clone_url` returns 400.
  - Bogus URL returns 400 with git's stderr surfaced and the target dir cleaned up.
- [ ] Manual TUI smoke: from session list press `w`, then `c`, enter a clone URL, confirm the new workspace appears in the list after success.

## Out of scope

- Auth/credential prompting (defers to `~/.ssh/config` and git credential helpers).
- Cancellation mid-clone; failed clones are cleaned up but in-flight ones block the form view.
- Submodule init, LFS, partial clones.
- Non-bare clone option (locked to `.bare` convention).
