### PR TITLE
feat(session): add workspace to existing session

### DIFF
--- a/internal/git/gitcli.go
+++ b/internal/git/gitcli.go
@@ -174,6 +174,14 @@ func (s *gitCLI) checkoutWorktree(ctx context.Context, repoPath string, branch s
 	return worktreePath, nil
 }
 
+func (s *gitCLI) pushSetUpstream(ctx context.Context, repoPath string, branchName string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "push", "--set-upstream", "origin", branchName)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git push --set-upstream failed: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
 func (s *gitCLI) currentBranch(ctx context.Context, repoPath string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "branch", "--show-current")
 	output, err := cmd.Output()

--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -76,6 +76,10 @@ func (s *GitService) Fetch(ctx context.Context, repoPath string, branch string) 
 	return s.cli.fetch(ctx, repoPath, branch)
 }
 
+func (s *GitService) PushSetUpstream(ctx context.Context, repoPath string, branchName string) error {
+	return s.cli.pushSetUpstream(ctx, repoPath, branchName)
+}
+
 func (s *GitService) SetupWorktreeAt(ctx context.Context, repoPath string, branchName string, baseBranch string, branchID uint, repoID uint, destPath string) (bool, string, error) {
 	creatingNew := baseBranch != ""
 

--- a/internal/session/sessioncontroller.go
+++ b/internal/session/sessioncontroller.go
@@ -192,6 +192,30 @@ func (c *SessionController) ArchiveSession(w http.ResponseWriter, r *http.Reques
 	common.RenderResponse(w, r, NewSessionResponse(session))
 }
 
+func (c *SessionController) AddWorkspace(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id, err := parseUintParam(r, "id")
+	if err != nil {
+		common.RenderError(w, r, common.NewInvalidRequest(err.Error()))
+		return
+	}
+
+	data := &AddWorkspaceRequest{}
+	if err := render.Bind(r, data); err != nil {
+		common.RenderError(w, r, common.NewInvalidRequest(err.Error()))
+		return
+	}
+
+	session, err := c.service.AddWorkspace(ctx, id, data.WorkspaceBranchSpec)
+	if err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+
+	render.Status(r, http.StatusAccepted)
+	common.RenderResponse(w, r, NewSessionResponse(session))
+}
+
 func (c *SessionController) DismissSession(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id, err := parseUintParam(r, "id")

--- a/internal/session/sessionrouter.go
+++ b/internal/session/sessionrouter.go
@@ -20,6 +20,7 @@ func (sr *SessionRouter) Routes() chi.Router {
 	r.Get("/", sr.controller.ListSessions)
 	r.Post("/", sr.controller.CreateSession)
 	r.Get("/workspace/{workspaceId}", sr.controller.ListSessionsByWorkspace)
+	r.Post("/{id}/workspaces", sr.controller.AddWorkspace)
 	r.Put("/{id}/activate", sr.controller.ActivateSession)
 	r.Put("/{id}/repair", sr.controller.RepairSession)
 	r.Put("/{id}/archive", sr.controller.ArchiveSession)

--- a/internal/session/sessionrouter_test.go
+++ b/internal/session/sessionrouter_test.go
@@ -288,6 +288,70 @@ func TestSessionRouter_GetSessionByID_ShowsCreatingStatus(t *testing.T) {
 	require.Equal(t, StatusCreating, response.Status)
 }
 
+func TestSessionRouter_AddWorkspace_RejectsNoWorkspaceID(t *testing.T) {
+	router, sessionStore, _, _, ws1ID, _ := setupSessionRouter(t)
+	swStore := NewSessionWorktreeStore(sessionStore.db)
+
+	session := &Session{Name: "session-1", Status: StatusActive, LastUsedAt: time.Now()}
+	addTestSession(t, sessionStore, swStore, session, ws1ID)
+
+	body := []byte(`{"branch":"main"}`)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/%d/workspaces", session.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSessionRouter_AddWorkspace_RejectsBothBranchFields(t *testing.T) {
+	router, sessionStore, _, _, ws1ID, ws2ID := setupSessionRouter(t)
+	swStore := NewSessionWorktreeStore(sessionStore.db)
+
+	session := &Session{Name: "session-1", Status: StatusActive, LastUsedAt: time.Now()}
+	addTestSession(t, sessionStore, swStore, session, ws1ID)
+
+	body := []byte(fmt.Sprintf(`{"workspace_id":%d,"branch":"main","base_branch":"main"}`, ws2ID))
+	req := httptest.NewRequest("POST", fmt.Sprintf("/%d/workspaces", session.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSessionRouter_AddWorkspace_SessionNotFound(t *testing.T) {
+	router, _, _, _, _, ws2ID := setupSessionRouter(t)
+
+	body := []byte(fmt.Sprintf(`{"workspace_id":%d,"branch":"main"}`, ws2ID))
+	req := httptest.NewRequest("POST", "/99999/workspaces", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestSessionRouter_AddWorkspace_DeletedSession(t *testing.T) {
+	router, sessionStore, _, _, ws1ID, ws2ID := setupSessionRouter(t)
+	swStore := NewSessionWorktreeStore(sessionStore.db)
+
+	session := &Session{Name: "deleted-session", Status: StatusDeleted, LastUsedAt: time.Now()}
+	addTestSession(t, sessionStore, swStore, session, ws1ID)
+
+	body := []byte(fmt.Sprintf(`{"workspace_id":%d,"branch":"main"}`, ws2ID))
+	req := httptest.NewRequest("POST", fmt.Sprintf("/%d/workspaces", session.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.Routes().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 func TestSessionRouter_GetSessionByID_ShowsBrokenStatusError(t *testing.T) {
 	router, sessionStore, _, _, _, _ := setupSessionRouter(t)
 

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -234,6 +234,26 @@ type assignedSlot struct {
 	branchName string
 }
 
+type worktreeSetupResult struct {
+	swt          *SessionWorktree
+	wt           *git.Worktree
+	ws           *workspace.Workspace
+	branch       *git.Branch
+	worktreePath string
+	created      bool
+	warning      string
+}
+
+func freeSubdir(base string, used map[string]struct{}) string {
+	sub := base
+	for suffix := 2; ; suffix++ {
+		if _, taken := used[sub]; !taken {
+			return sub
+		}
+		sub = fmt.Sprintf("%s-%d", base, suffix)
+	}
+}
+
 func (s *SessionService) CreateSession(ctx context.Context, input CreateSessionInput) (*Session, error) {
 	if len(input.Workspaces) == 0 {
 		return nil, common.NewInvalidRequest("workspaces is required")
@@ -309,15 +329,7 @@ func (s *SessionService) CreateSession(ctx context.Context, input CreateSessionI
 		if base == "" {
 			base = fmt.Sprintf("workspace-%d", sl.ws.ID)
 		}
-		sub := base
-		suffix := 2
-		for {
-			if _, taken := used[sub]; !taken {
-				break
-			}
-			sub = fmt.Sprintf("%s-%d", base, suffix)
-			suffix++
-		}
+		sub := freeSubdir(base, used)
 		used[sub] = struct{}{}
 		branchName := sl.spec.Branch
 		if branchName == "" {
@@ -432,6 +444,195 @@ func (s *SessionService) eagerCreateWorktree(ctx context.Context, sessionID uint
 	return nil
 }
 
+func (s *SessionService) AddWorkspace(ctx context.Context, sessionID uint, spec WorkspaceBranchSpec) (*Session, error) {
+	sess, err := s.store.GetByID(sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if sess.Status == StatusDeleted || sess.Status == StatusArchived {
+		return nil, common.NewInvalidRequest("cannot add workspace to deleted or archived session")
+	}
+
+	ws, err := s.workspaceService.GetWorkspace(ctx, spec.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	if !ws.IsGitRepo {
+		return nil, common.NewInvalidRequest(fmt.Sprintf("workspace %q is not a git repository", ws.Name))
+	}
+
+	repoID, err := s.resolveRepoID(ctx, ws)
+	if err != nil {
+		return nil, err
+	}
+	used := make(map[string]struct{}, len(sess.Worktrees))
+	for i := range sess.Worktrees {
+		wt := sess.Worktrees[i].Worktree
+		if wt == nil {
+			continue
+		}
+		if wt.RepoID == repoID {
+			return nil, common.NewConflict(fmt.Sprintf("workspace %q is already in this session", ws.Name))
+		}
+		if wt.Path != "" {
+			used[filepath.Base(wt.Path)] = struct{}{}
+		}
+	}
+	base := SanitizeSessionName(ws.Name)
+	if base == "" {
+		base = fmt.Sprintf("workspace-%d", ws.ID)
+	}
+	destPath := filepath.Join(sess.SessionRoot, freeSubdir(base, used))
+
+	branchName := spec.Branch
+	if branchName == "" {
+		branchName = s.branchPrefix + sess.Name
+	}
+
+	position := len(sess.Worktrees)
+	if err := s.eagerCreateWorktree(ctx, sess.ID, ws, branchName, destPath, position); err != nil {
+		return nil, fmt.Errorf("eager create worktree: %w", err)
+	}
+
+	if err := s.workspaceService.Touch(ctx, ws.ID); err != nil {
+		slog.WarnContext(ctx, "failed to touch workspace last-used timestamp", "workspace", ws.ID, "error", err)
+	}
+
+	go s.runAddWorkspace(sess.ID, spec)
+
+	return s.store.GetByID(sess.ID)
+}
+
+func (s *SessionService) runAddWorkspace(sessionID uint, spec WorkspaceBranchSpec) {
+	ctx, cancel := context.WithTimeout(context.Background(), s.setupTimeout)
+	defer cancel()
+
+	sess, err := s.store.GetByID(sessionID)
+	if err != nil {
+		slog.Error("runAddWorkspace: failed to load session", "id", sessionID, "error", err)
+		return
+	}
+
+	ctx = slogctx.Append(ctx,
+		"session", sess.ID,
+		"session_root", sess.SessionRoot,
+		"workspace_count", len(sess.Worktrees),
+	)
+
+	markBroken := func(stage string, err error) {
+		msg := fmt.Sprintf("%s failed: %v", stage, err)
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			msg = fmt.Sprintf("%s timed out after %s", stage, s.setupTimeout)
+		}
+		if updateErr := s.markSessionBroken(sess, msg); updateErr != nil {
+			slog.ErrorContext(ctx, "failed to persist broken status", "stage", stage, "error", updateErr)
+		}
+	}
+
+	if len(sess.Worktrees) == 0 {
+		markBroken("find new worktree", fmt.Errorf("session %d has no worktrees", sess.ID))
+		return
+	}
+	newSwt := &sess.Worktrees[len(sess.Worktrees)-1]
+
+	ws := newSwt.Workspace
+	if ws == nil {
+		markBroken("workspace lookup", fmt.Errorf("worktree %d has no workspace", newSwt.WorktreeID))
+		return
+	}
+
+	var setupWarnings []string
+	result, err := s.setupSingleWorktree(ctx, sess, newSwt, ws, spec)
+	if err != nil {
+		markBroken("worktree setup", err)
+		return
+	}
+	if result.warning != "" {
+		setupWarnings = append(setupWarnings, fmt.Sprintf("%s: %s", ws.Name, result.warning))
+	}
+
+	if result.created {
+		branchName := ""
+		if result.branch != nil {
+			branchName = result.branch.Name
+		}
+		env := []string{
+			envSessionRoot + "=" + sess.SessionRoot,
+			envSessionName + "=" + sess.Name,
+			envBranch + "=" + branchName,
+			envWorktreePath + "=" + result.worktreePath,
+			envWorkspaceName + "=" + ws.Name,
+			envWorkspacePath + "=" + ws.Path,
+		}
+		wsScript := filepath.Join(ws.Path, ".utena", worktreeSetupName)
+		if err := traceOp(ctx, "worktree-setup script", func() error {
+			return s.runScript(ctx, wsScript, result.worktreePath, env)
+		}, "script", wsScript, "ws", ws.Name); err != nil {
+			slog.WarnContext(ctx, "workspace worktree-setup script failed", "ws", ws.Name, "error", err)
+			setupWarnings = append(setupWarnings, fmt.Sprintf("%s: %s", ws.Name, err.Error()))
+		}
+
+		globalEnv := []string{
+			envSessionRoot + "=" + sess.SessionRoot,
+			envSessionName + "=" + sess.Name,
+			envBranch + "=" + branchName,
+		}
+		globalScript := filepath.Join(s.configDir, worktreeSetupName)
+		if err := traceOp(ctx, "global worktree-setup script", func() error {
+			return s.runScript(ctx, globalScript, sess.SessionRoot, globalEnv)
+		}, "script", globalScript); err != nil {
+			slog.WarnContext(ctx, "global worktree-setup script failed", "error", err)
+			setupWarnings = append(setupWarnings, fmt.Sprintf("global: %s", err.Error()))
+		}
+	}
+
+	setupWarnings = append(setupWarnings, s.applyClaudeSettings(ctx, sess)...)
+
+	sess.Status = StatusActive
+	if len(setupWarnings) == 0 {
+		sess.StatusError = ""
+	} else {
+		sess.StatusError = strings.Join(setupWarnings, "; ")
+	}
+	if err := s.store.Update(sess); err != nil {
+		markBroken("persist active status", err)
+		return
+	}
+}
+
+func (s *SessionService) applyClaudeSettings(ctx context.Context, sess *Session) []string {
+	var warnings []string
+	workspacePaths := make([]string, 0, len(sess.Worktrees))
+	checkouts := make([]claudesettings.SessionCheckout, 0, len(sess.Worktrees))
+	for i := range sess.Worktrees {
+		swt := &sess.Worktrees[i]
+		wt := swt.Worktree
+		if wt == nil || wt.Path == "" {
+			continue
+		}
+		ws := swt.Workspace
+		if ws == nil {
+			slog.WarnContext(ctx, "claude settings: workspace not populated", "worktree", wt.ID)
+			continue
+		}
+		workspacePaths = append(workspacePaths, ws.Path)
+		checkouts = append(checkouts, claudesettings.SessionCheckout{
+			Subdir:        filepath.Base(wt.Path),
+			WorkspaceName: ws.Name,
+		})
+	}
+	if err := claudesettings.EnsureSessionRoot(sess.SessionRoot, workspacePaths); err != nil {
+		slog.WarnContext(ctx, "ensure session-root claude settings failed", "error", err)
+		warnings = append(warnings, fmt.Sprintf("claude-settings: %s", err.Error()))
+	}
+	if err := claudesettings.EnsureMultiSessionGuide(sess.SessionRoot, checkouts); err != nil {
+		slog.WarnContext(ctx, "ensure session CLAUDE.md failed", "error", err)
+		warnings = append(warnings, fmt.Sprintf("claude-guide: %s", err.Error()))
+	}
+	return warnings
+}
+
 func (s *SessionService) resolveWorktreeWorkspace(ctx context.Context, wt *git.Worktree, cache map[uint]*workspace.Workspace) (*workspace.Workspace, error) {
 	if wt == nil {
 		return nil, fmt.Errorf("worktree is nil")
@@ -448,6 +649,65 @@ func (s *SessionService) resolveWorktreeWorkspace(ctx context.Context, wt *git.W
 	}
 	cache[wt.RepoID] = ws
 	return ws, nil
+}
+
+func (s *SessionService) setupSingleWorktree(ctx context.Context, sess *Session, swt *SessionWorktree, ws *workspace.Workspace, spec WorkspaceBranchSpec) (worktreeSetupResult, error) {
+	wt := swt.Worktree
+	if wt == nil {
+		return worktreeSetupResult{}, fmt.Errorf("session worktree %d has nil worktree ref", swt.ID)
+	}
+
+	baseBranchName := spec.BaseBranch
+	branchName := spec.Branch
+	finalBranchName := branchName
+	if baseBranchName != "" {
+		finalBranchName = s.branchPrefix + sess.Name
+	}
+	if finalBranchName == "" && wt.Branch != nil {
+		finalBranchName = wt.Branch.Name
+	}
+
+	var warning string
+	if err := s.setupBranch(ctx, ws, branchName, baseBranchName); err != nil {
+		var w SetupWarning
+		if !errors.As(err, &w) {
+			return worktreeSetupResult{}, fmt.Errorf("branch setup: %w", err)
+		}
+		warning = w.Message
+	}
+
+	repoID, err := s.resolveRepoID(ctx, ws)
+	if err != nil {
+		return worktreeSetupResult{}, fmt.Errorf("repo lookup: %w", err)
+	}
+
+	branch, err := tracedOp(ctx, "find-or-create-branch", func() (*git.Branch, error) {
+		return s.gitService.FindOrCreateBranch(ctx, finalBranchName, repoID)
+	}, "name", finalBranchName, "ws", ws.Name)
+	if err != nil {
+		return worktreeSetupResult{}, fmt.Errorf("find-or-create-branch: %w", err)
+	}
+
+	var (
+		created bool
+		wtPath  string
+	)
+	if err := traceOp(ctx, "git worktree add", func() error {
+		var e error
+		created, wtPath, e = s.gitService.SetupWorktreeAt(ctx, ws.Path, finalBranchName, baseBranchName, branch.ID, repoID, wt.Path)
+		return e
+	}, "branch", finalBranchName, "ws", ws.Name); err != nil {
+		return worktreeSetupResult{}, fmt.Errorf("worktree setup: %w", err)
+	}
+
+	if refreshed, err := s.gitService.GetWorktree(wt.ID); err == nil {
+		*wt = *refreshed
+	}
+	if wt.Path == "" {
+		wt.Path = wtPath
+	}
+
+	return worktreeSetupResult{swt: swt, wt: wt, ws: ws, branch: branch, worktreePath: wt.Path, created: created, warning: warning}, nil
 }
 
 func (s *SessionService) runSetup(sessionID uint, tmuxName string, specs []WorkspaceBranchSpec) {
@@ -476,15 +736,7 @@ func (s *SessionService) runSetup(sessionID uint, tmuxName string, specs []Works
 		slog.InfoContext(ctx, "session setup: done", "status", sess.Status, "duration_ms", time.Since(setupStart).Milliseconds())
 	}()
 
-	type slotResult struct {
-		swt          *SessionWorktree
-		wt           *git.Worktree
-		ws           *workspace.Workspace
-		branch       *git.Branch
-		worktreePath string
-		created      bool
-	}
-	var done []slotResult
+	var done []worktreeSetupResult
 	var setupWarnings []string
 	wsCache := make(map[uint]*workspace.Workspace)
 
@@ -522,63 +774,15 @@ func (s *SessionService) runSetup(sessionID uint, tmuxName string, specs []Works
 			markBroken("workspace lookup", err)
 			return
 		}
-
-		spec := specByWS[ws.ID]
-		baseBranchName := spec.BaseBranch
-		branchName := spec.Branch
-		finalBranchName := branchName
-		if baseBranchName != "" {
-			finalBranchName = s.branchPrefix + sess.Name
-		}
-		if finalBranchName == "" && wt.Branch != nil {
-			finalBranchName = wt.Branch.Name
-		}
-
-		if err := s.setupBranch(ctx, ws, branchName, baseBranchName); err != nil {
-			var w SetupWarning
-			if errors.As(err, &w) {
-				setupWarnings = append(setupWarnings, fmt.Sprintf("%s: %s", ws.Name, w.Message))
-			} else {
-				markBroken("branch setup", err)
-				return
-			}
-		}
-
-		repoID, err := s.resolveRepoID(ctx, ws)
+		result, err := s.setupSingleWorktree(ctx, sess, swt, ws, specByWS[ws.ID])
 		if err != nil {
-			markBroken("repo lookup", err)
-			return
-		}
-
-		branch, err := tracedOp(ctx, "find-or-create-branch", func() (*git.Branch, error) {
-			return s.gitService.FindOrCreateBranch(ctx, finalBranchName, repoID)
-		}, "name", finalBranchName, "ws", ws.Name)
-		if err != nil {
-			markBroken("find-or-create-branch", err)
-			return
-		}
-
-		var (
-			created bool
-			wtPath  string
-		)
-		if err := traceOp(ctx, "git worktree add", func() error {
-			var e error
-			created, wtPath, e = s.gitService.SetupWorktreeAt(ctx, ws.Path, finalBranchName, baseBranchName, branch.ID, repoID, wt.Path)
-			return e
-		}, "branch", finalBranchName, "ws", ws.Name); err != nil {
 			markBroken("worktree setup", err)
 			return
 		}
-
-		if refreshed, err := s.gitService.GetWorktree(wt.ID); err == nil {
-			*wt = *refreshed
+		if result.warning != "" {
+			setupWarnings = append(setupWarnings, fmt.Sprintf("%s: %s", ws.Name, result.warning))
 		}
-		if wt.Path == "" {
-			wt.Path = wtPath
-		}
-
-		done = append(done, slotResult{swt: swt, wt: wt, ws: ws, branch: branch, worktreePath: wt.Path, created: created})
+		done = append(done, result)
 	}
 
 	for _, r := range done {
@@ -632,23 +836,7 @@ func (s *SessionService) runSetup(sessionID uint, tmuxName string, specs []Works
 		}
 	}
 
-	workspacePaths := make([]string, 0, len(done))
-	checkouts := make([]claudesettings.SessionCheckout, 0, len(done))
-	for _, r := range done {
-		workspacePaths = append(workspacePaths, r.ws.Path)
-		checkouts = append(checkouts, claudesettings.SessionCheckout{
-			Subdir:        filepath.Base(r.worktreePath),
-			WorkspaceName: r.ws.Name,
-		})
-	}
-	if err := claudesettings.EnsureSessionRoot(sess.SessionRoot, workspacePaths); err != nil {
-		slog.WarnContext(ctx, "ensure session-root claude settings failed", "error", err)
-		setupWarnings = append(setupWarnings, fmt.Sprintf("claude-settings: %s", err.Error()))
-	}
-	if err := claudesettings.EnsureMultiSessionGuide(sess.SessionRoot, checkouts); err != nil {
-		slog.WarnContext(ctx, "ensure session CLAUDE.md failed", "error", err)
-		setupWarnings = append(setupWarnings, fmt.Sprintf("claude-guide: %s", err.Error()))
-	}
+	setupWarnings = append(setupWarnings, s.applyClaudeSettings(ctx, sess)...)
 
 	if err := s.setupTmux(ctx, sess, tmuxName, sess.SessionRoot); err != nil {
 		markBroken("tmux setup", err)

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -700,6 +700,15 @@ func (s *SessionService) setupSingleWorktree(ctx context.Context, sess *Session,
 		return worktreeSetupResult{}, fmt.Errorf("worktree setup: %w", err)
 	}
 
+	if created && baseBranchName != "" {
+		if pushErr := s.gitService.PushSetUpstream(ctx, ws.Path, finalBranchName); pushErr != nil {
+			slog.WarnContext(ctx, "push --set-upstream failed", "branch", finalBranchName, "error", pushErr)
+			if warning == "" {
+				warning = fmt.Sprintf("upstream not set: %v", pushErr)
+			}
+		}
+	}
+
 	if refreshed, err := s.gitService.GetWorktree(wt.ID); err == nil {
 		*wt = *refreshed
 	}

--- a/internal/session/sessionservice_addworkspace_test.go
+++ b/internal/session/sessionservice_addworkspace_test.go
@@ -1,0 +1,181 @@
+package session
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/eleonorayaya/utena/internal/eventbus"
+	"github.com/eleonorayaya/utena/internal/git"
+	utmux "github.com/eleonorayaya/utena/internal/tmux"
+	"github.com/eleonorayaya/utena/internal/workspace"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionService_AddWorkspace_RejectsDeletedSession(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, ws2ID := setupSessionService(t)
+
+	session := &Session{Name: "deleted-session", Status: StatusDeleted, LastUsedAt: time.Now()}
+	addTestSession(t, sessionStore, swtStoreFor(service), session, ws1ID)
+
+	ctx := context.Background()
+	_, err := service.AddWorkspace(ctx, session.ID, WorkspaceBranchSpec{WorkspaceID: ws2ID, Branch: "main"})
+	require.Error(t, err)
+}
+
+func TestSessionService_AddWorkspace_RejectsArchivedSession(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, ws2ID := setupSessionService(t)
+
+	session := &Session{Name: "archived-session", Status: StatusArchived, LastUsedAt: time.Now()}
+	addTestSession(t, sessionStore, swtStoreFor(service), session, ws1ID)
+
+	ctx := context.Background()
+	_, err := service.AddWorkspace(ctx, session.ID, WorkspaceBranchSpec{WorkspaceID: ws2ID, Branch: "main"})
+	require.Error(t, err)
+}
+
+func TestSessionService_AddWorkspace_RejectsNonGitWorkspace(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, ws2ID := setupSessionService(t)
+
+	session := &Session{Name: "active-session", Status: StatusActive, SessionRoot: t.TempDir(), LastUsedAt: time.Now()}
+	addTestSession(t, sessionStore, swtStoreFor(service), session, ws1ID)
+
+	ctx := context.Background()
+	_, err := service.AddWorkspace(ctx, session.ID, WorkspaceBranchSpec{WorkspaceID: ws2ID, Branch: "main"})
+	require.Error(t, err)
+}
+
+func TestSessionService_AddWorkspace_RejectsDuplicateWorkspace(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, _ := setupSessionService(t)
+
+	session := &Session{Name: "active-session", Status: StatusActive, SessionRoot: t.TempDir(), LastUsedAt: time.Now()}
+	addTestSession(t, sessionStore, swtStoreFor(service), session, ws1ID)
+
+	ws1 := &workspace.Workspace{}
+	require.NoError(t, sessionStore.db.First(ws1, "id = ?", ws1ID).Error)
+	ws1.IsGitRepo = true
+	require.NoError(t, sessionStore.db.Save(ws1).Error)
+
+	ctx := context.Background()
+	_, err := service.AddWorkspace(ctx, session.ID, WorkspaceBranchSpec{WorkspaceID: ws1ID, Branch: "main"})
+	require.Error(t, err)
+}
+
+func TestSessionService_AddWorkspace_CreatesJunctionRow(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, ws2ID := setupSessionService(t)
+
+	session := &Session{Name: "active-session", Status: StatusActive, SessionRoot: t.TempDir(), LastUsedAt: time.Now()}
+	addTestSession(t, sessionStore, swtStoreFor(service), session, ws1ID)
+
+	repo2 := &git.Repo{Path: "/tmp/other", FullName: "test/other"}
+	require.NoError(t, sessionStore.db.Create(repo2).Error)
+	ws2 := &workspace.Workspace{}
+	require.NoError(t, sessionStore.db.First(ws2, "id = ?", ws2ID).Error)
+	ws2.IsGitRepo = true
+	ws2.RepoID = &repo2.ID
+	require.NoError(t, sessionStore.db.Save(ws2).Error)
+
+	ctx := context.Background()
+	updated, err := service.AddWorkspace(ctx, session.ID, WorkspaceBranchSpec{WorkspaceID: ws2ID, Branch: "main"})
+	require.NoError(t, err)
+	require.Len(t, updated.Worktrees, 2)
+	require.Equal(t, 1, updated.Worktrees[1].Position)
+}
+
+func TestSessionService_AddWorkspace_AssignsCollisionFreePath(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, ws2ID := setupSessionService(t)
+
+	sessionRoot := t.TempDir()
+	session := &Session{Name: "active-session", Status: StatusActive, SessionRoot: sessionRoot, LastUsedAt: time.Now()}
+	addTestSession(t, sessionStore, swtStoreFor(service), session, ws1ID)
+
+	repo2 := &git.Repo{Path: "/tmp/other", FullName: "test/other"}
+	require.NoError(t, sessionStore.db.Create(repo2).Error)
+	ws2 := &workspace.Workspace{}
+	require.NoError(t, sessionStore.db.First(ws2, "id = ?", ws2ID).Error)
+	ws2.IsGitRepo = true
+	ws2.RepoID = &repo2.ID
+	require.NoError(t, sessionStore.db.Save(ws2).Error)
+
+	ctx := context.Background()
+	updated, err := service.AddWorkspace(ctx, session.ID, WorkspaceBranchSpec{WorkspaceID: ws2ID, Branch: "main"})
+	require.NoError(t, err)
+	require.Len(t, updated.Worktrees, 2)
+
+	newWt := updated.Worktrees[1].Worktree
+	require.NotNil(t, newWt)
+	require.Equal(t, filepath.Join(sessionRoot, "other"), newWt.Path)
+}
+
+func setupTwoRepoSessionService(t *testing.T) (*SessionService, *SessionStore, *utmux.MockRunner, uint, uint) {
+	t.Helper()
+
+	repo1Path := initTestRepo(t)
+	repo2Path := initTestRepo(t)
+
+	database := setupTestDB(t)
+	bus := eventbus.NewEventBus()
+	sessionStore := NewSessionStore(database)
+	workspaceStore := workspace.NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
+
+	repo1 := &git.Repo{Path: repo1Path, FullName: "test/repo1"}
+	require.NoError(t, database.Create(repo1).Error)
+	repo2 := &git.Repo{Path: repo2Path, FullName: "test/repo2"}
+	require.NoError(t, database.Create(repo2).Error)
+
+	ws1 := &workspace.Workspace{Name: "repo1", Path: repo1Path, IsGitRepo: true, RepoID: &repo1.ID}
+	require.NoError(t, workspaceStore.Add(ws1))
+	ws2 := &workspace.Workspace{Name: "repo2", Path: repo2Path, IsGitRepo: true, RepoID: &repo2.ID}
+	require.NoError(t, workspaceStore.Add(ws2))
+
+	mock := utmux.NewMockRunner()
+	tmuxService := createTmuxService(t, database, mock, bus)
+	gitService := git.NewGitService(database)
+	workspaceService := workspace.NewWorkspaceService(workspaceStore, gitService)
+	dismissedPRStore := NewDismissedPRStore(database)
+	sessionActionStore := NewSessionActionStore(database)
+	sessionWorktreeStore := NewSessionWorktreeStore(database)
+	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir(), t.TempDir())
+
+	return service, sessionStore, mock, ws1.ID, ws2.ID
+}
+
+func TestSessionService_AddWorkspace_FullIntegration(t *testing.T) {
+	service, sessionStore, _, ws1ID, ws2ID := setupTwoRepoSessionService(t)
+
+	ctx := context.Background()
+	sess, err := service.CreateSession(ctx, CreateSessionInput{
+		Name:       "my-feature",
+		Workspaces: []WorkspaceBranchSpec{{WorkspaceID: ws1ID, BaseBranch: "main"}},
+	})
+	require.NoError(t, err)
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 5*time.Second)
+
+	updated, err := service.AddWorkspace(ctx, sess.ID, WorkspaceBranchSpec{WorkspaceID: ws2ID, BaseBranch: "main"})
+	require.NoError(t, err)
+	require.Len(t, updated.Worktrees, 2)
+
+	expectedPath := filepath.Join(service.sessionsRoot, "my-feature", "repo2")
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, statErr := os.Stat(expectedPath); statErr == nil {
+			break
+		}
+		current, _ := sessionStore.GetByID(sess.ID)
+		if current != nil && current.Status == StatusBroken {
+			t.Fatalf("session became broken: %s", current.StatusError)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	info, err := os.Stat(expectedPath)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+
+	final, err := sessionStore.GetByID(sess.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusActive, final.Status)
+}

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -469,6 +469,14 @@ func TestSessionService_DetachWorktreesByRepoID_NoRows(t *testing.T) {
 func initTestRepo(t *testing.T) string {
 	t.Helper()
 	bareDir := t.TempDir()
+	t.Cleanup(func() {
+		filepath.Walk(bareDir, func(path string, _ os.FileInfo, err error) error {
+			if err == nil {
+				os.Chmod(path, 0700)
+			}
+			return nil
+		})
+	})
 	dir := t.TempDir()
 	gitEnv := append(os.Environ(),
 		"GIT_CONFIG_GLOBAL=/dev/null",

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -78,6 +78,20 @@ func (c *CreateSessionRequest) Bind(r *http.Request) error {
 	return nil
 }
 
+type AddWorkspaceRequest struct {
+	WorkspaceBranchSpec
+}
+
+func (r *AddWorkspaceRequest) Bind(_ *http.Request) error {
+	if r.WorkspaceID == 0 {
+		return errors.New("workspace_id is required")
+	}
+	if (r.Branch != "") == (r.BaseBranch != "") {
+		return errors.New("exactly one of branch or base_branch is required")
+	}
+	return nil
+}
+
 type UpdateSessionRequest struct {
 	*Session
 }

--- a/internal/tui/addworkspaceform/keys.go
+++ b/internal/tui/addworkspaceform/keys.go
@@ -1,0 +1,47 @@
+package addworkspaceform
+
+import (
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/eleonorayaya/utena/internal/tui/branchpicker"
+	"github.com/eleonorayaya/utena/internal/tui/workspacepicker"
+)
+
+type formKeyMap struct {
+	Back key.Binding
+}
+
+func (k formKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Back}
+}
+
+func (k formKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{k.Back}}
+}
+
+var formKeys = formKeyMap{
+	Back: key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+}
+
+type mergedKeyMap struct {
+	keymaps []help.KeyMap
+}
+
+func (m mergedKeyMap) ShortHelp() []key.Binding {
+	var out []key.Binding
+	for _, km := range m.keymaps {
+		out = append(out, km.ShortHelp()...)
+	}
+	return out
+}
+
+func (m mergedKeyMap) FullHelp() [][]key.Binding {
+	var out [][]key.Binding
+	for _, km := range m.keymaps {
+		out = append(out, km.FullHelp()...)
+	}
+	return out
+}
+
+var _ help.KeyMap = formKeys
+var _ help.KeyMap = mergedKeyMap{keymaps: []help.KeyMap{formKeys, workspacepicker.Keys, branchpicker.Keys}}

--- a/internal/tui/addworkspaceform/model.go
+++ b/internal/tui/addworkspaceform/model.go
@@ -1,0 +1,249 @@
+package addworkspaceform
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/eleonorayaya/utena/internal/tui/branchpicker"
+	"github.com/eleonorayaya/utena/internal/tui/provider"
+	"github.com/eleonorayaya/utena/internal/tui/router"
+	"github.com/eleonorayaya/utena/internal/tui/sessionprogress"
+	"github.com/eleonorayaya/utena/internal/tui/theme"
+	"github.com/eleonorayaya/utena/internal/tui/workspacepicker"
+	"github.com/eleonorayaya/utena/internal/workspace"
+)
+
+func errStyle() lipgloss.Style    { return lipgloss.NewStyle().Foreground(theme.Current.Error) }
+func promptStyle() lipgloss.Style { return lipgloss.NewStyle().Bold(true) }
+func pathStyle() lipgloss.Style   { return lipgloss.NewStyle().Foreground(theme.Current.Path) }
+
+type step int
+
+const (
+	workspacePickerStep step = iota
+	branchPickerStep
+	branchModeStep
+)
+
+type Model struct {
+	activeStep      step
+	workspacePicker workspacepicker.Model
+	branchPicker    branchpicker.Model
+	sessionID       uint
+	selectedWS      *workspace.Workspace
+	pickedBranch    string
+	err             string
+	width, height   int
+}
+
+func New() Model {
+	return Model{
+		workspacePicker: workspacepicker.New("Select workspace to add", false),
+		branchPicker:    branchpicker.New(""),
+	}
+}
+
+type StartMsg struct {
+	SessionID uint
+}
+
+func Start(sessionID uint) tea.Cmd {
+	return func() tea.Msg { return StartMsg{SessionID: sessionID} }
+}
+
+func (m Model) Init() (Model, tea.Cmd) {
+	m.activeStep = workspacePickerStep
+	m.sessionID = 0
+	m.selectedWS = nil
+	m.pickedBranch = ""
+	m.err = ""
+	return m, provider.FetchWorkspaces()
+}
+
+func (m *Model) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+	m.workspacePicker.SetSize(width, height)
+	m.branchPicker.SetSize(width, height)
+}
+
+func (m Model) Keys() help.KeyMap {
+	switch m.activeStep {
+	case workspacePickerStep:
+		return mergedKeyMap{keymaps: []help.KeyMap{formKeys, workspacepicker.Keys}}
+	case branchPickerStep:
+		return mergedKeyMap{keymaps: []help.KeyMap{formKeys, branchpicker.Keys}}
+	default:
+		return formKeys
+	}
+}
+
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.SetSize(msg.Width, msg.Height)
+		return m, nil
+
+	case StartMsg:
+		m.sessionID = msg.SessionID
+		m.activeStep = workspacePickerStep
+		m.selectedWS = nil
+		m.pickedBranch = ""
+		m.err = ""
+		return m, provider.RequestWorkspacesState()
+
+	case provider.WorkspacesStateUpdatedMsg:
+		var cmd tea.Cmd
+		m.workspacePicker, cmd = m.workspacePicker.Update(msg)
+		return m, cmd
+
+	case provider.ErrMsg:
+		m.err = msg.Err.Error()
+		return m, nil
+
+	case provider.WorkspaceAddedToSessionMsg:
+		return m, tea.Sequence(
+			router.NavigateTo(router.SessionProgressView),
+			sessionprogress.Start(msg.SessionID),
+		)
+	}
+
+	switch m.activeStep {
+	case workspacePickerStep:
+		return m.updateWorkspacePicker(msg)
+	case branchPickerStep:
+		return m.updateBranchPicker(msg)
+	case branchModeStep:
+		return m.updateBranchMode(msg)
+	}
+	return m, nil
+}
+
+func (m Model) OnWindowSizeMsg(msg tea.WindowSizeMsg) (Model, tea.Cmd) {
+	m.SetSize(msg.Width, msg.Height)
+	return m, nil
+}
+
+func (m Model) OnKeyMsg(_ tea.KeyMsg) (Model, tea.Cmd, bool) {
+	return m, nil, false
+}
+
+func (m Model) updateWorkspacePicker(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case workspacepicker.SelectedMsg:
+		ws := msg.Workspace
+		if !ws.IsGitRepo {
+			m.err = "selected workspace is not a git repository"
+			return m, nil
+		}
+		m.selectedWS = &ws
+		m.err = ""
+		title := fmt.Sprintf("Select branch for %s", ws.Name)
+		m.branchPicker = branchpicker.New(title)
+		m.branchPicker.SetSize(m.width, m.height)
+		m.activeStep = branchPickerStep
+		return m, provider.RequestBranches(ws.ID)
+
+	case tea.KeyMsg:
+		if key.Matches(msg, formKeys.Back) {
+			return m, router.Back()
+		}
+	}
+
+	var cmd tea.Cmd
+	m.workspacePicker, cmd = m.workspacePicker.Update(msg)
+	return m, cmd
+}
+
+func (m Model) updateBranchPicker(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case branchpicker.SelectedMsg:
+		m.pickedBranch = msg.Branch
+		m.activeStep = branchModeStep
+		return m, nil
+
+	case branchpicker.FetchRequestedMsg:
+		var cmd tea.Cmd
+		m.branchPicker, cmd = m.branchPicker.Update(msg)
+		if m.selectedWS != nil {
+			return m, tea.Batch(cmd, provider.FetchOriginBranches(m.selectedWS.ID))
+		}
+		return m, cmd
+
+	case provider.BranchesFetchedMsg:
+		var cmd tea.Cmd
+		m.branchPicker, cmd = m.branchPicker.Update(msg)
+		return m, cmd
+
+	case tea.KeyMsg:
+		if key.Matches(msg, formKeys.Back) {
+			m.activeStep = workspacePickerStep
+			m.pickedBranch = ""
+			return m, provider.RequestWorkspacesState()
+		}
+	}
+
+	var cmd tea.Cmd
+	m.branchPicker, cmd = m.branchPicker.Update(msg)
+	return m, cmd
+}
+
+func (m Model) updateBranchMode(msg tea.Msg) (Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch keyMsg.String() {
+	case "n":
+		spec := provider.SessionWorkspaceSpec{WorkspaceID: m.selectedWS.ID, BaseBranch: m.pickedBranch}
+		return m, provider.AddWorkspaceToSession(m.sessionID, spec)
+	case "e":
+		spec := provider.SessionWorkspaceSpec{WorkspaceID: m.selectedWS.ID, Branch: m.pickedBranch}
+		return m, provider.AddWorkspaceToSession(m.sessionID, spec)
+	case "esc":
+		m.activeStep = branchPickerStep
+		if m.selectedWS != nil {
+			return m, provider.RequestBranches(m.selectedWS.ID)
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m Model) View() string {
+	switch m.activeStep {
+	case branchPickerStep:
+		v := m.branchPicker.View()
+		if m.err != "" {
+			v += "\n" + errStyle().Render(m.err)
+		}
+		return v
+
+	case branchModeStep:
+		var b strings.Builder
+		wsName := ""
+		if m.selectedWS != nil {
+			wsName = m.selectedWS.Name
+		}
+		b.WriteString(promptStyle().Render("Workspace: ") + pathStyle().Render(wsName) + "\n")
+		b.WriteString(promptStyle().Render("Branch: ") + pathStyle().Render(m.pickedBranch) + "\n\n")
+		b.WriteString("  n  Create new branch from selected\n")
+		b.WriteString("  e  Use existing branch\n\n")
+		b.WriteString("  esc: back")
+		if m.err != "" {
+			b.WriteString("\n" + errStyle().Render(m.err))
+		}
+		return b.String()
+
+	default:
+		v := m.workspacePicker.View()
+		if m.err != "" {
+			v += "\n" + errStyle().Render(m.err)
+		}
+		return v
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/help"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/eleonorayaya/utena/internal/tui/addworkspaceform"
 	"github.com/eleonorayaya/utena/internal/tui/debug"
 	"github.com/eleonorayaya/utena/internal/tui/prlist"
 	"github.com/eleonorayaya/utena/internal/tui/provider"
@@ -62,6 +63,7 @@ func NewApp(logPath, port string, initialView router.View, opts ...AppOption) Ap
 		router.WorkspaceDetailView:    &router.ViewAdapter[workspacedetail.Model]{Model: workspacedetail.New()},
 		router.WorkspaceCloneFormView: &router.ViewAdapter[workspacecloneform.Model]{Model: workspacecloneform.New()},
 		router.PRListView:             &router.ViewAdapter[prlist.Model]{Model: prlist.New()},
+		router.AddWorkspaceFormView:   &router.ViewAdapter[addworkspaceform.Model]{Model: addworkspaceform.New()},
 	}
 
 	return App{

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/eleonorayaya/utena/internal/tui/addworkspaceform"
 	"github.com/eleonorayaya/utena/internal/tui/branchpicker"
 	"github.com/eleonorayaya/utena/internal/tui/debug"
 	"github.com/eleonorayaya/utena/internal/tui/filepicker"
@@ -21,14 +22,15 @@ type ViewModel[T any] interface {
 }
 
 var (
-	_ ViewModel[router.Router]         = router.Router{}
-	_ ViewModel[sessionlist.Model]     = sessionlist.Model{}
-	_ ViewModel[sessionform.Model]     = sessionform.Model{}
-	_ ViewModel[sessionprogress.Model] = sessionprogress.Model{}
-	_ ViewModel[todolist.Model]        = todolist.Model{}
-	_ ViewModel[todoform.Model]        = todoform.Model{}
-	_ ViewModel[debug.Model]           = debug.Model{}
-	_ ViewModel[workspacepicker.Model] = workspacepicker.Model{}
-	_ ViewModel[branchpicker.Model]    = branchpicker.Model{}
-	_ ViewModel[filepicker.Model]      = filepicker.Model{}
+	_ ViewModel[router.Router]          = router.Router{}
+	_ ViewModel[sessionlist.Model]      = sessionlist.Model{}
+	_ ViewModel[sessionform.Model]      = sessionform.Model{}
+	_ ViewModel[sessionprogress.Model]  = sessionprogress.Model{}
+	_ ViewModel[todolist.Model]         = todolist.Model{}
+	_ ViewModel[todoform.Model]         = todoform.Model{}
+	_ ViewModel[debug.Model]            = debug.Model{}
+	_ ViewModel[workspacepicker.Model]  = workspacepicker.Model{}
+	_ ViewModel[branchpicker.Model]     = branchpicker.Model{}
+	_ ViewModel[filepicker.Model]       = filepicker.Model{}
+	_ ViewModel[addworkspaceform.Model] = addworkspaceform.Model{}
 )

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -609,6 +609,43 @@ func (c *client) deleteTodo(id uint) tea.Cmd {
 	}
 }
 
+func (c *client) addWorkspaceToSession(sessionID uint, spec SessionWorkspaceSpec) tea.Cmd {
+	return func() tea.Msg {
+		item := map[string]any{"workspace_id": spec.WorkspaceID}
+		if spec.Branch != "" {
+			item["branch"] = spec.Branch
+		}
+		if spec.BaseBranch != "" {
+			item["base_branch"] = spec.BaseBranch
+		}
+		jsonBody, err := json.Marshal(item)
+		if err != nil {
+			return ErrMsg{err}
+		}
+
+		res, err := c.httpClient.Post(
+			fmt.Sprintf("%s/sessions/%d/workspaces", c.baseURL, sessionID),
+			"application/json",
+			bytes.NewReader(jsonBody),
+		)
+		if err != nil {
+			log.Printf("[ERROR] add workspace to session %d: %v", sessionID, err)
+			return ErrMsg{err}
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusAccepted {
+			return parseAPIError(res, "add workspace to session")
+		}
+
+		var resp struct {
+			ID uint `json:"id"`
+		}
+		json.NewDecoder(res.Body).Decode(&resp)
+		return workspaceAddedToSessionMsg{sessionID: resp.ID}
+	}
+}
+
 func (c *client) getSession(id uint) tea.Cmd {
 	return func() tea.Msg {
 		res, err := c.httpClient.Get(fmt.Sprintf("%s/sessions/%d", c.baseURL, id))

--- a/internal/tui/provider/sessionsprovider.go
+++ b/internal/tui/provider/sessionsprovider.go
@@ -63,6 +63,10 @@ func ArchiveSession(id uint) tea.Cmd {
 	return func() tea.Msg { return archiveSessionIntentMsg{id: id} }
 }
 
+func AddWorkspaceToSession(sessionID uint, spec SessionWorkspaceSpec) tea.Cmd {
+	return func() tea.Msg { return addWorkspaceToSessionIntentMsg{sessionID: sessionID, spec: spec} }
+}
+
 type fetchSessionsIntentMsg struct{}
 type requestSessionsStateMsg struct{}
 
@@ -122,6 +126,19 @@ type sessionPolledMsg struct {
 
 type pollSessionIntentMsg struct {
 	id uint
+}
+
+type addWorkspaceToSessionIntentMsg struct {
+	sessionID uint
+	spec      SessionWorkspaceSpec
+}
+
+type workspaceAddedToSessionMsg struct {
+	sessionID uint
+}
+
+type WorkspaceAddedToSessionMsg struct {
+	SessionID uint
 }
 
 type SessionPolledMsg struct {
@@ -219,6 +236,16 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 		return p, func() tea.Msg {
 			return SessionPolledMsg{Session: msg.session}
 		}
+
+	case addWorkspaceToSessionIntentMsg:
+		return p, p.client.addWorkspaceToSession(msg.sessionID, msg.spec)
+
+	case workspaceAddedToSessionMsg:
+		id := msg.sessionID
+		return p, tea.Batch(
+			p.client.fetchSessions(),
+			func() tea.Msg { return WorkspaceAddedToSessionMsg{SessionID: id} },
+		)
 	}
 
 	return p, nil

--- a/internal/tui/router/view.go
+++ b/internal/tui/router/view.go
@@ -15,4 +15,5 @@ const (
 	WorkspaceCloneFormView
 	PRListView
 	SessionDetailView
+	AddWorkspaceFormView
 )

--- a/internal/tui/sessiondetail/keys.go
+++ b/internal/tui/sessiondetail/keys.go
@@ -6,27 +6,29 @@ import (
 )
 
 type keyMap struct {
-	Activate key.Binding
-	Repair   key.Binding
-	Archive  key.Binding
-	Delete   key.Binding
-	Back     key.Binding
+	Activate     key.Binding
+	Repair       key.Binding
+	Archive      key.Binding
+	Delete       key.Binding
+	AddWorkspace key.Binding
+	Back         key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Activate, k.Repair, k.Archive, k.Delete, k.Back}
+	return []key.Binding{k.Activate, k.Repair, k.Archive, k.Delete, k.AddWorkspace, k.Back}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.Activate, k.Repair, k.Archive, k.Delete, k.Back}}
+	return [][]key.Binding{{k.Activate, k.Repair, k.Archive, k.Delete, k.AddWorkspace, k.Back}}
 }
 
 var keys = keyMap{
-	Activate: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "activate")),
-	Repair:   key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "repair")),
-	Archive:  key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "archive")),
-	Delete:   key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
-	Back:     key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+	Activate:     key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "activate")),
+	Repair:       key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "repair")),
+	Archive:      key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "archive")),
+	Delete:       key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
+	AddWorkspace: key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "add workspace")),
+	Back:         key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
 }
 
 var _ help.KeyMap = keys

--- a/internal/tui/sessiondetail/model.go
+++ b/internal/tui/sessiondetail/model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/eleonorayaya/utena/internal/git"
 	"github.com/eleonorayaya/utena/internal/session"
+	"github.com/eleonorayaya/utena/internal/tui/addworkspaceform"
 	"github.com/eleonorayaya/utena/internal/tui/provider"
 	"github.com/eleonorayaya/utena/internal/tui/router"
 	"github.com/eleonorayaya/utena/internal/tui/sessionprogress"
@@ -130,6 +131,17 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 		return m, tea.Sequence(
 			router.NavigateTo(router.SessionProgressView),
 			sessionprogress.Start(id),
+		)
+
+	case key.Matches(msg, keys.AddWorkspace):
+		s := m.sess.Status
+		if s == session.StatusDeleted || s == session.StatusArchived || s == session.StatusCreating {
+			return m, nil
+		}
+		id := m.sess.ID
+		return m, tea.Sequence(
+			router.NavigateTo(router.AddWorkspaceFormView),
+			addworkspaceform.Start(id),
 		)
 	}
 


### PR DESCRIPTION
## Summary

- Adds `POST /sessions/{id}/workspaces` endpoint accepting a `WorkspaceBranchSpec` (either `branch` or `base_branch`)
- Validates the session is not deleted/archived, the workspace is a git repo, and it isn't already in the session
- Eagerly creates DB records (branch + worktree + junction row) and returns 202 while async setup runs
- `runAddWorkspace` goroutine handles disk worktree creation, setup scripts, and claude settings update without touching the existing tmux session
- Extracts `setupSingleWorktree` helper used by both `runSetup` and `runAddWorkspace` to avoid duplication
- Extracts `applyClaudeSettings` helper (used by both goroutines) and `freeSubdir` pure helper for collision-free subdirectory naming

## Test plan

- [ ] Service-level: rejects deleted/archived sessions, non-git workspaces, duplicate workspaces; creates junction row with correct position; assigns collision-free path
- [ ] Integration: creates session with one workspace, adds second workspace, verifies subdirectory appears on disk and session stays active
- [ ] HTTP layer: rejects missing `workspace_id`, both branch fields set, session not found, deleted session
- [ ] `task go:test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)