### PR TITLE
feat(session): workspace setup actions + live TUI step progress

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -42,6 +42,7 @@ type Session struct {
 	SessionRoot    string                 `json:"session_root,omitempty" gorm:"index"`
 	ClaudeSessions []claude.ClaudeSession `json:"claude_sessions,omitempty" gorm:"foreignKey:SessionID;constraint:OnDelete:CASCADE"`
 	SessionActions []SessionAction        `json:"session_actions,omitempty" gorm:"foreignKey:SessionID;constraint:OnDelete:CASCADE"`
+	SetupSteps     []SessionSetupStep     `json:"setup_steps,omitempty" gorm:"foreignKey:SessionID;constraint:OnDelete:CASCADE"`
 	Worktrees      []SessionWorktree      `json:"worktrees,omitempty" gorm:"foreignKey:SessionID;constraint:OnDelete:CASCADE"`
 	TmuxSessionID  *uint                  `json:"tmux_session_id,omitempty" gorm:"uniqueIndex"`
 	StatusError    string                 `json:"status_error,omitempty"`

--- a/internal/session/sessionmodule.go
+++ b/internal/session/sessionmodule.go
@@ -26,7 +26,8 @@ func NewSessionModule(tmuxService *utmux.TmuxService, workspaceModule *workspace
 	dismissedPRStore := NewDismissedPRStore(database)
 	sessionActionStore := NewSessionActionStore(database)
 	sessionWorktreeStore := NewSessionWorktreeStore(database)
-	service := NewSessionService(store, sessionWorktreeStore, dismissedPRStore, sessionActionStore, workspaceModule.Service, workspaceModule.GitService, tmuxService, bus, branchPrefix, configDir, sessionsRoot)
+	setupStepStore := NewSessionSetupStepStore(database)
+	service := NewSessionService(store, sessionWorktreeStore, dismissedPRStore, sessionActionStore, setupStepStore, workspaceModule.Service, workspaceModule.GitService, tmuxService, bus, branchPrefix, configDir, sessionsRoot)
 	controller := NewSessionController(service)
 	router := NewSessionRouter(controller)
 
@@ -63,7 +64,7 @@ func (m *SessionModule) OnAppEnd(ctx context.Context) error {
 }
 
 func (m *SessionModule) Models() []any {
-	return []any{&Session{}, &SessionWorktree{}, &DismissedPR{}, &SessionAction{}}
+	return []any{&Session{}, &SessionWorktree{}, &DismissedPR{}, &SessionAction{}, &SessionSetupStep{}}
 }
 
 func (m *SessionModule) Routes() chi.Router {

--- a/internal/session/sessionrouter_test.go
+++ b/internal/session/sessionrouter_test.go
@@ -37,7 +37,7 @@ func setupSessionRouter(t *testing.T) (*SessionRouter, *SessionStore, *workspace
 	dismissedPRStore := NewDismissedPRStore(database)
 	sessionActionStore := NewSessionActionStore(database)
 	sessionWorktreeStore := NewSessionWorktreeStore(database)
-	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir(), t.TempDir())
+	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, NewSessionSetupStepStore(database), workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir(), t.TempDir())
 	controller := NewSessionController(service)
 	router := NewSessionRouter(controller)
 

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -70,6 +70,7 @@ type SessionService struct {
 	sessionWorktreeStore *SessionWorktreeStore
 	dismissedPRStore     *DismissedPRStore
 	sessionActionStore   *SessionActionStore
+	setupStepStore       *SessionSetupStepStore
 	workspaceService     *workspace.WorkspaceService
 	gitService           *git.GitService
 	tmuxService          *utmux.TmuxService
@@ -80,12 +81,13 @@ type SessionService struct {
 	setupTimeout         time.Duration
 }
 
-func NewSessionService(store *SessionStore, sessionWorktreeStore *SessionWorktreeStore, dismissedPRStore *DismissedPRStore, sessionActionStore *SessionActionStore, workspaceService *workspace.WorkspaceService, gitService *git.GitService, tmuxService *utmux.TmuxService, bus eventbus.EventBus, branchPrefix string, configDir string, sessionsRoot string) *SessionService {
+func NewSessionService(store *SessionStore, sessionWorktreeStore *SessionWorktreeStore, dismissedPRStore *DismissedPRStore, sessionActionStore *SessionActionStore, setupStepStore *SessionSetupStepStore, workspaceService *workspace.WorkspaceService, gitService *git.GitService, tmuxService *utmux.TmuxService, bus eventbus.EventBus, branchPrefix string, configDir string, sessionsRoot string) *SessionService {
 	return &SessionService{
 		store:                store,
 		sessionWorktreeStore: sessionWorktreeStore,
 		dismissedPRStore:     dismissedPRStore,
 		sessionActionStore:   sessionActionStore,
+		setupStepStore:       setupStepStore,
 		workspaceService:     workspaceService,
 		gitService:           gitService,
 		tmuxService:          tmuxService,
@@ -395,6 +397,12 @@ func (s *SessionService) CreateSession(ctx context.Context, input CreateSessionI
 		if err := s.workspaceService.Touch(ctx, a.ws.ID); err != nil {
 			slog.WarnContext(ctx, "failed to touch workspace last-used timestamp", "workspace", a.ws.ID, "error", err)
 		}
+	}
+
+	stepWS := assignedToStepWorkspaces(assigned)
+	defs := buildSetupSteps(stepWS, s.loadWorkspaceConfigs(stepWS))
+	if _, err := s.persistSetupSteps(sess.ID, defs); err != nil {
+		slog.WarnContext(ctx, "failed to pre-create setup steps", "session", sess.ID, "error", err)
 	}
 
 	go s.runSetup(sess.ID, tmuxName, input.Workspaces)
@@ -745,10 +753,6 @@ func (s *SessionService) runSetup(sessionID uint, tmuxName string, specs []Works
 		slog.InfoContext(ctx, "session setup: done", "status", sess.Status, "duration_ms", time.Since(setupStart).Milliseconds())
 	}()
 
-	var done []worktreeSetupResult
-	var setupWarnings []string
-	wsCache := make(map[uint]*workspace.Workspace)
-
 	markBroken := func(stage string, err error) {
 		msg := fmt.Sprintf("%s failed: %v", stage, err)
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
@@ -759,18 +763,15 @@ func (s *SessionService) runSetup(sessionID uint, tmuxName string, specs []Works
 		}
 	}
 
-	if sess.SessionRoot != "" {
-		if err := os.MkdirAll(sess.SessionRoot, 0o755); err != nil {
-			markBroken("ensure session root", err)
-			return
-		}
-	}
-
 	if len(sess.Worktrees) == 0 {
 		markBroken("missing worktrees", fmt.Errorf("session %d has no SessionWorktree rows", sess.ID))
 		return
 	}
 
+	wsCache := make(map[uint]*workspace.Workspace)
+	orderedWS := make([]stepWorkspace, 0, len(sess.Worktrees))
+	wsByID := make(map[uint]*workspace.Workspace, len(sess.Worktrees))
+	swtByID := make(map[uint]*SessionWorktree, len(sess.Worktrees))
 	for i := range sess.Worktrees {
 		swt := &sess.Worktrees[i]
 		wt := swt.Worktree
@@ -783,80 +784,48 @@ func (s *SessionService) runSetup(sessionID uint, tmuxName string, specs []Works
 			markBroken("workspace lookup", err)
 			return
 		}
-		result, err := s.setupSingleWorktree(ctx, sess, swt, ws, specByWS[ws.ID])
-		if err != nil {
-			markBroken("worktree setup", err)
-			return
-		}
-		if result.warning != "" {
-			setupWarnings = append(setupWarnings, fmt.Sprintf("%s: %s", ws.Name, result.warning))
-		}
-		done = append(done, result)
+		orderedWS = append(orderedWS, stepWorkspace{ID: ws.ID, Name: ws.Name, Path: ws.Path})
+		wsByID[ws.ID] = ws
+		swtByID[ws.ID] = swt
 	}
 
-	for _, r := range done {
-		if !r.created {
-			continue
-		}
-		branchName := ""
-		if r.branch != nil {
-			branchName = r.branch.Name
-		}
-		env := []string{
-			envSessionRoot + "=" + sess.SessionRoot,
-			envSessionName + "=" + sess.Name,
-			envBranch + "=" + branchName,
-			envWorktreePath + "=" + r.worktreePath,
-			envWorkspaceName + "=" + r.ws.Name,
-			envWorkspacePath + "=" + r.ws.Path,
-		}
-		wsScript := filepath.Join(r.ws.Path, ".utena", worktreeSetupName)
-		if err := traceOp(ctx, "worktree-setup script", func() error {
-			return s.runScript(ctx, wsScript, r.worktreePath, env)
-		}, "script", wsScript, "ws", r.ws.Name); err != nil {
-			slog.WarnContext(ctx, "workspace worktree-setup script failed", "ws", r.ws.Name, "error", err)
-			setupWarnings = append(setupWarnings, fmt.Sprintf("%s: %s", r.ws.Name, err.Error()))
-		}
+	configs := s.loadWorkspaceConfigs(orderedWS)
+	defs := buildSetupSteps(orderedWS, configs)
+	steps := s.ensureSetupSteps(sess.ID, defs)
+
+	execSteps := make([]execStep, len(defs))
+	for i := range defs {
+		execSteps[i] = execStep{def: defs[i], db: steps[i]}
 	}
 
-	anyCreated := false
-	for _, r := range done {
-		if r.created {
-			anyCreated = true
-			break
-		}
+	executor := &setupExecution{
+		svc:       s,
+		sess:      sess,
+		tmuxName:  tmuxName,
+		execSteps: execSteps,
+		orderedWS: orderedWS,
+		specByWS:  specByWS,
+		wsByID:    wsByID,
+		swtByID:   swtByID,
+		updater:   &stepUpdater{store: s.setupStepStore},
+		results:   make(map[uint]*worktreeSetupResult, len(orderedWS)),
 	}
-	if anyCreated {
-		globalBranch := ""
-		if len(done) > 0 && done[0].branch != nil {
-			globalBranch = done[0].branch.Name
-		}
-		globalEnv := []string{
-			envSessionRoot + "=" + sess.SessionRoot,
-			envSessionName + "=" + sess.Name,
-			envBranch + "=" + globalBranch,
-		}
-		globalScript := filepath.Join(s.configDir, worktreeSetupName)
-		if err := traceOp(ctx, "global worktree-setup script", func() error {
-			return s.runScript(ctx, globalScript, sess.SessionRoot, globalEnv)
-		}, "script", globalScript); err != nil {
-			slog.WarnContext(ctx, "global worktree-setup script failed", "error", err)
-			setupWarnings = append(setupWarnings, fmt.Sprintf("global: %s", err.Error()))
-		}
+	executor.run(ctx)
+
+	if executor.broken {
+		markBroken(executor.brokenStage, executor.brokenErr)
+		return
 	}
-
-	setupWarnings = append(setupWarnings, s.applyClaudeSettings(ctx, sess)...)
-
-	if err := s.setupTmux(ctx, sess, tmuxName, sess.SessionRoot); err != nil {
-		markBroken("tmux setup", err)
+	if ctx.Err() != nil {
+		markBroken("setup", ctx.Err())
 		return
 	}
 
 	sess.Status = StatusActive
-	if len(setupWarnings) == 0 {
+	if len(executor.warnings) == 0 {
 		sess.StatusError = ""
 	} else {
-		sess.StatusError = strings.Join(setupWarnings, "; ")
+		sess.StatusError = strings.Join(executor.warnings, "; ")
 	}
 	if err := s.store.Update(sess); err != nil {
 		markBroken("persist active status", err)

--- a/internal/session/sessionservice_addworkspace_test.go
+++ b/internal/session/sessionservice_addworkspace_test.go
@@ -138,7 +138,7 @@ func setupTwoRepoSessionService(t *testing.T) (*SessionService, *SessionStore, *
 	dismissedPRStore := NewDismissedPRStore(database)
 	sessionActionStore := NewSessionActionStore(database)
 	sessionWorktreeStore := NewSessionWorktreeStore(database)
-	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir(), t.TempDir())
+	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, NewSessionSetupStepStore(database), workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir(), t.TempDir())
 
 	return service, sessionStore, mock, ws1.ID, ws2.ID
 }

--- a/internal/session/sessionservice_pr_test.go
+++ b/internal/session/sessionservice_pr_test.go
@@ -65,6 +65,7 @@ func setupPRTestEnv(t *testing.T) *prTestEnv {
 		&DismissedPR{},
 		&claude.ClaudeSession{},
 		&SessionAction{},
+		&SessionSetupStep{},
 	)
 
 	bus := eventbus.NewEventBus()
@@ -99,7 +100,7 @@ func setupPRTestEnv(t *testing.T) *prTestEnv {
 	tmuxService := createTmuxService(t, database, mock, bus)
 	sessionActionStore := NewSessionActionStore(database)
 	sessionWorktreeStore := NewSessionWorktreeStore(database)
-	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir(), t.TempDir())
+	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, NewSessionSetupStepStore(database), workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir(), t.TempDir())
 
 	return &prTestEnv{
 		service:          service,
@@ -505,7 +506,7 @@ func TestHandlePRUpdated_BareWorkspace_CreatesWorktree(t *testing.T) {
 	dismissedPRStore := NewDismissedPRStore(database)
 	sessionActionStore := NewSessionActionStore(database)
 	sessionWorktreeStore := NewSessionWorktreeStore(database)
-	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir(), t.TempDir())
+	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, NewSessionSetupStepStore(database), workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir(), t.TempDir())
 
 	branchID := branch.ID
 	event := eventbus.Event{

--- a/internal/session/sessionservice_setupsteps_test.go
+++ b/internal/session/sessionservice_setupsteps_test.go
@@ -1,0 +1,246 @@
+package session
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func stepByKind(t *testing.T, steps []*SessionSetupStep, kind SetupStepKind) *SessionSetupStep {
+	t.Helper()
+	for _, s := range steps {
+		if s.Kind == kind {
+			return s
+		}
+	}
+	return nil
+}
+
+func TestSessionService_SetupSteps_PrePopulated(t *testing.T) {
+	repoPath := initTestRepo(t)
+	service, _, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	sess, err := service.CreateSession(context.Background(), CreateSessionInput{
+		Name:       "steps-prepop",
+		Workspaces: []WorkspaceBranchSpec{{WorkspaceID: wsGitID, BaseBranch: "main"}},
+	})
+	require.NoError(t, err)
+
+	steps, err := service.setupStepStore.ListBySessionID(sess.ID)
+	require.NoError(t, err)
+
+	kinds := make([]SetupStepKind, len(steps))
+	for i, s := range steps {
+		kinds[i] = s.Kind
+	}
+	require.Equal(t, []SetupStepKind{
+		StepKindCreateSessionDir,
+		StepKindSetupWorktree,
+		StepKindApplyClaude,
+		StepKindSetupTmux,
+	}, kinds)
+}
+
+func TestSessionService_SetupSteps_AllComplete(t *testing.T) {
+	repoPath := initTestRepo(t)
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	sess, err := service.CreateSession(context.Background(), CreateSessionInput{
+		Name:       "steps-complete",
+		Workspaces: []WorkspaceBranchSpec{{WorkspaceID: wsGitID, BaseBranch: "main"}},
+	})
+	require.NoError(t, err)
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 5*time.Second)
+
+	steps, err := service.setupStepStore.ListBySessionID(sess.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, steps)
+	for _, s := range steps {
+		require.Equal(t, SetupStepDone, s.Status, "step %q should be done", s.Label)
+	}
+}
+
+func TestSessionService_ConfigAction_CopyFile(t *testing.T) {
+	repoPath := initTestRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(repoPath, ".env.example"), []byte("SECRET=1\n"), 0o644))
+	writeWorkspaceConfig(t, repoPath, `{
+		"setup_actions": [
+			{"type": "copy_file", "src": ".env.example", "dest": ".env", "dest_relative_to": "workspace_dir"},
+			{"type": "copy_file", "src": ".env.example", "dest": "shared/config.env", "dest_relative_to": "session_root"}
+		]
+	}`)
+
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	sess, err := service.CreateSession(context.Background(), CreateSessionInput{
+		Name:       "copy-test",
+		Workspaces: []WorkspaceBranchSpec{{WorkspaceID: wsGitID, BaseBranch: "main"}},
+	})
+	require.NoError(t, err)
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 5*time.Second)
+
+	workspaceDir := filepath.Join(service.sessionsRoot, "copy-test", "git-repo")
+	data, err := os.ReadFile(filepath.Join(workspaceDir, ".env"))
+	require.NoError(t, err)
+	require.Equal(t, "SECRET=1\n", string(data))
+
+	sessionRootCopy := filepath.Join(service.sessionsRoot, "copy-test", "shared", "config.env")
+	data, err = os.ReadFile(sessionRootCopy)
+	require.NoError(t, err)
+	require.Equal(t, "SECRET=1\n", string(data))
+
+	steps, err := service.setupStepStore.ListBySessionID(sess.ID)
+	require.NoError(t, err)
+	copyStep := stepByKind(t, steps, StepKindCopyFile)
+	require.NotNil(t, copyStep)
+	require.Equal(t, SetupStepDone, copyStep.Status)
+}
+
+func TestSessionService_ConfigAction_InstallDeps(t *testing.T) {
+	repoPath := initTestRepo(t)
+	pmScript := filepath.Join(t.TempDir(), "fake-pm")
+	writeScript(t, pmScript, "#!/bin/sh\ntouch dep-installed\n")
+	writeWorkspaceConfig(t, repoPath, `{
+		"setup_actions": [
+			{"type": "install_deps", "package_manager": "`+pmScript+`"}
+		]
+	}`)
+
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	sess, err := service.CreateSession(context.Background(), CreateSessionInput{
+		Name:       "install-test",
+		Workspaces: []WorkspaceBranchSpec{{WorkspaceID: wsGitID, BaseBranch: "main"}},
+	})
+	require.NoError(t, err)
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 5*time.Second)
+
+	marker := filepath.Join(service.sessionsRoot, "install-test", "git-repo", "dep-installed")
+	_, err = os.Stat(marker)
+	require.NoError(t, err, "install_deps should have run in the worktree dir")
+
+	steps, err := service.setupStepStore.ListBySessionID(sess.ID)
+	require.NoError(t, err)
+	installStep := stepByKind(t, steps, StepKindInstallDeps)
+	require.NotNil(t, installStep)
+	require.Equal(t, SetupStepDone, installStep.Status)
+}
+
+func TestSessionService_ConfigAction_InstallDeps_Parallel(t *testing.T) {
+	service, sessionStore, _, ws1ID, ws2ID := setupTwoRepoSessionService(t)
+
+	pmScript := filepath.Join(t.TempDir(), "fake-pm")
+	writeScript(t, pmScript, "#!/bin/sh\ntouch dep-installed\n")
+	cfg := `{"setup_actions": [{"type": "install_deps", "package_manager": "` + pmScript + `"}]}`
+
+	ws1, err := service.workspaceService.GetWorkspace(context.Background(), ws1ID)
+	require.NoError(t, err)
+	ws2, err := service.workspaceService.GetWorkspace(context.Background(), ws2ID)
+	require.NoError(t, err)
+	writeWorkspaceConfig(t, ws1.Path, cfg)
+	writeWorkspaceConfig(t, ws2.Path, cfg)
+
+	sess, err := service.CreateSession(context.Background(), CreateSessionInput{
+		Name: "parallel-install",
+		Workspaces: []WorkspaceBranchSpec{
+			{WorkspaceID: ws1ID, BaseBranch: "main"},
+			{WorkspaceID: ws2ID, BaseBranch: "main"},
+		},
+	})
+	require.NoError(t, err)
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 10*time.Second)
+
+	for _, sub := range []string{"repo1", "repo2"} {
+		marker := filepath.Join(service.sessionsRoot, "parallel-install", sub, "dep-installed")
+		_, statErr := os.Stat(marker)
+		require.NoError(t, statErr, "install_deps should have run in %s", sub)
+	}
+
+	steps, err := service.setupStepStore.ListBySessionID(sess.ID)
+	require.NoError(t, err)
+	installCount := 0
+	for _, s := range steps {
+		if s.Kind == StepKindInstallDeps {
+			installCount++
+			require.Equal(t, SetupStepDone, s.Status)
+		}
+	}
+	require.Equal(t, 2, installCount, "one install_deps step per workspace")
+}
+
+func TestSessionService_ConfigAction_CopyFailsInstallContinues(t *testing.T) {
+	repoPath := initTestRepo(t)
+	pmScript := filepath.Join(t.TempDir(), "fake-pm")
+	writeScript(t, pmScript, "#!/bin/sh\ntouch dep-installed\n")
+	writeWorkspaceConfig(t, repoPath, `{
+		"setup_actions": [
+			{"type": "copy_file", "src": "does-not-exist", "dest": ".env", "dest_relative_to": "workspace_dir"},
+			{"type": "install_deps", "package_manager": "`+pmScript+`"}
+		]
+	}`)
+
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	sess, err := service.CreateSession(context.Background(), CreateSessionInput{
+		Name:       "copy-fail",
+		Workspaces: []WorkspaceBranchSpec{{WorkspaceID: wsGitID, BaseBranch: "main"}},
+	})
+	require.NoError(t, err)
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 5*time.Second)
+
+	final, err := sessionStore.GetByID(sess.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusActive, final.Status)
+	require.NotEmpty(t, final.StatusError, "failed copy should surface as a warning")
+
+	steps, err := service.setupStepStore.ListBySessionID(sess.ID)
+	require.NoError(t, err)
+	copyStep := stepByKind(t, steps, StepKindCopyFile)
+	require.NotNil(t, copyStep)
+	require.Equal(t, SetupStepFailed, copyStep.Status)
+
+	installStep := stepByKind(t, steps, StepKindInstallDeps)
+	require.NotNil(t, installStep)
+	require.Equal(t, SetupStepDone, installStep.Status, "install_deps should still run after a failed copy_file")
+
+	marker := filepath.Join(service.sessionsRoot, "copy-fail", "git-repo", "dep-installed")
+	_, statErr := os.Stat(marker)
+	require.NoError(t, statErr)
+}
+
+func TestSessionService_RepairSession_StepsReset(t *testing.T) {
+	repoPath := initTestRepo(t)
+	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
+
+	sess, err := service.CreateSession(context.Background(), CreateSessionInput{
+		Name:       "repair-steps",
+		Workspaces: []WorkspaceBranchSpec{{WorkspaceID: wsGitID, BaseBranch: "main"}},
+	})
+	require.NoError(t, err)
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 5*time.Second)
+
+	before, err := service.setupStepStore.ListBySessionID(sess.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, before)
+
+	reloaded, err := sessionStore.GetByID(sess.ID)
+	require.NoError(t, err)
+	reloaded.Status = StatusBroken
+	reloaded.StatusError = "forced for test"
+	require.NoError(t, sessionStore.Update(reloaded))
+
+	_, err = service.RepairSession(context.Background(), sess.ID)
+	require.NoError(t, err)
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 5*time.Second)
+
+	after, err := service.setupStepStore.ListBySessionID(sess.ID)
+	require.NoError(t, err)
+	require.Len(t, after, len(before), "repair should not change step count")
+	for _, s := range after {
+		require.Equal(t, SetupStepDone, s.Status, "step %q should be done after repair", s.Label)
+	}
+}

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -47,7 +47,7 @@ func setupSessionService(t *testing.T) (*SessionService, *SessionStore, *workspa
 	sessionWorktreeStore := NewSessionWorktreeStore(database)
 	configDir := t.TempDir()
 	sessionsRoot := t.TempDir()
-	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, workspaceService, gitService, tmuxService, bus, "eqt/", configDir, sessionsRoot)
+	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, NewSessionSetupStepStore(database), workspaceService, gitService, tmuxService, bus, "eqt/", configDir, sessionsRoot)
 	return service, sessionStore, workspaceStore, mock, ws1.ID, ws2.ID
 }
 
@@ -541,7 +541,7 @@ func setupWorktreeSessionServiceFull(t *testing.T, repoPath string, configDir st
 	dismissedPRStore := NewDismissedPRStore(database)
 	sessionActionStore := NewSessionActionStore(database)
 	sessionWorktreeStore := NewSessionWorktreeStore(database)
-	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, workspaceService, gitService, tmuxService, bus, "eqt/", configDir, t.TempDir())
+	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, NewSessionSetupStepStore(database), workspaceService, gitService, tmuxService, bus, "eqt/", configDir, t.TempDir())
 	return service, sessionStore, mock, wsGit.ID, database, gitService
 }
 
@@ -783,7 +783,7 @@ func TestSessionService_RefreshSession_AllHealthy(t *testing.T) {
 	gitService := git.NewGitService(database)
 	workspaceService := workspace.NewWorkspaceService(workspaceStore, gitService)
 	swtStore := NewSessionWorktreeStore(database)
-	service := NewSessionService(sessionStore, swtStore, NewDismissedPRStore(database), NewSessionActionStore(database), workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir(), t.TempDir())
+	service := NewSessionService(sessionStore, swtStore, NewDismissedPRStore(database), NewSessionActionStore(database), NewSessionSetupStepStore(database), workspaceService, gitService, tmuxService, bus, "eqt/", t.TempDir(), t.TempDir())
 
 	ts := &utmux.TmuxSession{Name: "utena-session-1", StartDir: "/tmp/utena", Status: utmux.TmuxStatusActive}
 	require.NoError(t, database.Create(ts).Error)
@@ -1072,7 +1072,7 @@ func setupBareWorktreeSessionService(t *testing.T, configDir string) (*SessionSe
 	dismissedPRStore := NewDismissedPRStore(database)
 	sessionActionStore := NewSessionActionStore(database)
 	sessionWorktreeStore := NewSessionWorktreeStore(database)
-	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, workspaceService, gitService, tmuxService, bus, "eqt/", configDir, t.TempDir())
+	service := NewSessionService(sessionStore, sessionWorktreeStore, dismissedPRStore, sessionActionStore, NewSessionSetupStepStore(database), workspaceService, gitService, tmuxService, bus, "eqt/", configDir, t.TempDir())
 	return service, sessionStore, mock, wsGit.ID, repoPath
 }
 

--- a/internal/session/sessionsetupstep.go
+++ b/internal/session/sessionsetupstep.go
@@ -1,0 +1,75 @@
+package session
+
+import (
+	"github.com/eleonorayaya/utena/internal/db"
+	"gorm.io/gorm"
+)
+
+type SetupStepStatus string
+
+const (
+	SetupStepPending SetupStepStatus = "pending"
+	SetupStepRunning SetupStepStatus = "running"
+	SetupStepDone    SetupStepStatus = "done"
+	SetupStepFailed  SetupStepStatus = "failed"
+)
+
+type SetupStepKind string
+
+const (
+	StepKindCreateSessionDir SetupStepKind = "create_session_dir"
+	StepKindSetupWorktree    SetupStepKind = "setup_worktree"
+	StepKindCopyFile         SetupStepKind = "copy_file"
+	StepKindInstallDeps      SetupStepKind = "install_deps"
+	StepKindApplyClaude      SetupStepKind = "apply_claude"
+	StepKindSetupTmux        SetupStepKind = "setup_tmux"
+)
+
+type SessionSetupStep struct {
+	gorm.Model
+	SessionID   uint            `json:"session_id" gorm:"index;not null"`
+	Position    int             `json:"position" gorm:"not null"`
+	Kind        SetupStepKind   `json:"kind" gorm:"not null"`
+	WorkspaceID *uint           `json:"workspace_id,omitempty" gorm:"index"`
+	DependsOnID *uint           `json:"depends_on_id,omitempty" gorm:"index"`
+	Label       string          `json:"label" gorm:"not null"`
+	Status      SetupStepStatus `json:"status" gorm:"not null;default:'pending'"`
+	ErrorMsg    string          `json:"error_msg,omitempty" gorm:"type:text"`
+}
+
+type SessionSetupStepStore struct {
+	db db.Database
+}
+
+func NewSessionSetupStepStore(database db.Database) *SessionSetupStepStore {
+	return &SessionSetupStepStore{db: database}
+}
+
+func (s *SessionSetupStepStore) Create(steps []*SessionSetupStep) error {
+	if len(steps) == 0 {
+		return nil
+	}
+	return s.db.Create(steps).Error
+}
+
+func (s *SessionSetupStepStore) Update(step *SessionSetupStep) error {
+	return s.db.Save(step).Error
+}
+
+func (s *SessionSetupStepStore) ListBySessionID(sessionID uint) ([]*SessionSetupStep, error) {
+	var steps []*SessionSetupStep
+	if err := s.db.Where("session_id = ?", sessionID).Order("position ASC").Find(&steps).Error; err != nil {
+		return nil, err
+	}
+	return steps, nil
+}
+
+func (s *SessionSetupStepStore) DeleteBySessionID(sessionID uint) error {
+	return s.db.Where("session_id = ?", sessionID).Delete(&SessionSetupStep{}).Error
+}
+
+func (s *SessionSetupStepStore) ResetAllForSession(sessionID uint) error {
+	return s.db.Model(&SessionSetupStep{}).
+		Where("session_id = ?", sessionID).
+		Updates(map[string]any{"status": SetupStepPending, "error_msg": ""}).Error
+}

--- a/internal/session/sessionsetupstep_test.go
+++ b/internal/session/sessionsetupstep_test.go
@@ -1,0 +1,84 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/eleonorayaya/utena/internal/db/testdb"
+	"github.com/stretchr/testify/require"
+)
+
+func newSetupStepStore(t *testing.T) *SessionSetupStepStore {
+	t.Helper()
+	database := testdb.New(t, &SessionSetupStep{})
+	return NewSessionSetupStepStore(database)
+}
+
+func TestSessionSetupStepStore_CreateAndList(t *testing.T) {
+	store := newSetupStepStore(t)
+
+	steps := []*SessionSetupStep{
+		{SessionID: 7, Position: 0, Kind: StepKindCreateSessionDir, Label: "Create session directory", Status: SetupStepPending},
+		{SessionID: 7, Position: 1, Kind: StepKindSetupWorktree, Label: "Setup workspace: a", Status: SetupStepPending},
+	}
+	require.NoError(t, store.Create(steps))
+	require.NotZero(t, steps[0].ID)
+	require.NotZero(t, steps[1].ID)
+
+	listed, err := store.ListBySessionID(7)
+	require.NoError(t, err)
+	require.Len(t, listed, 2)
+	require.Equal(t, 0, listed[0].Position)
+	require.Equal(t, 1, listed[1].Position)
+	require.Equal(t, StepKindCreateSessionDir, listed[0].Kind)
+}
+
+func TestSessionSetupStepStore_Update(t *testing.T) {
+	store := newSetupStepStore(t)
+	step := &SessionSetupStep{SessionID: 1, Position: 0, Kind: StepKindSetupTmux, Label: "Setup tmux", Status: SetupStepPending}
+	require.NoError(t, store.Create([]*SessionSetupStep{step}))
+
+	step.Status = SetupStepFailed
+	step.ErrorMsg = "boom"
+	require.NoError(t, store.Update(step))
+
+	listed, err := store.ListBySessionID(1)
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	require.Equal(t, SetupStepFailed, listed[0].Status)
+	require.Equal(t, "boom", listed[0].ErrorMsg)
+}
+
+func TestSessionSetupStepStore_ResetAllForSession(t *testing.T) {
+	store := newSetupStepStore(t)
+	dep := uint(99)
+	steps := []*SessionSetupStep{
+		{SessionID: 3, Position: 0, Kind: StepKindCreateSessionDir, Label: "dir", Status: SetupStepDone},
+		{SessionID: 3, Position: 1, Kind: StepKindSetupWorktree, Label: "ws", Status: SetupStepFailed, ErrorMsg: "x", DependsOnID: &dep},
+	}
+	require.NoError(t, store.Create(steps))
+
+	require.NoError(t, store.ResetAllForSession(3))
+
+	listed, err := store.ListBySessionID(3)
+	require.NoError(t, err)
+	require.Len(t, listed, 2)
+	for _, s := range listed {
+		require.Equal(t, SetupStepPending, s.Status)
+		require.Empty(t, s.ErrorMsg)
+	}
+	require.NotNil(t, listed[1].DependsOnID, "ResetAllForSession must preserve DependsOnID")
+	require.Equal(t, uint(99), *listed[1].DependsOnID)
+}
+
+func TestSessionSetupStepStore_DeleteBySessionID(t *testing.T) {
+	store := newSetupStepStore(t)
+	require.NoError(t, store.Create([]*SessionSetupStep{
+		{SessionID: 5, Position: 0, Kind: StepKindCreateSessionDir, Label: "dir", Status: SetupStepPending},
+	}))
+
+	require.NoError(t, store.DeleteBySessionID(5))
+
+	listed, err := store.ListBySessionID(5)
+	require.NoError(t, err)
+	require.Empty(t, listed)
+}

--- a/internal/session/sessionstore.go
+++ b/internal/session/sessionstore.go
@@ -26,6 +26,9 @@ func (s *SessionStore) loaded() *gorm.DB {
 		Joins("TmuxSession").
 		Preload("ClaudeSessions").
 		Preload("SessionActions").
+		Preload("SetupSteps", func(db *gorm.DB) *gorm.DB {
+			return db.Order("session_setup_steps.position ASC")
+		}).
 		Preload("Worktrees", func(db *gorm.DB) *gorm.DB {
 			return db.Order("session_worktrees.position ASC")
 		}).

--- a/internal/session/sessionstore_test.go
+++ b/internal/session/sessionstore_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func setupTestDB(t *testing.T) db.Database {
-	return testdb.New(t, &workspace.Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}, &utmux.TmuxSession{}, &Session{}, &SessionWorktree{}, &claude.ClaudeSession{}, &SessionAction{})
+	return testdb.New(t, &workspace.Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}, &utmux.TmuxSession{}, &Session{}, &SessionWorktree{}, &claude.ClaudeSession{}, &SessionAction{}, &SessionSetupStep{})
 }
 
 func setupSessionStore(t *testing.T) (*SessionStore, uint, uint) {
@@ -367,7 +367,7 @@ func TestSessionStore_OnAppEnd(t *testing.T) {
 
 func setupTestDBWithGitAndTmux(t *testing.T) (db.Database, uint, *git.Branch, *utmux.TmuxSession) {
 	t.Helper()
-	database := testdb.New(t, &workspace.Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}, &utmux.TmuxSession{}, &Session{}, &SessionWorktree{}, &claude.ClaudeSession{}, &SessionAction{})
+	database := testdb.New(t, &workspace.Workspace{}, &git.Repo{}, &git.Branch{}, &git.Worktree{}, &git.PullRequest{}, &utmux.TmuxSession{}, &Session{}, &SessionWorktree{}, &claude.ClaudeSession{}, &SessionAction{}, &SessionSetupStep{})
 
 	repo := &git.Repo{Path: "/tmp/utena", FullName: "eleonorayaya/utena"}
 	database.Create(repo)

--- a/internal/session/setupexecutor.go
+++ b/internal/session/setupexecutor.go
@@ -1,0 +1,444 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/eleonorayaya/utena/internal/workspace"
+)
+
+func assignedToStepWorkspaces(assigned []assignedSlot) []stepWorkspace {
+	out := make([]stepWorkspace, len(assigned))
+	for i, a := range assigned {
+		out[i] = stepWorkspace{ID: a.ws.ID, Name: a.ws.Name, Path: a.ws.Path}
+	}
+	return out
+}
+
+func (s *SessionService) loadWorkspaceConfigs(wss []stepWorkspace) map[uint]*WorkspaceConfig {
+	configs := make(map[uint]*WorkspaceConfig, len(wss))
+	for _, ws := range wss {
+		cfg, err := loadWorkspaceConfig(ws.Path)
+		if err != nil {
+			slog.Warn("failed to load workspace config", "ws", ws.Name, "path", ws.Path, "error", err)
+		}
+		configs[ws.ID] = cfg
+	}
+	return configs
+}
+
+func newSetupStep(sessionID uint, pos int, d stepDef) *SessionSetupStep {
+	return &SessionSetupStep{
+		SessionID:   sessionID,
+		Position:    pos,
+		Kind:        d.Kind,
+		WorkspaceID: d.WorkspaceID,
+		Label:       d.Label,
+		Status:      SetupStepPending,
+	}
+}
+
+func (s *SessionService) persistSetupSteps(sessionID uint, defs []stepDef) ([]*SessionSetupStep, error) {
+	steps := make([]*SessionSetupStep, len(defs))
+	for i, d := range defs {
+		steps[i] = newSetupStep(sessionID, i, d)
+	}
+	if err := s.setupStepStore.Create(steps); err != nil {
+		return nil, err
+	}
+	for i, d := range defs {
+		if d.DependsOnPos == nil {
+			continue
+		}
+		depID := steps[*d.DependsOnPos].ID
+		steps[i].DependsOnID = &depID
+		if err := s.setupStepStore.Update(steps[i]); err != nil {
+			return nil, err
+		}
+	}
+	return steps, nil
+}
+
+func stepsMatchDefs(steps []*SessionSetupStep, defs []stepDef) bool {
+	if len(steps) != len(defs) {
+		return false
+	}
+	for i := range defs {
+		if steps[i].Kind != defs[i].Kind {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *SessionService) ensureSetupSteps(sessionID uint, defs []stepDef) []*SessionSetupStep {
+	existing, err := s.setupStepStore.ListBySessionID(sessionID)
+	if err == nil && stepsMatchDefs(existing, defs) {
+		if resetErr := s.setupStepStore.ResetAllForSession(sessionID); resetErr != nil {
+			slog.Warn("failed to reset setup steps", "session", sessionID, "error", resetErr)
+		}
+		for _, st := range existing {
+			st.Status = SetupStepPending
+			st.ErrorMsg = ""
+		}
+		return existing
+	}
+
+	if err == nil && len(existing) > 0 {
+		if delErr := s.setupStepStore.DeleteBySessionID(sessionID); delErr != nil {
+			slog.Warn("failed to delete stale setup steps", "session", sessionID, "error", delErr)
+		}
+	}
+
+	steps, createErr := s.persistSetupSteps(sessionID, defs)
+	if createErr != nil {
+		slog.Warn("failed to persist setup steps; progress tracking disabled for session", "session", sessionID, "error", createErr)
+		steps = make([]*SessionSetupStep, len(defs))
+		for i, d := range defs {
+			steps[i] = newSetupStep(sessionID, i, d)
+		}
+	}
+	return steps
+}
+
+type stepUpdater struct {
+	store *SessionSetupStepStore
+	mu    sync.Mutex
+}
+
+func (u *stepUpdater) set(step *SessionSetupStep, status SetupStepStatus, errMsg string) {
+	step.Status = status
+	step.ErrorMsg = errMsg
+	if step.ID == 0 {
+		return
+	}
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if err := u.store.Update(step); err != nil {
+		slog.Warn("failed to update setup step status", "step", step.ID, "status", status, "error", err)
+	}
+}
+
+type execStep struct {
+	def stepDef
+	db  *SessionSetupStep
+}
+
+type setupExecution struct {
+	svc       *SessionService
+	sess      *Session
+	tmuxName  string
+	execSteps []execStep
+	orderedWS []stepWorkspace
+	specByWS  map[uint]WorkspaceBranchSpec
+	wsByID    map[uint]*workspace.Workspace
+	swtByID   map[uint]*SessionWorktree
+	updater   *stepUpdater
+
+	mu          sync.Mutex
+	results     map[uint]*worktreeSetupResult
+	warnings    []string
+	broken      bool
+	brokenStage string
+	brokenErr   error
+}
+
+func isTerminalStatus(status SetupStepStatus) bool {
+	return status == SetupStepDone || status == SetupStepFailed
+}
+
+func (e *setupExecution) addWarning(msg string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.warnings = append(e.warnings, msg)
+}
+
+func (e *setupExecution) setResult(wsID uint, r *worktreeSetupResult) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.results[wsID] = r
+}
+
+func (e *setupExecution) anyWorktreeCreated() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, r := range e.results {
+		if r != nil && r.created {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *setupExecution) getResult(wsID uint) *worktreeSetupResult {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.results[wsID]
+}
+
+func (e *setupExecution) setBroken(stage string, err error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.broken {
+		return
+	}
+	e.broken = true
+	e.brokenStage = stage
+	e.brokenErr = err
+}
+
+func (e *setupExecution) isBroken() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.broken
+}
+
+func (e *setupExecution) ready(idx int) bool {
+	es := e.execSteps[idx]
+	if es.db.Status != SetupStepPending {
+		return false
+	}
+	switch {
+	case es.def.Kind == StepKindCreateSessionDir:
+		return true
+	case es.def.Kind == StepKindApplyClaude && es.def.DependsOnPos == nil:
+		for i := range e.execSteps {
+			o := e.execSteps[i]
+			if o.def.WorkspaceID != nil && !isTerminalStatus(o.db.Status) {
+				return false
+			}
+		}
+		return true
+	case es.def.DependsOnPos != nil:
+		dep := e.execSteps[*es.def.DependsOnPos]
+		return isTerminalStatus(dep.db.Status)
+	default:
+		return false
+	}
+}
+
+func (e *setupExecution) run(ctx context.Context) {
+	execCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for {
+		if execCtx.Err() != nil {
+			return
+		}
+
+		var ready []int
+		for i := range e.execSteps {
+			if e.ready(i) {
+				ready = append(ready, i)
+			}
+		}
+		if len(ready) == 0 {
+			return
+		}
+
+		var wg sync.WaitGroup
+		for _, idx := range ready {
+			es := &e.execSteps[idx]
+			e.updater.set(es.db, SetupStepRunning, "")
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				critical, err := e.executeStep(execCtx, es.def)
+				if err != nil {
+					e.updater.set(es.db, SetupStepFailed, err.Error())
+					if critical {
+						e.setBroken(string(es.def.Kind), err)
+						cancel()
+					} else {
+						e.addWarning(err.Error())
+					}
+					return
+				}
+				e.updater.set(es.db, SetupStepDone, "")
+			}()
+		}
+		wg.Wait()
+
+		if e.isBroken() {
+			return
+		}
+	}
+}
+
+func (e *setupExecution) executeStep(ctx context.Context, def stepDef) (bool, error) {
+	switch def.Kind {
+	case StepKindCreateSessionDir:
+		if e.sess.SessionRoot != "" {
+			if err := os.MkdirAll(e.sess.SessionRoot, 0o755); err != nil {
+				return true, fmt.Errorf("ensure session root: %w", err)
+			}
+		}
+		return false, nil
+	case StepKindSetupWorktree:
+		return e.execSetupWorktree(ctx, def)
+	case StepKindCopyFile:
+		return false, e.execCopyFile(def)
+	case StepKindInstallDeps:
+		return false, e.execInstallDeps(ctx, def)
+	case StepKindApplyClaude:
+		return false, e.execApplyClaude(ctx)
+	case StepKindSetupTmux:
+		if err := e.svc.setupTmux(ctx, e.sess, e.tmuxName, e.sess.SessionRoot); err != nil {
+			return true, fmt.Errorf("tmux setup: %w", err)
+		}
+		return false, nil
+	}
+	return false, nil
+}
+
+func (e *setupExecution) execSetupWorktree(ctx context.Context, def stepDef) (bool, error) {
+	wsID := *def.WorkspaceID
+	ws := e.wsByID[wsID]
+	swt := e.swtByID[wsID]
+
+	result, err := e.svc.setupSingleWorktree(ctx, e.sess, swt, ws, e.specByWS[wsID])
+	if err != nil {
+		return true, fmt.Errorf("worktree setup: %w", err)
+	}
+	if result.warning != "" {
+		e.addWarning(fmt.Sprintf("%s: %s", ws.Name, result.warning))
+	}
+	e.setResult(wsID, &result)
+
+	if result.created {
+		branchName := ""
+		if result.branch != nil {
+			branchName = result.branch.Name
+		}
+		env := []string{
+			envSessionRoot + "=" + e.sess.SessionRoot,
+			envSessionName + "=" + e.sess.Name,
+			envBranch + "=" + branchName,
+			envWorktreePath + "=" + result.worktreePath,
+			envWorkspaceName + "=" + ws.Name,
+			envWorkspacePath + "=" + ws.Path,
+		}
+		wsScript := filepath.Join(ws.Path, ".utena", worktreeSetupName)
+		if scriptErr := traceOp(ctx, "worktree-setup script", func() error {
+			return e.svc.runScript(ctx, wsScript, result.worktreePath, env)
+		}, "script", wsScript, "ws", ws.Name); scriptErr != nil {
+			slog.WarnContext(ctx, "workspace worktree-setup script failed", "ws", ws.Name, "error", scriptErr)
+			e.addWarning(fmt.Sprintf("%s: %s", ws.Name, scriptErr.Error()))
+		}
+	}
+	return false, nil
+}
+
+func (e *setupExecution) execCopyFile(def stepDef) error {
+	wsID := *def.WorkspaceID
+	ws := e.wsByID[wsID]
+	result := e.getResult(wsID)
+	worktreePath := ""
+	if result != nil {
+		worktreePath = result.worktreePath
+	}
+
+	if err := validateRelPath(def.CopySrc); err != nil {
+		return fmt.Errorf("copy_file src %q: %w", def.CopySrc, err)
+	}
+	if err := validateRelPath(def.CopyDest); err != nil {
+		return fmt.Errorf("copy_file dest %q: %w", def.CopyDest, err)
+	}
+
+	base := worktreePath
+	if def.CopyDestRelTo == DestRelativeToSessionRoot {
+		base = e.sess.SessionRoot
+	}
+	if base == "" {
+		return fmt.Errorf("copy_file %q: destination base path unavailable", def.CopyDest)
+	}
+
+	srcPath := filepath.Join(ws.Path, def.CopySrc)
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("copy_file source not found: %s", srcPath)
+		}
+		return fmt.Errorf("copy_file read %s: %w", srcPath, err)
+	}
+
+	destPath := filepath.Join(base, def.CopyDest)
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("copy_file mkdir %s: %w", filepath.Dir(destPath), err)
+	}
+	if err := os.WriteFile(destPath, data, 0o644); err != nil {
+		return fmt.Errorf("copy_file write %s: %w", destPath, err)
+	}
+	return nil
+}
+
+func (e *setupExecution) execInstallDeps(ctx context.Context, def stepDef) error {
+	wsID := *def.WorkspaceID
+	result := e.getResult(wsID)
+	if result == nil || result.worktreePath == "" {
+		return fmt.Errorf("install_deps: worktree path unavailable")
+	}
+	worktreePath := result.worktreePath
+
+	pm := def.PackageManager
+	if pm == "" || pm == packageManagerAuto {
+		pm = detectPackageManager(worktreePath)
+	}
+
+	return traceOp(ctx, "install_deps", func() error {
+		cmd := exec.CommandContext(ctx, pm, "install")
+		cmd.Dir = worktreePath
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("%s install failed: %s: %w", pm, strings.TrimSpace(string(output)), err)
+		}
+		return nil
+	}, "pm", pm, "dir", worktreePath)
+}
+
+func (e *setupExecution) execApplyClaude(ctx context.Context) error {
+	if e.anyWorktreeCreated() {
+		globalBranch := ""
+		if len(e.orderedWS) > 0 {
+			if r := e.getResult(e.orderedWS[0].ID); r != nil && r.branch != nil {
+				globalBranch = r.branch.Name
+			}
+		}
+		globalEnv := []string{
+			envSessionRoot + "=" + e.sess.SessionRoot,
+			envSessionName + "=" + e.sess.Name,
+			envBranch + "=" + globalBranch,
+		}
+		globalScript := filepath.Join(e.svc.configDir, worktreeSetupName)
+		if err := traceOp(ctx, "global worktree-setup script", func() error {
+			return e.svc.runScript(ctx, globalScript, e.sess.SessionRoot, globalEnv)
+		}, "script", globalScript); err != nil {
+			slog.WarnContext(ctx, "global worktree-setup script failed", "error", err)
+			e.addWarning(fmt.Sprintf("global: %s", err.Error()))
+		}
+	}
+
+	for _, w := range e.svc.applyClaudeSettings(ctx, e.sess) {
+		e.addWarning(w)
+	}
+	return nil
+}
+
+func validateRelPath(p string) error {
+	if p == "" {
+		return fmt.Errorf("path is empty")
+	}
+	if filepath.IsAbs(p) {
+		return fmt.Errorf("path must be relative")
+	}
+	if strings.Contains(p, "..") {
+		return fmt.Errorf("path must not contain '..'")
+	}
+	return nil
+}

--- a/internal/session/setupstepdefinition.go
+++ b/internal/session/setupstepdefinition.go
@@ -1,0 +1,92 @@
+package session
+
+import "fmt"
+
+type stepWorkspace struct {
+	ID   uint
+	Name string
+	Path string
+}
+
+type stepDef struct {
+	Kind         SetupStepKind
+	Label        string
+	WorkspaceID  *uint
+	DependsOnPos *int
+
+	CopySrc       string
+	CopyDest      string
+	CopyDestRelTo DestRelativeTo
+
+	PackageManager string
+}
+
+func intPtr(i int) *int    { return &i }
+func uintPtr(u uint) *uint { return &u }
+
+func buildSetupSteps(workspaces []stepWorkspace, configs map[uint]*WorkspaceConfig) []stepDef {
+	defs := make([]stepDef, 0, len(workspaces)*2+3)
+
+	defs = append(defs, stepDef{Kind: StepKindCreateSessionDir, Label: "Create session directory"})
+	sessionDirPos := 0
+
+	for _, ws := range workspaces {
+		defs = append(defs, stepDef{
+			Kind:         StepKindSetupWorktree,
+			Label:        fmt.Sprintf("Setup workspace: %s", ws.Name),
+			WorkspaceID:  uintPtr(ws.ID),
+			DependsOnPos: intPtr(sessionDirPos),
+		})
+		lastPos := len(defs) - 1
+
+		cfg := configs[ws.ID]
+		if cfg == nil {
+			continue
+		}
+
+		for _, action := range cfg.SetupActions {
+			if action.Type != WorkspaceActionCopyFile {
+				continue
+			}
+			defs = append(defs, stepDef{
+				Kind:          StepKindCopyFile,
+				Label:         fmt.Sprintf("Copy %s → %s", action.Src, action.Dest),
+				WorkspaceID:   uintPtr(ws.ID),
+				DependsOnPos:  intPtr(lastPos),
+				CopySrc:       action.Src,
+				CopyDest:      action.Dest,
+				CopyDestRelTo: action.DestRelativeTo,
+			})
+			lastPos = len(defs) - 1
+		}
+
+		for _, action := range cfg.SetupActions {
+			if action.Type != WorkspaceActionInstallDeps {
+				continue
+			}
+			label := fmt.Sprintf("Install dependencies: %s", ws.Name)
+			if action.PackageManager != "" && action.PackageManager != packageManagerAuto {
+				label = fmt.Sprintf("Install dependencies: %s (%s)", ws.Name, action.PackageManager)
+			}
+			defs = append(defs, stepDef{
+				Kind:           StepKindInstallDeps,
+				Label:          label,
+				WorkspaceID:    uintPtr(ws.ID),
+				DependsOnPos:   intPtr(lastPos),
+				PackageManager: action.PackageManager,
+			})
+			lastPos = len(defs) - 1
+		}
+	}
+
+	defs = append(defs, stepDef{Kind: StepKindApplyClaude, Label: "Apply Claude settings"})
+	applyClaudePos := len(defs) - 1
+
+	defs = append(defs, stepDef{
+		Kind:         StepKindSetupTmux,
+		Label:        "Setup tmux",
+		DependsOnPos: intPtr(applyClaudePos),
+	})
+
+	return defs
+}

--- a/internal/session/setupstepdefinition_test.go
+++ b/internal/session/setupstepdefinition_test.go
@@ -1,0 +1,108 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func kinds(defs []stepDef) []SetupStepKind {
+	out := make([]SetupStepKind, len(defs))
+	for i, d := range defs {
+		out[i] = d.Kind
+	}
+	return out
+}
+
+func TestBuildSetupSteps_SingleWorkspaceNoConfig(t *testing.T) {
+	defs := buildSetupSteps([]stepWorkspace{{ID: 1, Name: "a", Path: "/a"}}, nil)
+
+	require.Equal(t, []SetupStepKind{
+		StepKindCreateSessionDir,
+		StepKindSetupWorktree,
+		StepKindApplyClaude,
+		StepKindSetupTmux,
+	}, kinds(defs))
+
+	require.Nil(t, defs[0].DependsOnPos)
+	require.Equal(t, 0, *defs[1].DependsOnPos)
+	require.Nil(t, defs[2].DependsOnPos, "apply_claude has no explicit dependency")
+	require.Equal(t, 2, *defs[3].DependsOnPos, "setup_tmux depends on apply_claude")
+}
+
+func TestBuildSetupSteps_CopyFilesChain(t *testing.T) {
+	configs := map[uint]*WorkspaceConfig{
+		1: {SetupActions: []WorkspaceSetupAction{
+			{Type: WorkspaceActionCopyFile, Src: ".env.example", Dest: ".env", DestRelativeTo: DestRelativeToWorkspaceDir},
+			{Type: WorkspaceActionCopyFile, Src: "a", Dest: "b"},
+		}},
+	}
+	defs := buildSetupSteps([]stepWorkspace{{ID: 1, Name: "a"}}, configs)
+
+	require.Equal(t, []SetupStepKind{
+		StepKindCreateSessionDir,
+		StepKindSetupWorktree,
+		StepKindCopyFile,
+		StepKindCopyFile,
+		StepKindApplyClaude,
+		StepKindSetupTmux,
+	}, kinds(defs))
+
+	require.Equal(t, 1, *defs[2].DependsOnPos, "first copy depends on setup_worktree")
+	require.Equal(t, 2, *defs[3].DependsOnPos, "second copy depends on first copy")
+	require.Equal(t, ".env.example", defs[2].CopySrc)
+	require.Equal(t, DestRelativeToWorkspaceDir, defs[2].CopyDestRelTo)
+}
+
+func TestBuildSetupSteps_InstallDepsAfterCopy(t *testing.T) {
+	configs := map[uint]*WorkspaceConfig{
+		1: {SetupActions: []WorkspaceSetupAction{
+			{Type: WorkspaceActionInstallDeps, PackageManager: packageManagerAuto},
+			{Type: WorkspaceActionCopyFile, Src: ".env.example", Dest: ".env"},
+		}},
+	}
+	defs := buildSetupSteps([]stepWorkspace{{ID: 1, Name: "a"}}, configs)
+
+	require.Equal(t, []SetupStepKind{
+		StepKindCreateSessionDir,
+		StepKindSetupWorktree,
+		StepKindCopyFile,
+		StepKindInstallDeps,
+		StepKindApplyClaude,
+		StepKindSetupTmux,
+	}, kinds(defs), "copy_file always emitted before install_deps regardless of config order")
+
+	require.Equal(t, 1, *defs[2].DependsOnPos, "copy depends on setup_worktree")
+	require.Equal(t, 2, *defs[3].DependsOnPos, "install_deps depends on the copy_file")
+}
+
+func TestBuildSetupSteps_MultiWorkspaceParallelChains(t *testing.T) {
+	defs := buildSetupSteps([]stepWorkspace{
+		{ID: 1, Name: "a"},
+		{ID: 2, Name: "b"},
+	}, nil)
+
+	require.Equal(t, []SetupStepKind{
+		StepKindCreateSessionDir,
+		StepKindSetupWorktree,
+		StepKindSetupWorktree,
+		StepKindApplyClaude,
+		StepKindSetupTmux,
+	}, kinds(defs))
+
+	require.Equal(t, 0, *defs[1].DependsOnPos, "workspace a setup depends on session dir")
+	require.Equal(t, 0, *defs[2].DependsOnPos, "workspace b setup also depends on session dir (parallel)")
+	require.Equal(t, uint(1), *defs[1].WorkspaceID)
+	require.Equal(t, uint(2), *defs[2].WorkspaceID)
+	require.Nil(t, defs[3].DependsOnPos)
+}
+
+func TestBuildSetupSteps_InstallDepsLabelWithExplicitPM(t *testing.T) {
+	configs := map[uint]*WorkspaceConfig{
+		1: {SetupActions: []WorkspaceSetupAction{
+			{Type: WorkspaceActionInstallDeps, PackageManager: packageManagerYarn},
+		}},
+	}
+	defs := buildSetupSteps([]stepWorkspace{{ID: 1, Name: "web"}}, configs)
+	require.Equal(t, "Install dependencies: web (yarn)", defs[2].Label)
+}

--- a/internal/session/workspaceconfig.go
+++ b/internal/session/workspaceconfig.go
@@ -1,0 +1,65 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+type WorkspaceSetupActionType string
+
+const (
+	WorkspaceActionCopyFile    WorkspaceSetupActionType = "copy_file"
+	WorkspaceActionInstallDeps WorkspaceSetupActionType = "install_deps"
+)
+
+type DestRelativeTo string
+
+const (
+	DestRelativeToWorkspaceDir DestRelativeTo = "workspace_dir"
+	DestRelativeToSessionRoot  DestRelativeTo = "session_root"
+)
+
+const (
+	packageManagerYarn = "yarn"
+	packageManagerNpm  = "npm"
+	packageManagerAuto = "auto"
+)
+
+type WorkspaceSetupAction struct {
+	Type           WorkspaceSetupActionType `json:"type"`
+	Src            string                   `json:"src,omitempty"`
+	Dest           string                   `json:"dest,omitempty"`
+	DestRelativeTo DestRelativeTo           `json:"dest_relative_to,omitempty"`
+	PackageManager string                   `json:"package_manager,omitempty"`
+}
+
+type WorkspaceConfig struct {
+	SetupActions []WorkspaceSetupAction `json:"setup_actions"`
+}
+
+func loadWorkspaceConfig(wsPath string) (*WorkspaceConfig, error) {
+	path := filepath.Join(wsPath, ".utena", "config.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var cfg WorkspaceConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func detectPackageManager(dir string) string {
+	if _, err := os.Stat(filepath.Join(dir, "yarn.lock")); err == nil {
+		return packageManagerYarn
+	}
+	return packageManagerNpm
+}

--- a/internal/session/workspaceconfig_test.go
+++ b/internal/session/workspaceconfig_test.go
@@ -1,0 +1,64 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeWorkspaceConfig(t *testing.T, wsPath, contents string) {
+	t.Helper()
+	dir := filepath.Join(wsPath, ".utena")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte(contents), 0o644))
+}
+
+func TestLoadWorkspaceConfig_Valid(t *testing.T) {
+	wsPath := t.TempDir()
+	writeWorkspaceConfig(t, wsPath, `{
+		"setup_actions": [
+			{"type": "copy_file", "src": ".env.example", "dest": ".env", "dest_relative_to": "workspace_dir"},
+			{"type": "install_deps", "package_manager": "auto"}
+		]
+	}`)
+
+	cfg, err := loadWorkspaceConfig(wsPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.SetupActions, 2)
+
+	require.Equal(t, WorkspaceActionCopyFile, cfg.SetupActions[0].Type)
+	require.Equal(t, ".env.example", cfg.SetupActions[0].Src)
+	require.Equal(t, ".env", cfg.SetupActions[0].Dest)
+	require.Equal(t, DestRelativeToWorkspaceDir, cfg.SetupActions[0].DestRelativeTo)
+
+	require.Equal(t, WorkspaceActionInstallDeps, cfg.SetupActions[1].Type)
+	require.Equal(t, packageManagerAuto, cfg.SetupActions[1].PackageManager)
+}
+
+func TestLoadWorkspaceConfig_Missing(t *testing.T) {
+	cfg, err := loadWorkspaceConfig(t.TempDir())
+	require.NoError(t, err)
+	require.Nil(t, cfg)
+}
+
+func TestLoadWorkspaceConfig_Malformed(t *testing.T) {
+	wsPath := t.TempDir()
+	writeWorkspaceConfig(t, wsPath, `{not valid json`)
+
+	cfg, err := loadWorkspaceConfig(wsPath)
+	require.Error(t, err)
+	require.Nil(t, cfg)
+}
+
+func TestDetectPackageManager_Yarn(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "yarn.lock"), []byte(""), 0o644))
+	require.Equal(t, packageManagerYarn, detectPackageManager(dir))
+}
+
+func TestDetectPackageManager_NPM(t *testing.T) {
+	require.Equal(t, packageManagerNpm, detectPackageManager(t.TempDir()))
+}

--- a/internal/tui/sessionprogress/model.go
+++ b/internal/tui/sessionprogress/model.go
@@ -24,6 +24,9 @@ func failedStyle() lipgloss.Style { return lipgloss.NewStyle().Foreground(theme.
 func warningStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(theme.Current.AccentLavender)
 }
+func doneStyle() lipgloss.Style    { return lipgloss.NewStyle().Foreground(theme.Current.StatusReady) }
+func runningStyle() lipgloss.Style { return lipgloss.NewStyle().Foreground(theme.Current.Primary) }
+func dimStyle() lipgloss.Style     { return lipgloss.NewStyle().Foreground(theme.Current.TextMuted) }
 
 type tickMsg time.Time
 
@@ -180,8 +183,12 @@ func (m Model) View() string {
 		b.WriteString(m.spinner.View() + pendingStyle().Render(" Loading..."))
 		b.WriteString("\n")
 	} else if m.session.Status == session.StatusCreating {
-		b.WriteString(m.spinner.View() + pendingStyle().Render(" Setting up..."))
-		b.WriteString("\n")
+		if len(m.session.SetupSteps) == 0 {
+			b.WriteString(m.spinner.View() + pendingStyle().Render(" Setting up..."))
+			b.WriteString("\n")
+		} else {
+			b.WriteString(m.renderSteps())
+		}
 	}
 
 	if m.warning != "" {
@@ -198,5 +205,28 @@ func (m Model) View() string {
 		b.WriteString("\n")
 	}
 
+	return b.String()
+}
+
+func (m Model) renderSteps() string {
+	var b strings.Builder
+	for i := range m.session.SetupSteps {
+		step := m.session.SetupSteps[i]
+		switch step.Status {
+		case session.SetupStepRunning:
+			b.WriteString(runningStyle().Render(m.spinner.View() + " " + step.Label))
+		case session.SetupStepDone:
+			b.WriteString(doneStyle().Render("  ✓ " + step.Label))
+		case session.SetupStepFailed:
+			b.WriteString(failedStyle().Render("  ✗ " + step.Label))
+			if step.ErrorMsg != "" {
+				b.WriteString("\n")
+				b.WriteString(failedStyle().Render("    " + step.ErrorMsg))
+			}
+		default:
+			b.WriteString(dimStyle().Render("  ○ " + step.Label))
+		}
+		b.WriteString("\n")
+	}
 	return b.String()
 }

--- a/internal/tui/sessionprogress/model_test.go
+++ b/internal/tui/sessionprogress/model_test.go
@@ -1,0 +1,76 @@
+package sessionprogress
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eleonorayaya/utena/internal/session"
+)
+
+func creatingModelWithSteps(steps []session.SessionSetupStep) Model {
+	m := New()
+	m.session = &session.Session{
+		Name:       "demo",
+		Status:     session.StatusCreating,
+		SetupSteps: steps,
+	}
+	return m
+}
+
+func TestRenderSteps_AllStatuses(t *testing.T) {
+	m := creatingModelWithSteps([]session.SessionSetupStep{
+		{Label: "Create session directory", Status: session.SetupStepDone},
+		{Label: "Setup workspace: api", Status: session.SetupStepRunning},
+		{Label: "Install dependencies: web", Status: session.SetupStepPending},
+		{Label: "Copy .env.example → .env", Status: session.SetupStepFailed, ErrorMsg: "source not found"},
+	})
+
+	out := m.renderSteps()
+
+	for _, label := range []string{
+		"Create session directory",
+		"Setup workspace: api",
+		"Install dependencies: web",
+		"Copy .env.example → .env",
+	} {
+		if !strings.Contains(out, label) {
+			t.Errorf("expected rendered steps to contain %q\n%s", label, out)
+		}
+	}
+
+	if !strings.Contains(out, "✓") {
+		t.Errorf("expected a done glyph (✓):\n%s", out)
+	}
+	if !strings.Contains(out, "✗") {
+		t.Errorf("expected a failed glyph (✗):\n%s", out)
+	}
+	if !strings.Contains(out, "○") {
+		t.Errorf("expected a pending glyph (○):\n%s", out)
+	}
+	if !strings.Contains(out, "source not found") {
+		t.Errorf("expected failed step error message to render:\n%s", out)
+	}
+}
+
+func TestView_StepsRenderedDuringCreating(t *testing.T) {
+	m := creatingModelWithSteps([]session.SessionSetupStep{
+		{Label: "Create session directory", Status: session.SetupStepDone},
+	})
+
+	out := m.View()
+	if !strings.Contains(out, "Create session directory") {
+		t.Errorf("expected View to render the step checklist:\n%s", out)
+	}
+	if strings.Contains(out, "Setting up...") {
+		t.Errorf("expected View NOT to fall back to the spinner when steps exist:\n%s", out)
+	}
+}
+
+func TestView_FallsBackToSpinnerWithoutSteps(t *testing.T) {
+	m := creatingModelWithSteps(nil)
+
+	out := m.View()
+	if !strings.Contains(out, "Setting up...") {
+		t.Errorf("expected spinner fallback for sessions without steps:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Add per-workspace **setup actions** configured in `.utena/config.json` that run during session creation: `copy_file` (copy a file from the workspace into the session, dest relative to either `session_root` or `workspace_dir`) and `install_deps` (run `yarn`/`npm install`, with `package_manager: "auto"` detecting yarn via `yarn.lock`).
- Replace the single "Setting up…" spinner with a **live step checklist** in the TUI: every step (create dir, per-workspace worktree setup, copy/install actions, Claude settings, tmux) renders as pending `○` → running (spinner) → done `✓` / failed `✗`, driven by the existing 200ms poll. Sessions without steps fall back to the spinner.
- `SessionSetupStep` model/store is pre-populated at `CreateSession` and preloaded onto `Session` — no new endpoint. `buildSetupSteps()` is the single source of truth for step ordering and dependencies; each step carries an optional FK to its predecessor.
- A **dependency-graph executor** runs ready steps concurrently per batch, so `install_deps` across workspaces run in parallel while each workspace's `copy_file`s stay ordered before its install. Readiness uses terminal state (done *or* failed) so a failed non-critical copy doesn't deadlock its dependent install. Critical failures (session dir, worktree, tmux) cancel the batch and mark the session broken; copy/install/script failures become warnings.

## Test plan
- [ ] `task test` — green across all packages (config parsing, step store, `buildSetupSteps` ordering/deps, copy_file both dest bases, install_deps, parallel install across two workspaces, copy-fails-install-continues, repair reset, TUI rendering of all four states + spinner fallback)
- [ ] Create a session via TUI and confirm the checklist renders with live step updates instead of the spinner
- [ ] Add a `.utena/config.json` `copy_file` action and verify the file lands at the configured dest
- [ ] Add an `install_deps` action and verify `node_modules` is present in the workspace dir
- [ ] Old sessions (no steps) still render the spinner without crashing
- [ ] Repair a broken session and confirm steps reset to pending then complete

> ⚠️ Known pre-existing flake unrelated to this change: `TestSessionService_AddWorkspace_FullIntegration` intermittently fails with a `TempDir` cleanup race (the `runAddWorkspace` goroutine writes into the temp dir after the test returns). It is not a data race (verified clean under `-race`). Candidate for a separate follow-up adding a sync point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
