### PR TITLE
feat(session): archive-first lifecycle; delete only archived sessions

### DIFF
--- a/docs/plans/2026-06-21-archive-delete-rework-design.md
+++ b/docs/plans/2026-06-21-archive-delete-rework-design.md
@@ -1,0 +1,119 @@
+# Archive / Delete UX Rework — Design
+
+Date: 2026-06-21
+
+## Problem
+
+Today the session list's primary destructive action (`d`) hard-deletes any
+session, soft-deleting the row (`StatusDeleted`) while deliberately leaving the
+worktree directory on disk as a durable artifact. Archive exists but is a
+secondary, lesser-used path. We want archiving to be the primary action and
+deletion to be a deliberate, fully-cleaning second step that only applies to
+already-archived sessions.
+
+## Goals
+
+1. The primary session-list action (`d`) **archives** a live session.
+2. **Delete is only allowed on already-archived sessions** (plus a force escape
+   hatch for stuck `creating` sessions).
+3. **Delete cleans up every associated resource gracefully** — a failure on one
+   resource logs a warning and continues with the rest.
+4. **Archive** kills the tmux session but leaves all other resources alive
+   (already true today).
+5. **Archived sessions are filtered from the list by default**, with a toggle
+   key to reveal them.
+
+## Decisions (from product owner)
+
+- **Archive funnel accepts broken too.** `active`, `inactive`, `completed`, and
+  `broken` sessions can be archived. `creating`/`pending` keep their existing
+  direct escape hatches (force-delete / dismiss) — they have no real resources.
+- **Contextual single key.** `d` archives a live session; on an
+  already-archived session (visible via the toggle) `d` deletes it. A separate
+  key toggles archived visibility.
+- **Delete removes worktree directories.** Explicit delete is the one path that
+  fully tears down on-disk worktrees. This is **irreversible** — uncommitted
+  work in a worktree is lost. Branch deletion stays governed by the existing
+  `delete_branch` query flag. (This intentionally diverges, for the explicit
+  user-delete path only, from commit `ed4cc31`, which made dirs durable across
+  *reconcile / branch-change*; that path is unchanged.)
+
+## Behavior by status (the `d` key)
+
+| Status                                   | `d` action            |
+|------------------------------------------|-----------------------|
+| active / inactive / completed / broken   | Archive (confirm)     |
+| archived                                 | Delete (confirm)      |
+| creating                                 | Force-delete (confirm)|
+| pending                                  | Dismiss               |
+| attached (any)                           | Blocked               |
+
+## Service layer
+
+### `ArchiveSession`
+Add `StatusBroken` to the set of archivable statuses. Otherwise unchanged: kill
+tmux, null `TmuxSessionID`, set `StatusArchived`, clear `IsAttached`.
+
+### `DeleteSession(ctx, id, deleteBranch, force)`
+- Reject if attached (`ErrSessionAttached`).
+- Gate: allow only when `status == StatusArchived` **or** `force` (the escape
+  hatch the TUI uses for `creating`). New error `ErrSessionNotArchived`
+  ("only archived sessions can be deleted") otherwise.
+- Graceful cleanup (`cleanupSessionResources`), each step logs+continues:
+  1. Kill tmux session if `TmuxSessionID != nil`.
+  2. For each worktree: `git worktree remove --force` the dir, then
+     `CleanupBranch` (honours `deleteBranch`).
+  3. `os.RemoveAll(SessionRoot)` — guarded so it only fires for paths under
+     `sessionsRoot`.
+- Hard-delete the session row (`SessionStore.HardDelete`, `Unscoped`). FK
+  `ON DELETE CASCADE` physically removes join rows, claude sessions, actions,
+  and setup steps.
+- Then delete the now-unreferenced worktree records
+  (`GitService.DeleteWorktree`) — must come **after** the cascade so the
+  `RESTRICT` FK on `session_worktrees.worktree_id` is satisfied.
+
+### New store methods
+- `SessionStore.HardDelete(id uint) error` — `Unscoped().Delete`.
+- `GitService.DeleteWorktree(id uint) error` — wraps `worktreeStore.Delete`
+  (already a hard delete).
+
+## TUI (`internal/tui/sessionlist`)
+
+- `rebuildFiltered`: hide `StatusArchived` unless `showArchived`. (Still always
+  hide `StatusDeleted` for safety, though hard-delete makes it rare.)
+- New `showArchived` field + toggle key (`a`, "toggle archived"), mirroring the
+  existing `showBroken` / `.` pattern.
+- `Close` (`d`) handler becomes contextual per the table above, with distinct
+  confirm prompts:
+  - live → "press d again to archive <name>"
+  - archived → "press d again to delete <name> (removes worktrees)"
+  - creating → existing force-delete prompt
+  - pending → dismiss immediately
+- Provider already exposes `ArchiveSession`; a new `DismissSession` command is
+  wired to the existing `PUT /sessions/{id}/dismiss` route (needed because the
+  new delete gate would otherwise reject `pending` sessions via `d`, a
+  regression). The contextual handler dispatches archive / delete / force-delete
+  / dismiss by status.
+
+### Session detail view (`internal/tui/sessiondetail`)
+The detail view keeps its separate `a` (archive) / `d` (delete) keys, brought in
+line with the new rule: archive now also accepts `broken`; delete is a no-op
+unless the session is `archived` (or `creating`, via the force hatch).
+
+## Testing
+
+- Service: broken is archivable; delete rejects non-archived without force;
+  delete of an archived session removes worktree dir + branch and hard-deletes
+  the row (GetByID → not found); cleanup continues when tmux kill fails; force
+  still deletes a creating session.
+- Rewrite `TestSessionService_DeleteSession_PreservesWorktreeDirOnDisk` (now the
+  opposite contract) and `TestSessionService_DeleteSession` (row gone, not
+  `StatusDeleted`).
+- TUI: `d` on a live session emits archive; `d` on an archived session emits
+  delete; archived hidden by default and revealed by the toggle.
+
+## Out of scope
+
+- Reconcile / branch-change worktree durability (unchanged).
+- `pending` dismiss and `creating` force semantics (only re-routed through the
+  contextual key, logic unchanged).

--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -377,6 +377,10 @@ func (s *GitService) DeleteWorktreesByRepoID(repoID uint) error {
 	return s.worktreeStore.DeleteByRepoID(repoID)
 }
 
+func (s *GitService) DeleteWorktree(id uint) error {
+	return s.worktreeStore.Delete(id)
+}
+
 func (s *GitService) IsHealthy(ctx context.Context, branch *Branch, repoPath string) bool {
 	wt, err := s.worktreeStore.GetByBranchID(branch.ID)
 	if errors.Is(err, ErrWorktreeNotFound) {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -16,6 +16,7 @@ import (
 var ErrSessionAlreadyExists = common.NewConflict("session already exists")
 var ErrSessionNotFound = common.NewNotFound("session not found")
 var ErrSessionAttached = common.NewInvalidRequest("cannot delete attached session")
+var ErrSessionNotArchived = common.NewInvalidRequest("only archived sessions can be deleted")
 var ErrSessionNotBroken = common.NewInvalidRequest("session is not broken")
 var ErrCannotActivate = common.NewInvalidRequest("cannot activate session in current state")
 
@@ -60,6 +61,19 @@ type SessionWorktree struct {
 
 func (s *Session) IsCreating() bool {
 	return s.Status == StatusCreating
+}
+
+// CanArchive reports whether the session is in a state that can be archived:
+// any live or finished session, including broken ones.
+func (s *Session) CanArchive() bool {
+	return s.Status == StatusActive || s.Status == StatusInactive ||
+		s.Status == StatusCompleted || s.Status == StatusBroken
+}
+
+// CanDelete reports whether the session may be deleted outright. Only archived
+// sessions qualify; creating sessions have a separate force escape hatch.
+func (s *Session) CanDelete() bool {
+	return s.Status == StatusArchived
 }
 
 func (s *Session) IsMulti() bool {

--- a/internal/session/sessionrouter_test.go
+++ b/internal/session/sessionrouter_test.go
@@ -200,7 +200,7 @@ func TestSessionRouter_DeleteSession(t *testing.T) {
 
 	session := &Session{
 		Name:       "session-1",
-		Status:     StatusActive,
+		Status:     StatusArchived,
 		LastUsedAt: time.Now(),
 	}
 	addTestSession(t, sessionStore, swStore, session, ws1ID)
@@ -212,9 +212,9 @@ func TestSessionRouter_DeleteSession(t *testing.T) {
 
 	require.Equal(t, http.StatusNoContent, w.Code)
 
-	retrieved, err := sessionStore.GetByID(session.ID)
-	require.NoError(t, err)
-	require.Equal(t, StatusDeleted, retrieved.Status)
+	_, err := sessionStore.GetByID(session.ID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
 }
 
 func TestSessionRouter_RepairSession_NotFound(t *testing.T) {

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -122,7 +122,6 @@ func (s *SessionService) markLegacyLayoutSessionsBroken(sessions []Session) {
 	if s.sessionsRoot == "" {
 		return
 	}
-	prefix := s.sessionsRoot + string(filepath.Separator)
 	for i := range sessions {
 		sess := &sessions[i]
 		if sess.Status == StatusDeleted || sess.Status == StatusArchived || sess.Status == StatusBroken {
@@ -131,7 +130,7 @@ func (s *SessionService) markLegacyLayoutSessionsBroken(sessions []Session) {
 		if sess.SessionRoot == "" {
 			continue
 		}
-		if strings.HasPrefix(sess.SessionRoot, prefix) {
+		if s.sessionRootWithinRoot(sess.SessionRoot) {
 			continue
 		}
 		if err := s.markSessionBroken(sess, "session uses legacy layout — please recreate"); err != nil {
@@ -1136,12 +1135,38 @@ func (s *SessionService) DeleteSession(ctx context.Context, id uint, deleteBranc
 		return ErrSessionAttached
 	}
 
-	if session.Status == StatusCreating && !force {
-		return common.NewInvalidRequest("cannot delete session while it is being created")
+	if !force {
+		if session.IsCreating() {
+			return common.NewInvalidRequest("cannot delete session while it is being created")
+		}
+		if !session.CanDelete() {
+			return ErrSessionNotArchived
+		}
 	}
 
-	s.cleanupSessionBranches(ctx, session, deleteBranch)
+	s.cleanupSessionResources(ctx, session, deleteBranch)
 
+	if err := s.store.HardDelete(id); err != nil {
+		return err
+	}
+
+	for i := range session.Worktrees {
+		wt := session.Worktrees[i].Worktree
+		if wt == nil {
+			continue
+		}
+		if err := s.gitService.DeleteWorktree(wt.ID); err != nil {
+			slog.Warn("failed to delete worktree record", "worktree", wt.ID, "error", err)
+		}
+	}
+
+	return nil
+}
+
+// cleanupSessionResources tears down every on-disk and tmux resource a session
+// owns, continuing past individual failures so a single stuck resource doesn't
+// strand the rest of the cleanup.
+func (s *SessionService) cleanupSessionResources(ctx context.Context, session *Session, deleteBranch bool) {
 	if session.TmuxSessionID != nil {
 		if err := s.tmuxService.KillSession(*session.TmuxSessionID); err != nil {
 			slog.Warn("failed to kill tmux session", "error", err)
@@ -1149,9 +1174,52 @@ func (s *SessionService) DeleteSession(ctx context.Context, id uint, deleteBranc
 		session.TmuxSessionID = nil
 	}
 
-	session.Status = StatusDeleted
+	wsCache := make(map[uint]*workspace.Workspace)
+	for i := range session.Worktrees {
+		wt := session.Worktrees[i].Worktree
+		if wt == nil {
+			continue
+		}
+		ws, err := s.resolveWorktreeWorkspace(ctx, wt, wsCache)
+		if err != nil {
+			slog.Warn("cleanup: failed to resolve workspace", "worktree", wt.ID, "error", err)
+			continue
+		}
+		if wt.Path != "" {
+			if err := s.gitService.RemoveWorktree(ctx, ws.Path, wt.Path); err != nil {
+				slog.Warn("failed to remove worktree dir", "worktree", wt.ID, "error", err)
+			}
+		}
+		if wt.Branch != nil {
+			if err := s.gitService.CleanupBranch(ctx, wt.Branch, ws.Path, deleteBranch); err != nil {
+				slog.Warn("failed to cleanup branch", "workspace_id", ws.ID, "error", err)
+			}
+		}
+	}
 
-	return s.store.Update(session)
+	s.removeSessionRoot(session)
+}
+
+// removeSessionRoot deletes the session's container directory, but only when it
+// is safely nested under the configured sessions root, to avoid touching
+// arbitrary paths recorded on legacy sessions.
+func (s *SessionService) removeSessionRoot(session *Session) {
+	if !s.sessionRootWithinRoot(session.SessionRoot) {
+		return
+	}
+	if err := os.RemoveAll(session.SessionRoot); err != nil {
+		slog.Warn("failed to remove session root dir", "path", session.SessionRoot, "error", err)
+	}
+}
+
+// sessionRootWithinRoot reports whether sessionRoot is nested under the
+// configured sessions root, the invariant that distinguishes container-layout
+// sessions from legacy ones with arbitrary paths.
+func (s *SessionService) sessionRootWithinRoot(sessionRoot string) bool {
+	if s.sessionsRoot == "" || sessionRoot == "" {
+		return false
+	}
+	return strings.HasPrefix(sessionRoot, s.sessionsRoot+string(filepath.Separator))
 }
 
 // DetachWorktreesByRepoID drops join rows first so the worktree delete
@@ -1165,24 +1233,6 @@ func (s *SessionService) DetachWorktreesByRepoID(ctx context.Context, repoID uin
 		return fmt.Errorf("failed to delete worktrees for repo %d: %w", repoID, err)
 	}
 	return nil
-}
-
-func (s *SessionService) cleanupSessionBranches(ctx context.Context, session *Session, deleteBranch bool) {
-	wsCache := make(map[uint]*workspace.Workspace)
-	for i := range session.Worktrees {
-		wt := session.Worktrees[i].Worktree
-		if wt == nil || wt.Branch == nil {
-			continue
-		}
-		ws, err := s.resolveWorktreeWorkspace(ctx, wt, wsCache)
-		if err != nil {
-			slog.Warn("cleanup: failed to resolve workspace", "worktree", wt.ID, "error", err)
-			continue
-		}
-		if err := s.gitService.CleanupBranch(ctx, wt.Branch, ws.Path, deleteBranch); err != nil {
-			slog.Warn("failed to cleanup branch", "workspace_id", ws.ID, "error", err)
-		}
-	}
 }
 
 func (s *SessionService) nameFromBranch(branchName string) string {
@@ -1311,7 +1361,7 @@ func (s *SessionService) ArchiveSession(ctx context.Context, id uint) (*Session,
 	if err != nil {
 		return nil, err
 	}
-	if sess.Status != StatusActive && sess.Status != StatusInactive && sess.Status != StatusCompleted {
+	if !sess.CanArchive() {
 		return nil, fmt.Errorf("cannot archive session in status %s", sess.Status)
 	}
 

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -337,43 +337,81 @@ func TestSessionService_UpdateSession(t *testing.T) {
 	require.True(t, retrieved.IsAttached)
 }
 
-func TestSessionService_DeleteSession_PreservesWorktreeDirOnDisk(t *testing.T) {
+func TestSessionService_DeleteSession_RemovesWorktreeDirOnDisk(t *testing.T) {
 	repoPath := initTestRepo(t)
 	service, sessionStore, _, wsGitID := setupWorktreeSessionService(t, repoPath, t.TempDir())
 
-	session := &Session{Name: "keep-me"}
+	session := &Session{Name: "drop-me"}
 	ctx := context.Background()
 	require.NoError(t, createSessionLegacy(ctx, service, session, wsGitID, "", "main"))
 	waitForStatus(t, sessionStore, session.ID, StatusActive, 5*time.Second)
 
-	worktreePath := filepath.Join(service.sessionsRoot, "keep-me", "git-repo")
+	sessionRoot := filepath.Join(service.sessionsRoot, "drop-me")
+	worktreePath := filepath.Join(sessionRoot, "git-repo")
 	info, err := os.Stat(worktreePath)
 	require.NoError(t, err)
 	require.True(t, info.IsDir())
 
+	archived, err := service.ArchiveSession(ctx, session.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusArchived, archived.Status)
+
 	require.NoError(t, service.DeleteSession(ctx, session.ID, true, false))
 
-	info, err = os.Stat(worktreePath)
-	require.NoError(t, err, "worktree dir must survive DeleteSession")
-	require.True(t, info.IsDir())
+	_, err = os.Stat(worktreePath)
+	require.True(t, os.IsNotExist(err), "worktree dir must be removed by DeleteSession")
+	_, err = os.Stat(sessionRoot)
+	require.True(t, os.IsNotExist(err), "session root dir must be removed by DeleteSession")
 }
 
-func TestSessionService_DeleteSession(t *testing.T) {
+func TestSessionService_DeleteSession_HardDeletesArchived(t *testing.T) {
 	service, sessionStore, _, _, ws1ID, _ := setupSessionService(t)
+	swt := swtStoreFor(service)
 
 	session := &Session{
 		Name:       "session-1",
+		Status:     StatusArchived,
+		LastUsedAt: time.Now(),
+	}
+	addTestSession(t, sessionStore, swt, session, ws1ID)
+
+	rows, err := swt.ListBySessionID(session.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+	wtID := rows[0].WorktreeID
+
+	ctx := context.Background()
+	require.NoError(t, service.DeleteSession(ctx, session.ID, true, false))
+
+	_, err = sessionStore.GetByID(session.ID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+
+	remaining, err := swt.ListBySessionID(session.ID)
+	require.NoError(t, err)
+	require.Empty(t, remaining, "session_worktree join rows must be cleaned up")
+
+	_, err = service.gitService.GetWorktree(wtID)
+	require.Error(t, err, "worktree record must be cleaned up")
+}
+
+func TestSessionService_DeleteSession_RejectsNonArchived(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, _ := setupSessionService(t)
+
+	session := &Session{
+		Name:       "still-active",
 		Status:     StatusActive,
 		LastUsedAt: time.Now(),
 	}
 	addTestSession(t, sessionStore, swtStoreFor(service), session, ws1ID)
 
 	ctx := context.Background()
-	require.NoError(t, service.DeleteSession(ctx, session.ID, true, false))
+	err := service.DeleteSession(ctx, session.ID, true, false)
+	require.ErrorIs(t, err, ErrSessionNotArchived)
 
 	retrieved, err := sessionStore.GetByID(session.ID)
 	require.NoError(t, err)
-	require.Equal(t, StatusDeleted, retrieved.Status)
+	require.Equal(t, StatusActive, retrieved.Status)
 }
 
 func TestSessionService_DeleteSession_NotFound(t *testing.T) {
@@ -415,9 +453,40 @@ func TestSessionService_DeleteSession_Creating_Force(t *testing.T) {
 	err := service.DeleteSession(ctx, sess.ID, true, true)
 	require.NoError(t, err)
 
-	retrieved, err := sessionStore.GetByID(sess.ID)
+	_, err = sessionStore.GetByID(sess.ID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestSessionService_ArchiveSession_AllowsBroken(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, _ := setupSessionService(t)
+
+	sess := &Session{
+		Name:       "broken-session",
+		Status:     StatusBroken,
+		LastUsedAt: time.Now(),
+	}
+	addTestSession(t, sessionStore, swtStoreFor(service), sess, ws1ID)
+
+	ctx := context.Background()
+	archived, err := service.ArchiveSession(ctx, sess.ID)
 	require.NoError(t, err)
-	require.Equal(t, StatusDeleted, retrieved.Status)
+	require.Equal(t, StatusArchived, archived.Status)
+}
+
+func TestSessionService_ArchiveSession_RejectsCreating(t *testing.T) {
+	service, sessionStore, _, _, ws1ID, _ := setupSessionService(t)
+
+	sess := &Session{
+		Name:       "creating-session",
+		Status:     StatusCreating,
+		LastUsedAt: time.Now(),
+	}
+	addTestSession(t, sessionStore, swtStoreFor(service), sess, ws1ID)
+
+	ctx := context.Background()
+	_, err := service.ArchiveSession(ctx, sess.ID)
+	require.Error(t, err)
 }
 
 func TestSessionService_DetachWorktreesByRepoID(t *testing.T) {

--- a/internal/session/sessionstore.go
+++ b/internal/session/sessionstore.go
@@ -203,6 +203,16 @@ func (s *SessionStore) Delete(id uint) error {
 	return s.db.Delete(&Session{}, "id = ?", id).Error
 }
 
+// HardDelete physically removes the session row (bypassing GORM soft delete) so
+// the database's ON DELETE CASCADE constraints fire, cleaning up join rows,
+// claude sessions, actions, and setup steps.
+func (s *SessionStore) HardDelete(id uint) error {
+	if id == 0 {
+		return errors.New("session ID cannot be zero")
+	}
+	return s.db.Where("id = ?", id).Unscoped().Delete(&Session{}).Error
+}
+
 func (s *SessionStore) GetByWorkspaceAndName(workspaceID uint, name string, excludeStatuses ...SessionStatus) (*Session, error) {
 	var session Session
 	q := s.db.Where("name = ? AND id IN (?)", name, s.sessionsForWorkspace(workspaceID))

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -365,6 +365,28 @@ func (c *client) archiveSession(id uint) tea.Cmd {
 	}
 }
 
+func (c *client) dismissSession(id uint) tea.Cmd {
+	return func() tea.Msg {
+		req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/sessions/%d/dismiss", c.baseURL, id), nil)
+		if err != nil {
+			return ErrMsg{err}
+		}
+
+		res, err := c.httpClient.Do(req)
+		if err != nil {
+			log.Printf("[ERROR] dismiss session %d: %v", id, err)
+			return ErrMsg{err}
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			return parseAPIError(res, "dismiss session")
+		}
+
+		return sessionDismissedMsg{id: id}
+	}
+}
+
 func (c *client) deleteWorkspace(id uint) tea.Cmd {
 	return func() tea.Msg {
 		req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/workspaces/%d", c.baseURL, id), nil)

--- a/internal/tui/provider/sessionsprovider.go
+++ b/internal/tui/provider/sessionsprovider.go
@@ -63,6 +63,10 @@ func ArchiveSession(id uint) tea.Cmd {
 	return func() tea.Msg { return archiveSessionIntentMsg{id: id} }
 }
 
+func DismissSession(id uint) tea.Cmd {
+	return func() tea.Msg { return dismissSessionIntentMsg{id: id} }
+}
+
 func AddWorkspaceToSession(sessionID uint, spec SessionWorkspaceSpec) tea.Cmd {
 	return func() tea.Msg { return addWorkspaceToSessionIntentMsg{sessionID: sessionID, spec: spec} }
 }
@@ -93,6 +97,10 @@ type archiveSessionIntentMsg struct {
 	id uint
 }
 
+type dismissSessionIntentMsg struct {
+	id uint
+}
+
 type setActiveWorkspaceMsg struct {
 	workspaceID uint
 }
@@ -119,6 +127,8 @@ type sessionDeletedMsg struct {
 }
 
 type sessionArchivedMsg struct{ id uint }
+
+type sessionDismissedMsg struct{ id uint }
 
 type sessionPolledMsg struct {
 	session session.Session
@@ -227,6 +237,12 @@ func (p sessionsProvider) Update(msg tea.Msg) (sessionsProvider, tea.Cmd) {
 		return p, p.client.archiveSession(msg.id)
 
 	case sessionArchivedMsg:
+		return p, p.client.fetchSessions()
+
+	case dismissSessionIntentMsg:
+		return p, p.client.dismissSession(msg.id)
+
+	case sessionDismissedMsg:
 		return p, p.client.fetchSessions()
 
 	case pollSessionIntentMsg:

--- a/internal/tui/sessiondetail/model.go
+++ b/internal/tui/sessiondetail/model.go
@@ -144,10 +144,7 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 		return m, provider.ActivateSession(m.sess.ID)
 
 	case key.Matches(msg, keys.Archive):
-		archivable := m.sess.Status == session.StatusActive ||
-			m.sess.Status == session.StatusInactive ||
-			m.sess.Status == session.StatusCompleted
-		if !archivable {
+		if !m.sess.CanArchive() {
 			return m, nil
 		}
 		return m, tea.Batch(
@@ -156,6 +153,11 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 		)
 
 	case key.Matches(msg, keys.Delete):
+		// Only archived sessions can be deleted; creating sessions keep the
+		// force escape hatch.
+		if !m.sess.CanDelete() && !m.sess.IsCreating() {
+			return m, nil
+		}
 		if pendingID == m.sess.ID {
 			return m, tea.Batch(
 				provider.DeleteSession(m.sess.ID, m.sess.IsCreating()),

--- a/internal/tui/sessiondetail/model_test.go
+++ b/internal/tui/sessiondetail/model_test.go
@@ -28,6 +28,14 @@ func makeBrokenSession() session.Session {
 	}
 }
 
+func makeArchivedSession() session.Session {
+	return session.Session{
+		Model:  gorm.Model{ID: 3},
+		Name:   "archived",
+		Status: session.StatusArchived,
+	}
+}
+
 func TestSessionDetail_SelectMsg_LoadsSession(t *testing.T) {
 	m, _ := New().Update(SelectMsg{Session: makeActiveSession()})
 	require.NotNil(t, m.sess)
@@ -56,26 +64,33 @@ func TestSessionDetail_Archive_ArchivesAndGoesBack(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
-func TestSessionDetail_Archive_SkipsWhenBroken(t *testing.T) {
+func TestSessionDetail_Archive_ArchivesWhenBroken(t *testing.T) {
 	m, _ := New().Update(SelectMsg{Session: makeBrokenSession()})
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
-	assert.Nil(t, cmd)
+	assert.NotNil(t, cmd)
 }
 
-func TestSessionDetail_Delete_RequiresDoublePress(t *testing.T) {
+func TestSessionDetail_Delete_SkipsWhenActive(t *testing.T) {
 	m, _ := New().Update(SelectMsg{Session: makeActiveSession()})
 	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
 	assert.Nil(t, cmd)
-	assert.Equal(t, uint(1), m2.pendingDeleteID)
+	assert.Equal(t, uint(0), m2.pendingDeleteID)
+}
+
+func TestSessionDetail_Delete_RequiresDoublePress(t *testing.T) {
+	m, _ := New().Update(SelectMsg{Session: makeArchivedSession()})
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	assert.Nil(t, cmd)
+	assert.Equal(t, uint(3), m2.pendingDeleteID)
 
 	_, cmd2 := m2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
 	assert.NotNil(t, cmd2)
 }
 
 func TestSessionDetail_Delete_ResetsByInterveningKey(t *testing.T) {
-	m, _ := New().Update(SelectMsg{Session: makeActiveSession()})
+	m, _ := New().Update(SelectMsg{Session: makeArchivedSession()})
 	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
-	assert.Equal(t, uint(1), m2.pendingDeleteID)
+	assert.Equal(t, uint(3), m2.pendingDeleteID)
 
 	m3, _ := m2.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	assert.Equal(t, uint(0), m3.pendingDeleteID)

--- a/internal/tui/sessionlist/keys.go
+++ b/internal/tui/sessionlist/keys.go
@@ -6,37 +6,39 @@ import (
 )
 
 type keyMap struct {
-	Up           key.Binding
-	Down         key.Binding
-	Select       key.Binding
-	Close        key.Binding
-	New          key.Binding
-	Info         key.Binding
-	Todos        key.Binding
-	Workspaces   key.Binding
-	ToggleBroken key.Binding
-	Quit         key.Binding
+	Up             key.Binding
+	Down           key.Binding
+	Select         key.Binding
+	Close          key.Binding
+	New            key.Binding
+	Info           key.Binding
+	Todos          key.Binding
+	Workspaces     key.Binding
+	ToggleBroken   key.Binding
+	ToggleArchived key.Binding
+	Quit           key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Select, k.Close, k.New, k.Info, k.Todos, k.Workspaces, k.ToggleBroken, k.Quit}
+	return []key.Binding{k.Select, k.Close, k.New, k.Info, k.Todos, k.Workspaces, k.ToggleBroken, k.ToggleArchived, k.Quit}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.Up, k.Down, k.Select, k.Close, k.New, k.Info, k.Todos, k.Workspaces, k.ToggleBroken, k.Quit}}
+	return [][]key.Binding{{k.Up, k.Down, k.Select, k.Close, k.New, k.Info, k.Todos, k.Workspaces, k.ToggleBroken, k.ToggleArchived, k.Quit}}
 }
 
 var keys = keyMap{
-	Up:           key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
-	Down:         key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
-	Select:       key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
-	Close:        key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "close")),
-	New:          key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
-	Info:         key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "info")),
-	Todos:        key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "todos")),
-	Workspaces:   key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "workspaces")),
-	ToggleBroken: key.NewBinding(key.WithKeys("."), key.WithHelp(".", "toggle broken")),
-	Quit:         key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
+	Up:             key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
+	Down:           key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
+	Select:         key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+	Close:          key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "archive/delete")),
+	New:            key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
+	Info:           key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "info")),
+	Todos:          key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "todos")),
+	Workspaces:     key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "workspaces")),
+	ToggleBroken:   key.NewBinding(key.WithKeys("."), key.WithHelp(".", "toggle broken")),
+	ToggleArchived: key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "toggle archived")),
+	Quit:           key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
 }
 
 var _ help.KeyMap = keys

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -27,6 +27,7 @@ type Model struct {
 	cursor          int
 	offset          int
 	showBroken      bool
+	showArchived    bool
 	pendingDeleteID uint
 	pendingRepairID uint
 	statusMsg       string
@@ -98,6 +99,9 @@ func (m *Model) rebuildFiltered() {
 			continue
 		}
 		if s.Status == session.StatusBroken && !m.showBroken {
+			continue
+		}
+		if s.Status == session.StatusArchived && !m.showArchived {
 			continue
 		}
 		m.filtered = append(m.filtered, s)
@@ -248,6 +252,11 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 		m.rebuildFiltered()
 		return m, nil, true
 
+	case key.Matches(msg, keys.ToggleArchived):
+		m.showArchived = !m.showArchived
+		m.rebuildFiltered()
+		return m, nil, true
+
 	case key.Matches(msg, keys.New):
 		return m, router.NavigateTo(router.SessionFormView), true
 
@@ -302,16 +311,23 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 			m.statusMsg = "cannot close attached session"
 			return m, nil, true
 		}
+		// Pending sessions hold no real resources; dismiss them outright.
+		if sel.Status == session.StatusPending {
+			return m, provider.DismissSession(sel.ID), true
+		}
 		if m.pendingDeleteID == sel.ID {
 			m.pendingDeleteID = 0
-			return m, provider.DeleteSession(sel.ID, sel.IsCreating()), true
+			switch {
+			case sel.CanDelete():
+				return m, provider.DeleteSession(sel.ID, false), true
+			case sel.IsCreating():
+				return m, provider.DeleteSession(sel.ID, true), true
+			default:
+				return m, provider.ArchiveSession(sel.ID), true
+			}
 		}
 		m.pendingDeleteID = sel.ID
-		if sel.IsCreating() {
-			m.statusMsg = forceDeleteMessage(sessionDisplayName(*sel))
-			return m, nil, true
-		}
-		m.statusMsg = fmt.Sprintf("press d again to close %s", sessionDisplayName(*sel))
+		m.statusMsg = m.closeConfirmMessage(*sel)
 		return m, nil, true
 	}
 
@@ -343,6 +359,21 @@ func sessionDisplayName(s session.Session) string {
 
 func forceDeleteMessage(name string) string {
 	return fmt.Sprintf("session is still creating — press d again to force delete %s", name)
+}
+
+// closeConfirmMessage prompts the appropriate destructive action for the
+// session's state: archive for a live session, delete for an already-archived
+// one, force-delete for a stuck creating session.
+func (m Model) closeConfirmMessage(s session.Session) string {
+	name := sessionDisplayName(s)
+	switch {
+	case s.CanDelete():
+		return fmt.Sprintf("press d again to delete %s (removes worktrees)", name)
+	case s.IsCreating():
+		return forceDeleteMessage(name)
+	default:
+		return fmt.Sprintf("press d again to archive %s", name)
+	}
 }
 
 func (m Model) renderRow(s session.Session, selected bool, width int) string {

--- a/internal/tui/sessionlist/sessionlist_test.go
+++ b/internal/tui/sessionlist/sessionlist_test.go
@@ -1,6 +1,7 @@
 package sessionlist
 
 import (
+	"reflect"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -8,6 +9,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 )
+
+func msgTypeName(cmd tea.Cmd) string {
+	if cmd == nil {
+		return ""
+	}
+	return reflect.TypeOf(cmd()).String()
+}
+
+func pressD(m Model) (Model, tea.Cmd, bool) {
+	return m.OnKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+}
 
 func TestSessionList_InfoKey_NavigatesToDetail(t *testing.T) {
 	m := New()
@@ -43,4 +55,92 @@ func TestSessionList_Delete_Creating_SecondPress_ForceDeletes(t *testing.T) {
 	assert.True(t, handled)
 	assert.NotNil(t, cmd)
 	assert.Equal(t, uint(0), result.pendingDeleteID)
+}
+
+func TestSessionList_Delete_Active_FirstPress_ShowsArchiveMessage(t *testing.T) {
+	m := New()
+	m.filtered = []session.Session{
+		{Model: gorm.Model{ID: 1}, Name: "live", Status: session.StatusActive},
+	}
+
+	result, cmd, handled := pressD(m)
+	assert.True(t, handled)
+	assert.Nil(t, cmd)
+	assert.Equal(t, uint(1), result.pendingDeleteID)
+	assert.Contains(t, result.statusMsg, "archive live")
+}
+
+func TestSessionList_Delete_Active_SecondPress_Archives(t *testing.T) {
+	m := New()
+	m.filtered = []session.Session{
+		{Model: gorm.Model{ID: 1}, Name: "live", Status: session.StatusActive},
+	}
+	m.pendingDeleteID = 1
+
+	result, cmd, handled := pressD(m)
+	assert.True(t, handled)
+	assert.Equal(t, "provider.archiveSessionIntentMsg", msgTypeName(cmd))
+	assert.Equal(t, uint(0), result.pendingDeleteID)
+}
+
+func TestSessionList_Delete_Archived_FirstPress_ShowsDeleteMessage(t *testing.T) {
+	m := New()
+	m.filtered = []session.Session{
+		{Model: gorm.Model{ID: 1}, Name: "old", Status: session.StatusArchived},
+	}
+
+	result, cmd, handled := pressD(m)
+	assert.True(t, handled)
+	assert.Nil(t, cmd)
+	assert.Equal(t, uint(1), result.pendingDeleteID)
+	assert.Contains(t, result.statusMsg, "delete old")
+}
+
+func TestSessionList_Delete_Archived_SecondPress_Deletes(t *testing.T) {
+	m := New()
+	m.filtered = []session.Session{
+		{Model: gorm.Model{ID: 1}, Name: "old", Status: session.StatusArchived},
+	}
+	m.pendingDeleteID = 1
+
+	_, cmd, handled := pressD(m)
+	assert.True(t, handled)
+	assert.Equal(t, "provider.deleteSessionIntentMsg", msgTypeName(cmd))
+}
+
+func TestSessionList_Pending_Dismisses(t *testing.T) {
+	m := New()
+	m.filtered = []session.Session{
+		{Model: gorm.Model{ID: 1}, Name: "pend", Status: session.StatusPending},
+	}
+
+	_, cmd, handled := pressD(m)
+	assert.True(t, handled)
+	assert.Equal(t, "provider.dismissSessionIntentMsg", msgTypeName(cmd))
+}
+
+func TestSessionList_FiltersArchivedByDefault(t *testing.T) {
+	m := New()
+	m.sessions = []session.Session{
+		{Model: gorm.Model{ID: 1}, Name: "live", Status: session.StatusActive},
+		{Model: gorm.Model{ID: 2}, Name: "old", Status: session.StatusArchived},
+	}
+	m.rebuildFiltered()
+
+	assert.Len(t, m.filtered, 1)
+	assert.Equal(t, "live", m.filtered[0].Name)
+}
+
+func TestSessionList_ToggleArchived_RevealsArchived(t *testing.T) {
+	m := New()
+	m.sessions = []session.Session{
+		{Model: gorm.Model{ID: 1}, Name: "live", Status: session.StatusActive},
+		{Model: gorm.Model{ID: 2}, Name: "old", Status: session.StatusArchived},
+	}
+	m.rebuildFiltered()
+
+	result, _, handled := m.OnKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	assert.True(t, handled)
+	assert.True(t, result.showArchived)
+	assert.Len(t, result.filtered, 2)
 }


### PR DESCRIPTION
## Summary
- Make **archive** the primary session-list action and gate **deletion** to already-archived sessions. The `d` key is now contextual: archive a live session, delete an archived one, force-delete a stuck `creating` session, dismiss a `pending` one.
- Add an `a` toggle to reveal archived sessions, which are **hidden from the list by default** (mirrors the existing `.` broken toggle).
- `ArchiveSession` now also accepts **broken** sessions so they funnel through archive → delete like everything else; archive still just kills tmux and leaves other resources alive.
- `DeleteSession` is gated to archived (creating keeps a `force` escape hatch) and performs **full graceful cleanup** — kill tmux, remove worktree dirs + session root, clean branches, hard-delete the row (FK cascade clears join rows, claude sessions, actions, setup steps), then drop the now-unreferenced worktree records. Each step continues past individual failures.
- Lift archive/delete eligibility into `Session.CanArchive`/`CanDelete` predicates and share the session-root containment check, removing triplicated status logic across the service and TUI layers.

⚠️ Deleting an archived session **permanently removes its worktree directories** (uncommitted work there is lost). Branch deletion remains governed by the existing `delete_branch` flag. Design doc: `docs/plans/2026-06-21-archive-delete-rework-design.md`.

## Test plan
- [ ] `task test` green (pre-existing, unrelated `TestSessionService_AddWorkspace_FullIntegration` failure confirmed failing identically on clean HEAD — a sandbox git-path issue)
- [ ] Service: broken is archivable; delete rejects non-archived without force; delete of an archived session removes worktree dir + session root and hard-deletes the row, with join rows + worktree records verified gone; force still deletes a creating session
- [ ] TUI list: `d` archives a live session, deletes an archived one; archived hidden by default and revealed by `a`
- [ ] TUI detail: archive accepts broken; delete only acts on archived/creating
- [ ] Manual: archive a session (tmux dies, worktree survives), reveal it, delete it (worktree dir gone), confirm re-creating a session of the same name works
