### PR TITLE
feat(workspace): async bare clone/migrate with live status + progress

### DIFF
--- a/internal/api/baremigration.go
+++ b/internal/api/baremigration.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/eleonorayaya/utena/internal/claudesettings"
 	"github.com/eleonorayaya/utena/internal/common"
@@ -24,8 +23,6 @@ type bareMigrationHandler struct {
 }
 
 func (h *bareMigrationHandler) handle(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Minute)
-	defer cancel()
 	raw := chi.URLParam(r, "id")
 	id, err := strconv.ParseUint(raw, 10, 64)
 	if err != nil {
@@ -33,7 +30,7 @@ func (h *bareMigrationHandler) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ws, err := h.workspaceService.GetWorkspace(ctx, uint(id))
+	ws, err := h.workspaceService.GetWorkspace(r.Context(), uint(id))
 	if err != nil {
 		common.RenderError(w, r, err)
 		return
@@ -49,20 +46,30 @@ func (h *bareMigrationHandler) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	migrating, err := h.workspaceService.BeginMigration(r.Context(), uint(id))
+	if err != nil {
+		common.RenderError(w, r, err)
+		return
+	}
+	go h.runMigration(uint(id), ws)
+
+	render.Status(r, http.StatusAccepted)
+	common.RenderResponse(w, r, workspace.NewWorkspaceResponse(migrating))
+}
+
+func (h *bareMigrationHandler) runMigration(id uint, ws *workspace.Workspace) {
+	ctx, cancel := context.WithTimeout(context.Background(), workspace.BareOpTimeout)
+	defer cancel()
+
 	if ws.RepoID != nil {
 		if err := h.sessionService.DetachWorktreesByRepoID(ctx, *ws.RepoID); err != nil {
-			common.RenderError(w, r, fmt.Errorf("failed to clear worktree records before bare migration: %w", err))
+			h.workspaceService.FailBareOperation(id, fmt.Errorf("failed to clear worktree records before bare migration: %w", err))
 			return
 		}
 	}
 
-	if err := h.gitService.MigrateToBare(ctx, ws.Path); err != nil {
-		common.RenderError(w, r, err)
-		return
-	}
-
-	if err := h.workspaceService.MarkAsBare(ctx, uint(id)); err != nil {
-		common.RenderError(w, r, err)
+	if err := h.gitService.MigrateToBare(ctx, ws.Path, h.workspaceService.ProgressFn(id)); err != nil {
+		h.workspaceService.FailBareOperation(id, err)
 		return
 	}
 
@@ -71,5 +78,7 @@ func (h *bareMigrationHandler) handle(w http.ResponseWriter, r *http.Request) {
 			"workspace", ws.Name, "error", err)
 	}
 
-	render.NoContent(w, r)
+	if err := h.workspaceService.FinalizeBareWorkspace(ctx, id); err != nil {
+		h.workspaceService.FailBareOperation(id, err)
+	}
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -347,13 +347,40 @@ func TestDaemon_RepairSession_AfterTmuxFailure(t *testing.T) {
 	require.True(t, mock.HasSessionByName("repair-me"))
 }
 
+func startMigrateAndWait(t *testing.T, router http.Handler, wsID uint) {
+	t.Helper()
+	req := httptest.NewRequest("POST", fmt.Sprintf("/workspaces/%d/migrate-bare", wsID), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusAccepted, w.Code, "body: %s", w.Body.String())
+
+	var started struct {
+		Status string `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &started))
+	require.Equal(t, "migrating", started.Status)
+
+	require.Eventually(t, func() bool {
+		sreq := httptest.NewRequest("GET", fmt.Sprintf("/workspaces/%d", wsID), nil)
+		sw := httptest.NewRecorder()
+		router.ServeHTTP(sw, sreq)
+		if sw.Code != http.StatusOK {
+			return false
+		}
+		var status struct {
+			Status      string `json:"status"`
+			StatusError string `json:"status_error"`
+		}
+		require.NoError(t, json.Unmarshal(sw.Body.Bytes(), &status))
+		require.NotEqual(t, "failed", status.Status, "migration failed: %s", status.StatusError)
+		return status.Status == "ready"
+	}, 30*time.Second, 25*time.Millisecond)
+}
+
 func TestDaemon_MigrateToBare_BootstrapsClaudeSettings(t *testing.T) {
 	app, router, _, ws1ID, _ := setupTestRouter(t)
 
-	req := httptest.NewRequest("POST", fmt.Sprintf("/workspaces/%d/migrate-bare", ws1ID), nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusNoContent, w.Code, "body: %s", w.Body.String())
+	startMigrateAndWait(t, router, ws1ID)
 
 	ws, err := app.Workspace.Store.GetByID(ws1ID)
 	require.NoError(t, err)
@@ -372,10 +399,7 @@ func TestDaemon_MigrateToBare_DetachesLinkedSessions(t *testing.T) {
 	createResp := createSessionViaAPI(t, router, body)
 	waitForSessionStatus(t, router, createResp.ID, session.StatusActive, 5*time.Second)
 
-	req := httptest.NewRequest("POST", fmt.Sprintf("/workspaces/%d/migrate-bare", ws1ID), nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusNoContent, w.Code, "body: %s", w.Body.String())
+	startMigrateAndWait(t, router, ws1ID)
 
 	sess, err := app.Session.Store.GetByID(createResp.ID)
 	require.NoError(t, err)

--- a/internal/git/gitcli.go
+++ b/internal/git/gitcli.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -10,6 +11,8 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
+	"time"
 )
 
 type gitCLI struct{}
@@ -282,7 +285,7 @@ func (s *gitCLI) remoteURL(ctx context.Context, repoPath string) (string, error)
 	return strings.TrimSpace(string(output)), nil
 }
 
-func (s *gitCLI) migrateToBare(ctx context.Context, workspacePath string) error {
+func (s *gitCLI) migrateToBare(ctx context.Context, workspacePath string, onProgress func(string)) error {
 	backupPath := workspacePath + "-backup"
 
 	if _, err := os.Stat(backupPath); err == nil {
@@ -308,7 +311,7 @@ func (s *gitCLI) migrateToBare(ctx context.Context, workspacePath string) error 
 		return fmt.Errorf("failed to create workspace directory (backup at %s): %w", backupPath, err)
 	}
 
-	if err := s.runBareClone(ctx, remoteURL, workspacePath); err != nil {
+	if err := s.runBareClone(ctx, remoteURL, workspacePath, onProgress); err != nil {
 		return fmt.Errorf("%w (backup at %s)", err, backupPath)
 	}
 
@@ -323,7 +326,7 @@ func (s *gitCLI) migrateToBare(ctx context.Context, workspacePath string) error 
 	return nil
 }
 
-func (s *gitCLI) cloneBareWorkspace(ctx context.Context, remoteURL, workspacePath string) error {
+func (s *gitCLI) cloneBareWorkspace(ctx context.Context, remoteURL, workspacePath string, onProgress func(string)) error {
 	remoteURL = strings.TrimSpace(remoteURL)
 	if remoteURL == "" {
 		return fmt.Errorf("remote URL is required")
@@ -348,7 +351,7 @@ func (s *gitCLI) cloneBareWorkspace(ctx context.Context, remoteURL, workspacePat
 		return fmt.Errorf("failed to create workspace directory %s: %w", workspacePath, err)
 	}
 
-	if err := s.runBareClone(ctx, remoteURL, workspacePath); err != nil {
+	if err := s.runBareClone(ctx, remoteURL, workspacePath, onProgress); err != nil {
 		_ = os.RemoveAll(workspacePath)
 		return err
 	}
@@ -366,13 +369,59 @@ func (s *gitCLI) cloneBareWorkspace(ctx context.Context, remoteURL, workspacePat
 	return nil
 }
 
-func (s *gitCLI) runBareClone(ctx context.Context, remoteURL, workspacePath string) error {
+func (s *gitCLI) runBareClone(ctx context.Context, remoteURL, workspacePath string, onProgress func(string)) error {
 	barePath := filepath.Join(workspacePath, ".bare")
-	cmd := exec.CommandContext(ctx, "git", "clone", "--bare", remoteURL, barePath)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git clone --bare failed: %s: %w", strings.TrimSpace(string(output)), err)
+	cmd := exec.CommandContext(ctx, "git", "clone", "--bare", "--progress", remoteURL, barePath)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 10 * time.Second
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("git clone --bare failed: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("git clone --bare failed: %w", err)
+	}
+
+	var lastLine string
+	scanner := bufio.NewScanner(stderr)
+	scanner.Split(progressSplit)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		lastLine = line
+		if onProgress != nil {
+			onProgress(line)
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		if lastLine != "" {
+			return fmt.Errorf("git clone --bare failed: %s: %w", lastLine, err)
+		}
+		return fmt.Errorf("git clone --bare failed: %w", err)
 	}
 	return nil
+}
+
+func progressSplit(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	for i, b := range data {
+		if b == '\n' || b == '\r' {
+			return i + 1, data[:i], nil
+		}
+	}
+	if atEOF && len(data) > 0 {
+		return len(data), data, nil
+	}
+	return 0, nil, nil
 }
 
 func writeBareMarker(workspacePath string) error {

--- a/internal/git/gitcli_test.go
+++ b/internal/git/gitcli_test.go
@@ -331,8 +331,12 @@ func TestGitCLI_CloneBareWorkspace_HappyPath(t *testing.T) {
 	target := filepath.Join(parent, "cloned")
 
 	svc := newGitCLI()
-	err := svc.cloneBareWorkspace(context.Background(), source, target)
+	var progress []string
+	err := svc.cloneBareWorkspace(context.Background(), source, target, func(line string) {
+		progress = append(progress, line)
+	})
 	require.NoError(t, err)
+	require.NotEmpty(t, progress, "expected git clone progress to be streamed")
 
 	gitInfo, err := os.Stat(filepath.Join(target, ".git"))
 	require.NoError(t, err)
@@ -362,7 +366,7 @@ func TestGitCLI_CloneBareWorkspace_CreatesParents(t *testing.T) {
 	target := filepath.Join(parent, "nested", "dirs", "cloned")
 
 	svc := newGitCLI()
-	err := svc.cloneBareWorkspace(context.Background(), source, target)
+	err := svc.cloneBareWorkspace(context.Background(), source, target, nil)
 	require.NoError(t, err)
 
 	require.True(t, isBareWorkspace(target))
@@ -377,7 +381,7 @@ func TestGitCLI_CloneBareWorkspace_RejectsNonEmptyTarget(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(target, "stray"), []byte("x"), 0644))
 
 	svc := newGitCLI()
-	err := svc.cloneBareWorkspace(context.Background(), source, target)
+	err := svc.cloneBareWorkspace(context.Background(), source, target, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not empty")
 
@@ -387,7 +391,7 @@ func TestGitCLI_CloneBareWorkspace_RejectsNonEmptyTarget(t *testing.T) {
 
 func TestGitCLI_CloneBareWorkspace_RejectsEmptyURL(t *testing.T) {
 	svc := newGitCLI()
-	err := svc.cloneBareWorkspace(context.Background(), "", filepath.Join(t.TempDir(), "target"))
+	err := svc.cloneBareWorkspace(context.Background(), "", filepath.Join(t.TempDir(), "target"), nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "required")
 }
@@ -397,7 +401,7 @@ func TestGitCLI_CloneBareWorkspace_CleansUpOnCloneFailure(t *testing.T) {
 	target := filepath.Join(parent, "cloned")
 
 	svc := newGitCLI()
-	err := svc.cloneBareWorkspace(context.Background(), filepath.Join(parent, "does-not-exist"), target)
+	err := svc.cloneBareWorkspace(context.Background(), filepath.Join(parent, "does-not-exist"), target, nil)
 	require.Error(t, err)
 
 	_, statErr := os.Stat(target)

--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/eleonorayaya/utena/internal/db"
 	"github.com/eleonorayaya/utena/internal/eventbus"
@@ -254,12 +255,12 @@ func (s *GitService) PruneWorktrees(ctx context.Context, repoPath string) error 
 	return s.cli.pruneWorktrees(ctx, repoPath)
 }
 
-func (s *GitService) MigrateToBare(ctx context.Context, workspacePath string) error {
-	return s.cli.migrateToBare(ctx, workspacePath)
+func (s *GitService) MigrateToBare(ctx context.Context, workspacePath string, onProgress func(string)) error {
+	return s.cli.migrateToBare(ctx, workspacePath, onProgress)
 }
 
-func (s *GitService) CloneBareWorkspace(ctx context.Context, remoteURL, workspacePath string) error {
-	return s.cli.cloneBareWorkspace(ctx, remoteURL, workspacePath)
+func (s *GitService) CloneBareWorkspace(ctx context.Context, remoteURL, workspacePath string, onProgress func(string)) error {
+	return s.cli.cloneBareWorkspace(ctx, remoteURL, workspacePath, onProgress)
 }
 
 func (s *GitService) ParseRepoFullName(remoteURL string) (owner string, repo string, err error) {
@@ -617,6 +618,9 @@ func ghPRToPullRequest(ghPR *github.PullRequest, repoID uint, branchID uint, cur
 }
 
 func (s *GitService) SyncBranches(ctx context.Context, repoID uint, repoPath string) error {
+	if _, err := os.Stat(repoPath); err != nil {
+		return fmt.Errorf("repo path unavailable, skipping branch sync: %s: %w", repoPath, err)
+	}
 	branches := s.branchStore.ListByRepo(repoID)
 	for i := range branches {
 		if err := s.SyncBranch(ctx, &branches[i], repoPath); err != nil {

--- a/internal/git/progress_test.go
+++ b/internal/git/progress_test.go
@@ -1,0 +1,52 @@
+package git
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func TestProgressSplit_SplitsOnCarriageReturnAndNewline(t *testing.T) {
+	input := "Counting objects:  10%\rCounting objects: 100%\rResolving deltas: done.\nWriting marker\n"
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	scanner.Split(progressSplit)
+
+	var got []string
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			got = append(got, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanner error: %v", err)
+	}
+
+	want := []string{
+		"Counting objects:  10%",
+		"Counting objects: 100%",
+		"Resolving deltas: done.",
+		"Writing marker",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d lines %q, want %d %q", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestProgressSplit_HandlesTrailingTokenWithoutTerminator(t *testing.T) {
+	scanner := bufio.NewScanner(strings.NewReader("no newline at end"))
+	scanner.Split(progressSplit)
+
+	var got []string
+	for scanner.Scan() {
+		got = append(got, scanner.Text())
+	}
+	if len(got) != 1 || got[0] != "no newline at end" {
+		t.Fatalf("got %q, want [\"no newline at end\"]", got)
+	}
+}

--- a/internal/git/syncbranches_test.go
+++ b/internal/git/syncbranches_test.go
@@ -1,0 +1,25 @@
+package git
+
+import (
+	"context"
+	"testing"
+
+	"github.com/eleonorayaya/utena/internal/db/testdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitService_SyncBranches_MissingRepoPathReturnsErrorEarly(t *testing.T) {
+	database := testdb.New(t, &Repo{}, &Branch{})
+	svc := NewGitService(database)
+	repoStore := NewRepoStore(database)
+	branchStore := NewBranchStore(database)
+
+	repo := &Repo{Path: "/nonexistent/path/repo", FullName: "owner/repo"}
+	require.NoError(t, repoStore.Add(repo))
+	require.NoError(t, branchStore.Add(&Branch{Name: "main", RepoID: repo.ID}))
+	require.NoError(t, branchStore.Add(&Branch{Name: "feature", RepoID: repo.ID}))
+
+	err := svc.SyncBranches(context.Background(), repo.ID, repo.Path)
+	require.Error(t, err, "syncing a repo whose path no longer exists should error once, not per-branch")
+	require.Contains(t, err.Error(), "repo path")
+}

--- a/internal/session/sessionservice_pr_test.go
+++ b/internal/session/sessionservice_pr_test.go
@@ -485,7 +485,7 @@ func TestHandlePRUpdated_BareWorkspace_CreatesWorktree(t *testing.T) {
 	database := setupTestDB(t)
 	ctx := context.Background()
 	gitService := git.NewGitService(database)
-	require.NoError(t, gitService.MigrateToBare(ctx, repoPath))
+	require.NoError(t, gitService.MigrateToBare(ctx, repoPath, nil))
 
 	repo := &git.Repo{Path: repoPath, FullName: "test/repo"}
 	require.NoError(t, database.Create(repo).Error)

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -1124,7 +1124,7 @@ func setupBareWorktreeSessionService(t *testing.T, configDir string) (*SessionSe
 	database := setupTestDB(t)
 	gitService := git.NewGitService(database)
 	ctx := context.Background()
-	require.NoError(t, gitService.MigrateToBare(ctx, repoPath))
+	require.NoError(t, gitService.MigrateToBare(ctx, repoPath, nil))
 
 	bus := eventbus.NewEventBus()
 	sessionStore := NewSessionStore(database)

--- a/internal/tui/provider/client.go
+++ b/internal/tui/provider/client.go
@@ -411,27 +411,26 @@ func (c *client) deleteWorkspace(id uint) tea.Cmd {
 
 func (c *client) migrateWorkspaceToBare(id uint) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/workspaces/%d/migrate-bare", c.baseURL, id), nil)
 		if err != nil {
-			return ErrMsg{err}
+			return workspaceMigrateStartedMsg{err: err}
 		}
 
-		httpClient := &http.Client{}
-		res, err := httpClient.Do(req)
+		res, err := c.httpClient.Do(req)
 		if err != nil {
 			log.Printf("[ERROR] migrate workspace %d to bare: %v", id, err)
-			return ErrMsg{err}
+			return workspaceMigrateStartedMsg{err: err}
 		}
 		defer res.Body.Close()
 
-		if res.StatusCode != http.StatusNoContent {
-			return parseAPIError(res, "migrate workspace to bare")
+		if res.StatusCode != http.StatusAccepted {
+			apiErr := parseAPIError(res, "migrate workspace to bare")
+			return workspaceMigrateStartedMsg{err: apiErr.Err}
 		}
-
-		return workspaceMigratedToBareMsg{}
+		return workspaceMigrateStartedMsg{}
 	}
 }
 
@@ -499,7 +498,7 @@ func (c *client) cloneWorkspace(cloneURL, rootPath, dirName string) tea.Cmd {
 			return workspaceClonedMsg{err: err}
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/workspaces/clone", bytes.NewReader(jsonBody))
@@ -508,8 +507,7 @@ func (c *client) cloneWorkspace(cloneURL, rootPath, dirName string) tea.Cmd {
 		}
 		req.Header.Set("Content-Type", "application/json")
 
-		httpClient := &http.Client{}
-		res, err := httpClient.Do(req)
+		res, err := c.httpClient.Do(req)
 		if err != nil {
 			log.Printf("[ERROR] clone workspace %q: %v", cloneURL, err)
 			return workspaceClonedMsg{err: err}
@@ -521,14 +519,11 @@ func (c *client) cloneWorkspace(cloneURL, rootPath, dirName string) tea.Cmd {
 			return workspaceClonedMsg{err: apiErr.Err}
 		}
 
-		var resp workspace.WorkspaceResponse
-		if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		var ws workspace.Workspace
+		if err := json.NewDecoder(res.Body).Decode(&ws); err != nil {
 			return workspaceClonedMsg{err: err}
 		}
-		if resp.Workspace == nil {
-			return workspaceClonedMsg{err: fmt.Errorf("clone workspace: empty response")}
-		}
-		return workspaceClonedMsg{workspace: *resp.Workspace}
+		return workspaceClonedMsg{workspace: ws}
 	}
 }
 

--- a/internal/tui/provider/workspacesprovider.go
+++ b/internal/tui/provider/workspacesprovider.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/eleonorayaya/utena/internal/git"
 	"github.com/eleonorayaya/utena/internal/workspace"
@@ -74,6 +76,9 @@ func AddWorkspace(path string, asRoot bool) tea.Cmd {
 	return func() tea.Msg { return addWorkspaceIntentMsg{path: path, asRoot: asRoot} }
 }
 
+// WorkspaceClonedMsg reports that a clone was accepted (the workspace row now
+// exists in the "cloning" state) or rejected. Live progress and completion are
+// observed via the workspace's Status/Progress in WorkspacesStateUpdatedMsg.
 type WorkspaceClonedMsg struct {
 	Workspace workspace.Workspace
 	Err       error
@@ -142,12 +147,16 @@ type cloneWorkspaceIntentMsg struct {
 	dirName  string
 }
 
-type fetchWorkspaceRootsIntentMsg struct{}
-
 type workspaceClonedMsg struct {
 	workspace workspace.Workspace
 	err       error
 }
+
+type workspaceMigrateStartedMsg struct {
+	err error
+}
+
+type fetchWorkspaceRootsIntentMsg struct{}
 
 type workspaceRootsMsg struct {
 	roots []string
@@ -175,7 +184,6 @@ type branchesLoadedMsg struct {
 type workspaceDeletedMsg struct{}
 type workspaceHiddenToggledMsg struct{}
 type workspaceAddedMsg struct{}
-type workspaceMigratedToBareMsg struct{}
 
 type migrateWorkspaceToBareIntentMsg struct {
 	id uint
@@ -186,10 +194,26 @@ type workspacesProvider struct {
 	workspaces        []workspace.Workspace
 	branches          []string
 	activeWorkspaceID uint
+	polling           bool
+}
+
+type pollWorkspacesTickMsg struct{}
+
+func pollWorkspacesTick() tea.Cmd {
+	return tea.Tick(700*time.Millisecond, func(time.Time) tea.Msg { return pollWorkspacesTickMsg{} })
 }
 
 func newWorkspacesProvider(c *client) workspacesProvider {
 	return workspacesProvider{client: c}
+}
+
+func anyWorkspaceBusy(workspaces []workspace.Workspace) bool {
+	for i := range workspaces {
+		if workspaces[i].IsBusy() {
+			return true
+		}
+	}
+	return false
 }
 
 func (p workspacesProvider) emitState() tea.Cmd {
@@ -207,7 +231,23 @@ func (p workspacesProvider) Update(msg tea.Msg) (workspacesProvider, tea.Cmd) {
 	switch msg := msg.(type) {
 	case workspacesLoadedMsg:
 		p.workspaces = msg.workspaces
-		return p, p.emitState()
+		cmds := []tea.Cmd{p.emitState()}
+		busy := anyWorkspaceBusy(p.workspaces)
+		switch {
+		case busy && !p.polling:
+			// Start the single poll chain; the tick re-arms itself while busy.
+			p.polling = true
+			cmds = append(cmds, pollWorkspacesTick())
+		case !busy:
+			p.polling = false
+		}
+		return p, tea.Batch(cmds...)
+
+	case pollWorkspacesTickMsg:
+		if !p.polling {
+			return p, nil
+		}
+		return p, tea.Batch(p.client.fetchWorkspaces(), pollWorkspacesTick())
 
 	case fetchWorkspacesIntentMsg:
 		return p, p.client.fetchWorkspaces()
@@ -276,7 +316,12 @@ func (p workspacesProvider) Update(msg tea.Msg) (workspacesProvider, tea.Cmd) {
 	case migrateWorkspaceToBareIntentMsg:
 		return p, p.client.migrateWorkspaceToBare(msg.id)
 
-	case workspaceMigratedToBareMsg:
+	case workspaceMigrateStartedMsg:
+		if msg.err != nil {
+			err := msg.err
+			return p, func() tea.Msg { return ErrMsg{err} }
+		}
+		// The workspace is now "migrating"; the busy-poll picks up progress.
 		return p, p.client.fetchWorkspaces()
 
 	case cloneWorkspaceIntentMsg:
@@ -285,15 +330,13 @@ func (p workspacesProvider) Update(msg tea.Msg) (workspacesProvider, tea.Cmd) {
 	case workspaceClonedMsg:
 		ws := msg.workspace
 		err := msg.err
-		var refetch tea.Cmd
-		if err == nil {
-			refetch = p.client.fetchWorkspaces()
-		}
 		emit := func() tea.Msg { return WorkspaceClonedMsg{Workspace: ws, Err: err} }
-		if refetch == nil {
+		if err != nil {
 			return p, emit
 		}
-		return p, tea.Batch(emit, refetch)
+		// The new "cloning" workspace exists; refresh so the list shows it and
+		// the busy-poll starts tracking progress.
+		return p, tea.Batch(emit, p.client.fetchWorkspaces())
 
 	case fetchWorkspaceRootsIntentMsg:
 		return p, p.client.fetchWorkspaceRoots()

--- a/internal/tui/workspacecloneform/model.go
+++ b/internal/tui/workspacecloneform/model.go
@@ -105,6 +105,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.errMsg = msg.Err.Error()
 			return m, nil
 		}
+		// The workspace now exists in the "cloning" state; the list view shows
+		// its progress. Return there.
 		return m, router.Back()
 
 	case tea.KeyMsg:
@@ -115,12 +117,13 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 }
 
 func (m Model) onKey(msg tea.KeyMsg) (Model, tea.Cmd) {
+	if key.Matches(msg, keys.Back) {
+		return m, router.Back()
+	}
 	if m.cloning {
 		return m, nil
 	}
 	switch {
-	case key.Matches(msg, keys.Back):
-		return m, router.Back()
 	case key.Matches(msg, keys.Submit):
 		return m.submit()
 	case key.Matches(msg, keys.NextField), key.Matches(msg, keys.PrevField):
@@ -211,7 +214,7 @@ func (m Model) View() string {
 
 	if m.cloning {
 		b.WriteString("\n\n")
-		b.WriteString(pendingStyle().Render("Cloning… this can take a while for large repos."))
+		b.WriteString(pendingStyle().Render("Starting clone…"))
 	}
 
 	if m.errMsg != "" {

--- a/internal/tui/workspacedetail/model.go
+++ b/internal/tui/workspacedetail/model.go
@@ -107,7 +107,7 @@ func (m Model) onKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd) {
 			prlist.Select(m.workspace.ID),
 		)
 	case key.Matches(msg, keys.Migrate):
-		if m.workspace == nil || !m.workspace.IsGitRepo || m.workspace.IsBare {
+		if m.workspace == nil || !m.workspace.IsGitRepo || m.workspace.IsBare || m.workspace.IsBusy() {
 			return m, nil
 		}
 		m.actionErr = ""
@@ -162,6 +162,22 @@ func (m Model) View() string {
 	} else {
 		b.WriteString("\n" + sectionStyle().Render("⎇ Repository") + "\n")
 		b.WriteString(labelStyle().Render("") + lipgloss.NewStyle().Foreground(theme.Current.TextMuted).Render("not a git repository") + "\n")
+	}
+
+	if ws.IsBusy() {
+		muted := lipgloss.NewStyle().Foreground(theme.Current.TextMuted)
+		label := "Cloning…"
+		if ws.Status == workspace.StatusMigrating {
+			label = "Migrating to bare… this can take a while for large repos."
+		}
+		b.WriteString("\n" + muted.Render(label) + "\n")
+		if ws.Progress != "" {
+			b.WriteString(muted.Render(ws.Progress) + "\n")
+		}
+	}
+
+	if ws.Status == workspace.StatusFailed && ws.StatusError != "" {
+		b.WriteString("\n" + lipgloss.NewStyle().Foreground(theme.Current.Error).Render("[!] "+ws.StatusError) + "\n")
 	}
 
 	if m.actionErr != "" {

--- a/internal/tui/workspacelist/workspaceitem.go
+++ b/internal/tui/workspacelist/workspaceitem.go
@@ -57,5 +57,20 @@ func (d compactDelegate) Render(w io.Writer, m list.Model, index int, item list.
 	path := workspacepicker.AbbreviatePath(i.workspace.Path)
 	pathStyle := lipgloss.NewStyle().Foreground(theme.Current.TextMuted)
 
-	fmt.Fprint(w, cursor+nameStyle.Render(name)+"  "+pathStyle.Render(path))
+	fmt.Fprint(w, cursor+nameStyle.Render(name)+"  "+pathStyle.Render(path)+statusSuffix(i.workspace))
+}
+
+func statusSuffix(ws workspace.Workspace) string {
+	switch ws.Status {
+	case workspace.StatusCloning, workspace.StatusMigrating:
+		label := string(ws.Status)
+		if ws.Progress != "" {
+			label += ": " + ws.Progress
+		}
+		return "  " + lipgloss.NewStyle().Foreground(theme.Current.StatusActive).Render("· "+label)
+	case workspace.StatusFailed:
+		return "  " + lipgloss.NewStyle().Foreground(theme.Current.Error).Render("· failed")
+	default:
+		return ""
+	}
 }

--- a/internal/workspace/clonejob.go
+++ b/internal/workspace/clonejob.go
@@ -1,0 +1,34 @@
+package workspace
+
+import "sync"
+
+// progressTracker holds the latest live progress line for an in-flight bare
+// operation, keyed by workspace ID.
+// ponytail: in-memory only; progress is ephemeral and updates many times/sec,
+// so it is never persisted — only the Status/StatusError on the row are.
+type progressTracker struct {
+	mu sync.Mutex
+	m  map[uint]string
+}
+
+func newProgressTracker() *progressTracker {
+	return &progressTracker{m: make(map[uint]string)}
+}
+
+func (t *progressTracker) set(id uint, msg string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.m[id] = msg
+}
+
+func (t *progressTracker) get(id uint) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.m[id]
+}
+
+func (t *progressTracker) clear(id uint) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.m, id)
+}

--- a/internal/workspace/clonejob_test.go
+++ b/internal/workspace/clonejob_test.go
@@ -1,0 +1,33 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProgressTracker_SetGetClear(t *testing.T) {
+	tr := newProgressTracker()
+
+	require.Empty(t, tr.get(1))
+
+	tr.set(1, "Receiving objects: 42%")
+	require.Equal(t, "Receiving objects: 42%", tr.get(1))
+
+	tr.set(1, "Resolving deltas: 100%")
+	require.Equal(t, "Resolving deltas: 100%", tr.get(1))
+
+	tr.clear(1)
+	require.Empty(t, tr.get(1))
+}
+
+func TestProgressTracker_IsolatesByID(t *testing.T) {
+	tr := newProgressTracker()
+	tr.set(1, "a")
+	tr.set(2, "b")
+	require.Equal(t, "a", tr.get(1))
+	require.Equal(t, "b", tr.get(2))
+	tr.clear(1)
+	require.Empty(t, tr.get(1))
+	require.Equal(t, "b", tr.get(2))
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -7,14 +7,39 @@ import (
 	"gorm.io/gorm"
 )
 
+type WorkspaceStatus string
+
+const (
+	StatusReady     WorkspaceStatus = "ready"
+	StatusCloning   WorkspaceStatus = "cloning"
+	StatusMigrating WorkspaceStatus = "migrating"
+	StatusFailed    WorkspaceStatus = "failed"
+)
+
 type Workspace struct {
 	gorm.Model
-	Name       string    `json:"name"`
-	Path       string    `json:"path" gorm:"uniqueIndex"`
-	IsGitRepo  bool      `json:"is_git_repo"`
-	IsBare     bool      `json:"is_bare" gorm:"default:false"`
-	IsHidden   bool      `json:"is_hidden" gorm:"default:false"`
-	RepoID     *uint     `json:"repo_id,omitempty" gorm:"uniqueIndex"`
-	Repo       *git.Repo `json:"repo,omitempty" gorm:"foreignKey:RepoID"`
-	LastUsedAt time.Time `json:"last_used_at,omitempty"`
+	Name        string          `json:"name"`
+	Path        string          `json:"path" gorm:"uniqueIndex"`
+	IsGitRepo   bool            `json:"is_git_repo"`
+	IsBare      bool            `json:"is_bare" gorm:"default:false"`
+	IsHidden    bool            `json:"is_hidden" gorm:"default:false"`
+	RepoID      *uint           `json:"repo_id,omitempty" gorm:"uniqueIndex"`
+	Repo        *git.Repo       `json:"repo,omitempty" gorm:"foreignKey:RepoID"`
+	LastUsedAt  time.Time       `json:"last_used_at,omitempty"`
+	Status      WorkspaceStatus `json:"status" gorm:"default:ready"`
+	StatusError string          `json:"status_error,omitempty"`
+	Progress    string          `json:"progress,omitempty" gorm:"-"`
+}
+
+// AfterFind normalizes a legacy empty status (rows created before the status
+// column existed) to ready on every load, so no read path can surface "".
+func (w *Workspace) AfterFind(*gorm.DB) error {
+	if w.Status == "" {
+		w.Status = StatusReady
+	}
+	return nil
+}
+
+func (w *Workspace) IsBusy() bool {
+	return w.Status == StatusCloning || w.Status == StatusMigrating
 }

--- a/internal/workspace/workspacecontroller.go
+++ b/internal/workspace/workspacecontroller.go
@@ -104,11 +104,7 @@ func (c *WorkspaceController) CloneWorkspace(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	ws, err := c.service.CloneAndAddFromURL(ctx, CloneFromURLRequest{
-		CloneURL: req.CloneURL,
-		RootPath: req.RootPath,
-		DirName:  req.DirName,
-	})
+	ws, err := c.service.StartClone(ctx, CloneFromURLRequest(req))
 	if err != nil {
 		renderServiceError(w, r, "clone workspace failed", err)
 		return

--- a/internal/workspace/workspacerouter_test.go
+++ b/internal/workspace/workspacerouter_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/eleonorayaya/utena/internal/db/testdb"
 	"github.com/eleonorayaya/utena/internal/git"
@@ -497,14 +498,28 @@ func TestWorkspaceRouter_CloneWorkspace_HappyPath(t *testing.T) {
 
 	require.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
 
-	var resp WorkspaceResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.Equal(t, filepath.Join(root, "imported"), resp.Path)
-	require.True(t, resp.IsBare)
+	var created WorkspaceResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	require.Equal(t, filepath.Join(root, "imported"), created.Path)
+	require.Equal(t, StatusCloning, created.Status)
+
+	require.Eventually(t, func() bool {
+		sreq := httptest.NewRequest("GET", fmt.Sprintf("/%d", created.ID), nil)
+		sw := httptest.NewRecorder()
+		router.Routes().ServeHTTP(sw, sreq)
+		if sw.Code != http.StatusOK {
+			return false
+		}
+		var ws WorkspaceResponse
+		require.NoError(t, json.Unmarshal(sw.Body.Bytes(), &ws))
+		require.NotEqual(t, StatusFailed, ws.Status, "clone failed: %s", ws.StatusError)
+		return ws.Status == StatusReady
+	}, 30*time.Second, 25*time.Millisecond)
 
 	persisted, err := store.GetByPath(filepath.Join(root, "imported"))
 	require.NoError(t, err)
 	require.True(t, persisted.IsGitRepo)
+	require.True(t, persisted.IsBare)
 }
 
 func TestWorkspaceRouter_CloneWorkspace_MissingURL(t *testing.T) {

--- a/internal/workspace/workspaceservice.go
+++ b/internal/workspace/workspaceservice.go
@@ -13,6 +13,9 @@ import (
 	"github.com/eleonorayaya/utena/internal/git"
 )
 
+// BareOpTimeout bounds a background bare operation (clone or migrate-to-bare).
+const BareOpTimeout = 45 * time.Minute
+
 type CloneFromURLRequest struct {
 	CloneURL string
 	RootPath string
@@ -22,17 +25,29 @@ type CloneFromURLRequest struct {
 type WorkspaceService struct {
 	store      *WorkspaceStore
 	gitService *git.GitService
+	progress   *progressTracker
 }
 
 func NewWorkspaceService(store *WorkspaceStore, gitService *git.GitService) *WorkspaceService {
 	return &WorkspaceService{
 		store:      store,
 		gitService: gitService,
+		progress:   newProgressTracker(),
 	}
 }
 
+// OnAppStart fails any workspace left mid-operation by a previous daemon run:
+// its background goroutine is gone, so the clone/migration will never complete.
 func (s *WorkspaceService) OnAppStart(ctx context.Context) error {
-
+	for _, ws := range s.store.List() {
+		if ws.IsBusy() {
+			ws.Status = StatusFailed
+			ws.StatusError = "interrupted by daemon restart"
+			if err := s.store.Update(&ws); err != nil {
+				slog.Warn("failed to fail interrupted workspace on startup", "workspace", ws.Name, "error", err)
+			}
+		}
+	}
 	return nil
 }
 
@@ -42,11 +57,28 @@ func (s *WorkspaceService) OnAppEnd(ctx context.Context) error {
 }
 
 func (s *WorkspaceService) ListWorkspaces(ctx context.Context) ([]Workspace, error) {
-	return s.store.List(), nil
+	list := s.store.List()
+	for i := range list {
+		s.overlayStatus(&list[i])
+	}
+	return list, nil
 }
 
 func (s *WorkspaceService) GetWorkspace(ctx context.Context, id uint) (*Workspace, error) {
-	return s.store.GetByID(id)
+	ws, err := s.store.GetByID(id)
+	if err != nil {
+		return nil, err
+	}
+	s.overlayStatus(ws)
+	return ws, nil
+}
+
+// overlayStatus attaches the live (unpersisted) progress line for in-flight
+// operations. Status itself is normalized at load time by Workspace.AfterFind.
+func (s *WorkspaceService) overlayStatus(ws *Workspace) {
+	if ws.IsBusy() {
+		ws.Progress = s.progress.get(ws.ID)
+	}
 }
 
 func (s *WorkspaceService) GetWorkspaceByPath(ctx context.Context, path string) (*Workspace, error) {
@@ -83,15 +115,6 @@ func (s *WorkspaceService) DeleteWorkspace(ctx context.Context, id uint) error {
 
 	s.store.RemoveWorkspaceFromConfig(ws.Path)
 	return nil
-}
-
-func (s *WorkspaceService) MarkAsBare(ctx context.Context, id uint) error {
-	ws, err := s.store.GetByID(id)
-	if err != nil {
-		return err
-	}
-	ws.IsBare = true
-	return s.store.Update(ws)
 }
 
 func (s *WorkspaceService) AddWorkspace(ctx context.Context, path string, asRoot bool) (*Workspace, error) {
@@ -137,50 +160,148 @@ func (s *WorkspaceService) AddWorkspace(ctx context.Context, path string, asRoot
 	return ws, nil
 }
 
-func (s *WorkspaceService) CloneAndAddFromURL(ctx context.Context, req CloneFromURLRequest) (*Workspace, error) {
-	cloneURL := strings.TrimSpace(req.CloneURL)
+func (s *WorkspaceService) resolveCloneTarget(req CloneFromURLRequest) (cloneURL, targetPath string, err error) {
+	cloneURL = strings.TrimSpace(req.CloneURL)
 	if cloneURL == "" {
-		return nil, common.NewInvalidRequest("clone_url is required")
+		return "", "", common.NewInvalidRequest("clone_url is required")
 	}
 	if s.gitService == nil {
-		return nil, fmt.Errorf("git service not configured")
+		return "", "", fmt.Errorf("git service not configured")
 	}
 
 	roots := s.store.ConfiguredRoots()
 	rootPath, err := resolveRootPath(req.RootPath, roots)
 	if err != nil {
-		return nil, err
+		return "", "", err
 	}
 
 	dirName := strings.TrimSpace(req.DirName)
 	if dirName == "" {
 		_, repoName, parseErr := s.gitService.ParseRepoFullName(cloneURL)
 		if parseErr != nil {
-			return nil, common.WrapInvalidRequest("cannot derive directory name from clone URL", parseErr)
+			return "", "", common.WrapInvalidRequest("cannot derive directory name from clone URL", parseErr)
 		}
 		dirName = repoName
 	}
 	if strings.ContainsAny(dirName, "/\\") {
-		return nil, common.NewInvalidRequest(fmt.Sprintf("invalid directory name %q (must not contain path separators)", dirName))
+		return "", "", common.NewInvalidRequest(fmt.Sprintf("invalid directory name %q (must not contain path separators)", dirName))
 	}
 
-	targetPath := filepath.Join(rootPath, dirName)
+	targetPath = filepath.Join(rootPath, dirName)
 	if _, statErr := os.Stat(targetPath); statErr == nil {
-		return nil, common.NewConflict(fmt.Sprintf("target path already exists: %s", targetPath))
+		return "", "", common.NewConflict(fmt.Sprintf("target path already exists: %s", targetPath))
 	} else if !os.IsNotExist(statErr) {
-		return nil, fmt.Errorf("failed to inspect target path %s: %w", targetPath, statErr)
+		return "", "", fmt.Errorf("failed to inspect target path %s: %w", targetPath, statErr)
 	}
 
-	if err := s.gitService.CloneBareWorkspace(ctx, cloneURL, targetPath); err != nil {
-		return nil, common.WrapInvalidRequest("git clone failed", err)
+	return cloneURL, targetPath, nil
+}
+
+// StartClone validates synchronously (returning user errors immediately),
+// creates the workspace row up-front in the "cloning" state, and runs the slow
+// clone in the background. Callers observe progress and completion via the
+// workspace's Status/Progress, not a separate job handle.
+func (s *WorkspaceService) StartClone(ctx context.Context, req CloneFromURLRequest) (*Workspace, error) {
+	cloneURL, targetPath, err := s.resolveCloneTarget(req)
+	if err != nil {
+		return nil, err
 	}
 
-	ws, addErr := s.AddWorkspace(ctx, targetPath, false)
-	if addErr != nil {
-		_ = os.RemoveAll(targetPath)
-		return nil, addErr
+	ws := &Workspace{
+		Name:   filepath.Base(targetPath),
+		Path:   targetPath,
+		Status: StatusCloning,
 	}
+	if err := s.store.Add(ws); err != nil {
+		return nil, err
+	}
+
+	id := ws.ID
+	go func() {
+		bgCtx, cancel := context.WithTimeout(context.Background(), BareOpTimeout)
+		defer cancel()
+		if cloneErr := s.gitService.CloneBareWorkspace(bgCtx, cloneURL, targetPath, s.ProgressFn(id)); cloneErr != nil {
+			_ = os.RemoveAll(targetPath)
+			s.FailBareOperation(id, common.WrapInvalidRequest("git clone failed", cloneErr))
+			return
+		}
+		if err := s.FinalizeBareWorkspace(bgCtx, id); err != nil {
+			s.FailBareOperation(id, err)
+		}
+	}()
 	return ws, nil
+}
+
+// ProgressFn returns the progress callback for a background bare operation; each
+// line is recorded against the workspace for status reads to surface.
+func (s *WorkspaceService) ProgressFn(id uint) func(string) {
+	return func(line string) { s.progress.set(id, line) }
+}
+
+// BeginMigration marks a workspace as migrating and returns the updated row.
+func (s *WorkspaceService) BeginMigration(ctx context.Context, id uint) (*Workspace, error) {
+	ws, err := s.store.GetByID(id)
+	if err != nil {
+		return nil, err
+	}
+	ws.Status = StatusMigrating
+	ws.StatusError = ""
+	if err := s.store.Update(ws); err != nil {
+		return nil, err
+	}
+	s.overlayStatus(ws)
+	return ws, nil
+}
+
+// FinalizeBareWorkspace clears live progress and promotes a freshly-cloned or
+// migrated workspace to ready: detect the on-disk git/bare kind, resolve the
+// repo, and record the path in config. Shared terminal step for both clone and
+// migrate-to-bare.
+func (s *WorkspaceService) FinalizeBareWorkspace(ctx context.Context, id uint) error {
+	s.progress.clear(id)
+	ws, err := s.store.GetByID(id)
+	if err != nil {
+		return err
+	}
+
+	// Reaching here means the bare clone/migrate succeeded, so the workspace is
+	// a bare git repo by construction.
+	ws.IsGitRepo = true
+	ws.IsBare = true
+	ws.Status = StatusReady
+	ws.StatusError = ""
+
+	if s.gitService != nil && ws.RepoID == nil {
+		if repo, repoErr := s.gitService.FindOrCreateRepo(ctx, ws.Path); repoErr == nil {
+			ws.RepoID = &repo.ID
+		} else {
+			slog.Warn("failed to resolve repo id for workspace", "workspace", ws.Name, "error", repoErr)
+		}
+	}
+
+	if err := s.store.Update(ws); err != nil {
+		return err
+	}
+	if err := s.store.appendWorkspacePath(ws.Path); err != nil {
+		slog.Warn("failed to record workspace path in config", "workspace", ws.Name, "error", err)
+	}
+	return nil
+}
+
+// FailBareOperation clears live progress and marks the workspace failed. Shared
+// error terminal for both clone and migrate-to-bare.
+func (s *WorkspaceService) FailBareOperation(id uint, cause error) {
+	s.progress.clear(id)
+	ws, err := s.store.GetByID(id)
+	if err != nil {
+		slog.Warn("failed to load workspace to mark failed", "id", id, "error", err)
+		return
+	}
+	ws.Status = StatusFailed
+	ws.StatusError = cause.Error()
+	if err := s.store.Update(ws); err != nil {
+		slog.Warn("failed to mark workspace failed", "workspace", ws.Name, "error", err)
+	}
 }
 
 func resolveRootPath(requested string, configured []string) (string, error) {

--- a/internal/workspace/workspaceservice_test.go
+++ b/internal/workspace/workspaceservice_test.go
@@ -35,6 +35,32 @@ func TestWorkspaceService_OnAppStart(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestWorkspaceService_OnAppStart_FailsInterruptedWorkspaces(t *testing.T) {
+	service, store := setupWorkspaceService(t)
+
+	cloning := &Workspace{Name: "c", Path: "/p/c", Status: StatusCloning}
+	migrating := &Workspace{Name: "m", Path: "/p/m", Status: StatusMigrating}
+	ready := &Workspace{Name: "r", Path: "/p/r", Status: StatusReady}
+	require.NoError(t, store.Add(cloning))
+	require.NoError(t, store.Add(migrating))
+	require.NoError(t, store.Add(ready))
+
+	require.NoError(t, service.OnAppStart(context.Background()))
+
+	got, err := store.GetByID(cloning.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusFailed, got.Status)
+	require.NotEmpty(t, got.StatusError)
+
+	got, err = store.GetByID(migrating.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusFailed, got.Status)
+
+	got, err = store.GetByID(ready.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusReady, got.Status, "ready workspaces are untouched")
+}
+
 func TestWorkspaceService_OnAppEnd(t *testing.T) {
 	service, _ := setupWorkspaceService(t)
 	ctx := context.Background()
@@ -288,51 +314,72 @@ func setupServiceWithGitAndRoots(t *testing.T, rootCount int) (*WorkspaceService
 	return service, roots
 }
 
-func TestWorkspaceService_CloneAndAddFromURL_HappyPath(t *testing.T) {
+func waitWorkspaceStatus(t *testing.T, svc *WorkspaceService, id uint, want WorkspaceStatus) *Workspace {
+	t.Helper()
+	var ws *Workspace
+	require.Eventually(t, func() bool {
+		w, err := svc.GetWorkspace(context.Background(), id)
+		if err != nil {
+			return false
+		}
+		ws = w
+		return w.Status == want
+	}, 30*time.Second, 20*time.Millisecond)
+	return ws
+}
+
+func TestWorkspaceService_StartClone_HappyPath(t *testing.T) {
 	service, rootDir := setupServiceWithGitAndRoot(t)
 	source := initTestRepo(t)
 
-	ws, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{
+	ws, err := service.StartClone(context.Background(), CloneFromURLRequest{
 		CloneURL: source,
 		DirName:  "imported",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, ws)
 	require.Equal(t, filepath.Join(rootDir, "imported"), ws.Path)
-	require.True(t, ws.IsBare)
-	require.True(t, ws.IsGitRepo)
+	require.Equal(t, StatusCloning, ws.Status)
 
-	bareInfo, err := os.Stat(filepath.Join(ws.Path, ".bare"))
+	done := waitWorkspaceStatus(t, service, ws.ID, StatusReady)
+	require.True(t, done.IsBare)
+	require.True(t, done.IsGitRepo)
+
+	bareInfo, err := os.Stat(filepath.Join(done.Path, ".bare"))
 	require.NoError(t, err)
 	require.True(t, bareInfo.IsDir())
 }
 
-func TestWorkspaceService_CloneAndAddFromURL_DerivesDirNameFromURL(t *testing.T) {
+func TestWorkspaceService_StartClone_FailureLeavesFailedWorkspace(t *testing.T) {
 	service, rootDir := setupServiceWithGitAndRoot(t)
 
-	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{
+	ws, err := service.StartClone(context.Background(), CloneFromURLRequest{
 		CloneURL: "git@github.com:foo/bar.git",
 	})
-	require.Error(t, err, "expected clone to fail with unreachable remote so we can verify path derivation")
+	require.NoError(t, err, "validation passes; the unreachable remote fails asynchronously")
+	require.Equal(t, "bar", ws.Name, "dir name derived from URL")
+
+	failed := waitWorkspaceStatus(t, service, ws.ID, StatusFailed)
+	require.NotEmpty(t, failed.StatusError)
 
 	_, statErr := os.Stat(filepath.Join(rootDir, "bar"))
-	require.True(t, os.IsNotExist(statErr), "failed clone should clean up the derived target dir")
+	require.True(t, os.IsNotExist(statErr), "failed clone should clean up the partial target dir")
 }
 
-func TestWorkspaceService_CloneAndAddFromURL_RejectsEmptyURL(t *testing.T) {
+func TestWorkspaceService_StartClone_RejectsEmptyURL(t *testing.T) {
 	service, _ := setupServiceWithGitAndRoot(t)
-	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{})
+	_, err := service.StartClone(context.Background(), CloneFromURLRequest{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "clone_url is required")
 }
 
-func TestWorkspaceService_CloneAndAddFromURL_RejectsTargetExists(t *testing.T) {
+func TestWorkspaceService_StartClone_RejectsTargetExists(t *testing.T) {
 	service, rootDir := setupServiceWithGitAndRoot(t)
 	existing := filepath.Join(rootDir, "imported")
 	require.NoError(t, os.MkdirAll(existing, 0755))
 
 	source := initTestRepo(t)
-	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{
+	_, err := service.StartClone(context.Background(), CloneFromURLRequest{
 		CloneURL: source,
 		DirName:  "imported",
 	})
@@ -340,37 +387,38 @@ func TestWorkspaceService_CloneAndAddFromURL_RejectsTargetExists(t *testing.T) {
 	require.Contains(t, err.Error(), "already exists")
 }
 
-func TestWorkspaceService_CloneAndAddFromURL_NoConfiguredRoots(t *testing.T) {
+func TestWorkspaceService_StartClone_NoConfiguredRoots(t *testing.T) {
 	service, _ := setupServiceWithGitAndRoots(t, 0)
 	source := initTestRepo(t)
 
-	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{CloneURL: source, DirName: "x"})
+	_, err := service.StartClone(context.Background(), CloneFromURLRequest{CloneURL: source, DirName: "x"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no workspace roots configured")
 }
 
-func TestWorkspaceService_CloneAndAddFromURL_MultipleRootsRequiresExplicit(t *testing.T) {
+func TestWorkspaceService_StartClone_MultipleRootsRequiresExplicit(t *testing.T) {
 	service, roots := setupServiceWithGitAndRoots(t, 2)
 	source := initTestRepo(t)
 
-	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{CloneURL: source, DirName: "x"})
+	_, err := service.StartClone(context.Background(), CloneFromURLRequest{CloneURL: source, DirName: "x"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "multiple workspace roots")
 
-	ws, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{
+	ws, err := service.StartClone(context.Background(), CloneFromURLRequest{
 		CloneURL: source,
 		RootPath: roots[1],
 		DirName:  "x",
 	})
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(roots[1], "x"), ws.Path)
+	waitWorkspaceStatus(t, service, ws.ID, StatusReady)
 }
 
-func TestWorkspaceService_CloneAndAddFromURL_RejectsUnknownRoot(t *testing.T) {
+func TestWorkspaceService_StartClone_RejectsUnknownRoot(t *testing.T) {
 	service, _ := setupServiceWithGitAndRoot(t)
 	source := initTestRepo(t)
 
-	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{
+	_, err := service.StartClone(context.Background(), CloneFromURLRequest{
 		CloneURL: source,
 		RootPath: "/nope",
 		DirName:  "x",
@@ -379,11 +427,11 @@ func TestWorkspaceService_CloneAndAddFromURL_RejectsUnknownRoot(t *testing.T) {
 	require.Contains(t, err.Error(), "not a configured workspace root")
 }
 
-func TestWorkspaceService_CloneAndAddFromURL_RejectsPathSeparatorInDirName(t *testing.T) {
+func TestWorkspaceService_StartClone_RejectsPathSeparatorInDirName(t *testing.T) {
 	service, _ := setupServiceWithGitAndRoot(t)
 	source := initTestRepo(t)
 
-	_, err := service.CloneAndAddFromURL(context.Background(), CloneFromURLRequest{
+	_, err := service.StartClone(context.Background(), CloneFromURLRequest{
 		CloneURL: source,
 		DirName:  "weird/name",
 	})

--- a/internal/workspace/workspacestore.go
+++ b/internal/workspace/workspacestore.go
@@ -223,16 +223,30 @@ func (s *WorkspaceStore) AddWorkspace(path string) (*Workspace, error) {
 		return nil, err
 	}
 
+	if err := s.appendWorkspacePath(path); err != nil {
+		return nil, err
+	}
+
+	return ws, nil
+}
+
+// appendWorkspacePath records a workspace path in config.json so it is
+// rediscovered on restart. Safe to call for an already-recorded path.
+func (s *WorkspaceStore) appendWorkspacePath(path string) error {
 	cfg, err := s.loadConfig()
 	if err != nil {
 		cfg = &config{}
 	}
+	for _, p := range cfg.Workspaces {
+		if p == path {
+			return nil
+		}
+	}
 	cfg.Workspaces = append(cfg.Workspaces, path)
 	if err := s.saveConfig(cfg); err != nil {
-		return nil, fmt.Errorf("failed to save config: %w", err)
+		return fmt.Errorf("failed to save config: %w", err)
 	}
-
-	return ws, nil
+	return nil
 }
 
 func (s *WorkspaceStore) AddWorkspaceRoot(path string) ([]Workspace, error) {


### PR DESCRIPTION
## Summary
- Clone-from-URL and migrate-to-bare now run **in the background** and surface progress through the workspace's own state — a persisted `Status` (`ready`/`cloning`/`migrating`/`failed`) plus a transient `Progress` line — instead of blocking the HTTP request behind a 5-minute client timeout (which was killing large-repo clones/migrations mid-flight).
- Clone creates the workspace row up-front as `cloning` and returns it immediately; the background op finalizes it to `ready`, or leaves a dismissable `failed` row (cleaning up the partial `.bare`). Clone and migrate share one lifecycle: `ProgressFn` / `FinalizeBareWorkspace` / `FailBareOperation`.
- **git**: stream `git clone --bare --progress`; cancel via process-group kill (`Setpgid` + `WaitDelay`) so a stuck clone can actually be aborted. Also skip branch-sync for repos whose path no longer exists — that runaway `failed to sync branch` WARN loop had grown the daemon log to ~76 GB.
- **Startup recovery**: a workspace left `cloning`/`migrating` by a killed daemon is marked `failed` on boot, so nothing hangs forever.
- **TUI**: the workspace list shows live status/progress inline and polls only while a workspace is busy (a single fetch chain, regardless of how many ops are in flight).

## Test plan
- [ ] `task test` and `task lint` green
- [ ] Clone a large repo from a URL via the TUI → workspace appears as `cloning` with advancing progress, then flips to `ready`
- [ ] Migrate an existing non-bare workspace → shows `migrating` → `ready`
- [ ] Clone with an unreachable/bad URL → workspace ends `failed` with the error, partial dir removed
- [ ] Restart the daemon mid-clone → the stuck workspace becomes `failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
