### PR TITLE
Start auto PR review sessions in auto mode with better-review skill

### DIFF
--- a/internal/session/sessionaction_test.go
+++ b/internal/session/sessionaction_test.go
@@ -95,7 +95,7 @@ func TestExecuteSessionActions_Claude_SpawnsWindow(t *testing.T) {
 	require.Len(t, spawner.calls, 1)
 	require.Equal(t, "my-session", spawner.calls[0].sessionName)
 	require.Equal(t, "/workspace", spawner.calls[0].startDir)
-	require.Equal(t, `claude "/review"`, spawner.calls[0].command)
+	require.Equal(t, `claude --permission-mode auto "/review"`, spawner.calls[0].command)
 
 	actions, _ := store.ListBySessionIDAndTrigger(sess.ID, TriggerOnCreate)
 	require.Empty(t, actions[0].Error)

--- a/internal/session/sessionactionexecutor.go
+++ b/internal/session/sessionactionexecutor.go
@@ -22,7 +22,7 @@ func executeSessionActions(actions []SessionAction, spawner WindowSpawner, store
 			if err = json.Unmarshal([]byte(action.Options), &opts); err != nil {
 				err = fmt.Errorf("invalid claude options: %w", err)
 			} else {
-				err = spawner.SpawnWindow(tmuxName, startDir, fmt.Sprintf("claude %q", opts.Prompt))
+				err = spawner.SpawnWindow(tmuxName, startDir, fmt.Sprintf("claude --permission-mode auto %q", opts.Prompt))
 			}
 		default:
 			slog.Warn("unknown session action type, skipping", "type", action.Type)

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -1592,14 +1592,7 @@ func (s *SessionService) maybeCreatePendingSession(ctx context.Context, data git
 		return
 	}
 
-	prompt := fmt.Sprintf(
-		"/review the latest changes for the PR %s are checked out in the current working directory. "+
-			"Review the changes and prepare an initial feedback report (in memory, don't write to a file). "+
-			"Then for each piece of feedback spawn a subagent to play devil's advocate and verify the validity of the feedback. "+
-			"Once that is done prepare a final feedback report for me incorporating the subagent feedback (in memory again). "+
-			"The final report should just reflect the final state of feedback and should not reference any initial feedback that was dismissed by the subagents or make any reference at all to the process.",
-		pr.HTMLURL,
-	)
+	prompt := fmt.Sprintf("/git-workflows:better-review %s", pr.HTMLURL)
 	reviewAction := &SessionAction{
 		Trigger: TriggerOnCreate,
 		Type:    SessionActionTypeClaude,


### PR DESCRIPTION
## Summary
- Auto PR review sessions now spawn `claude --permission-mode auto` so the review starts in auto mode without permission prompts.
- The review prompt now just invokes `/git-workflows:better-review <PR URL>`. That skill already fetches PR metadata, diffs locally, runs devil's-advocate subagents to filter weak feedback, and prints a clean report — replacing the previous hand-rolled multi-step prompt.

## Test plan
- [ ] `task test` passes (session package green)
- [ ] Assign yourself a PR and confirm the spawned session runs `claude --permission-mode auto "/git-workflows:better-review <url>"` and produces a review report
