### PR TITLE
fix(session): reactivate archived sessions instead of switching to a stray tmux session

### DIFF
--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -1055,10 +1055,13 @@ func (s *SessionService) ActivateSession(ctx context.Context, id uint) (*Session
 
 	s.ensureSessionWorktrees(ctx, session)
 
-	if session.TmuxSession == nil {
+	tmuxName := SanitizeTmuxName(session.Name)
+	if session.TmuxSessionID != nil && session.TmuxSession != nil && session.TmuxSession.Name != "" {
+		tmuxName = session.TmuxSession.Name
+	}
+	if tmuxName == "" {
 		return nil, fmt.Errorf("session has no tmux record; please repair")
 	}
-	tmuxName := session.TmuxSession.Name
 
 	if !s.tmuxService.HasSession(tmuxName) {
 		startDir := session.SessionRoot
@@ -1080,6 +1083,7 @@ func (s *SessionService) ActivateSession(ctx context.Context, id uint) (*Session
 			}
 		}
 		session.TmuxSessionID = &ts.ID
+		session.TmuxSession = ts
 		session.Status = StatusActive
 		session.StatusError = ""
 	}

--- a/internal/session/sessionservice_test.go
+++ b/internal/session/sessionservice_test.go
@@ -820,6 +820,38 @@ func TestSessionService_ActivateSession_RecreatesMissingTmux(t *testing.T) {
 	require.True(t, tmux.HasSessionByName("utena-session-1"))
 }
 
+func TestSessionService_ActivateSession_ReactivatesArchived(t *testing.T) {
+	service, sessionStore, _, tmux, ws1ID, _ := setupSessionService(t)
+
+	session := &Session{
+		Name:       "session-1",
+		Status:     StatusActive,
+		LastUsedAt: time.Now(),
+	}
+	addTestSession(t, sessionStore, swtStoreFor(service), session, ws1ID)
+	tmuxName := SanitizeTmuxName(session.Name)
+	tmuxRecord, err := service.tmuxService.RegisterPending(tmuxName, "/tmp/utena", nil)
+	require.NoError(t, err)
+	session.TmuxSessionID = &tmuxRecord.ID
+	require.NoError(t, sessionStore.Update(session))
+	tmux.Sessions[tmuxName] = true
+
+	ctx := context.Background()
+	archived, err := service.ArchiveSession(ctx, session.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusArchived, archived.Status)
+	require.Nil(t, archived.TmuxSessionID, "archive should release the tmux record claim")
+	require.False(t, tmux.HasSessionByName(tmuxName), "archive should kill the tmux session")
+
+	result, err := service.ActivateSession(ctx, session.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusActive, result.Status)
+	require.True(t, result.IsAttached)
+	require.True(t, tmux.HasSessionByName(tmuxName), "reactivation should recreate the tmux session")
+	require.NotNil(t, result.TmuxSession)
+	require.Equal(t, tmuxName, result.TmuxSession.Name, "response must carry the recreated tmux name for switch-client")
+}
+
 func TestSessionService_RefreshSession_DetectsMissingTmux(t *testing.T) {
 	service, sessionStore, _, tmux, ws1ID, _ := setupSessionService(t)
 


### PR DESCRIPTION
## Summary
- Reactivating an archived session from the session list failed to recreate its tmux session and instead switched the client to an empty/unrelated session.
- Root cause: archiving nils `TmuxSessionID`, and `GetByID`'s `Joins("TmuxSession")` returns a **non-nil empty struct** for the null FK — so the old `session.TmuxSession == nil` guard never fired, the derived tmux name was `""`, and the TUI ran `tmux switch-client -t ""`.
- Fix (all in `ActivateSession`): derive the tmux name from the immutable session name when the record link is gone (preferring the live record's name when present), guard on the derived name being empty, and populate the returned `TmuxSession` so the API response carries the correct name for the TUI's switch-client. `ArchiveSession` is unchanged, so it still releases the record claim and recreating a same-name session can't collide on the unique index.

## Test plan
- [x] Added `TestSessionService_ActivateSession_ReactivatesArchived` (asserts tmux session is recreated, status active, attached, the response carries `TmuxSession.Name`, and archive releases the record claim) — confirmed it fails before the fix
- [x] `task test` passes
- [ ] Manual: archive a session, hit enter on it in the session list, confirm it reattaches to the correct (recreated) tmux session

> Note: `task lint` is red on pre-existing unchecked-error issues in `sessionservice_test.go:542/544`, outside this diff.
