### PR TITLE
fix(session): set upstream from the worktree, not the bare workspace root

### DIFF
--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -708,7 +708,7 @@ func (s *SessionService) setupSingleWorktree(ctx context.Context, sess *Session,
 	}
 
 	if created && baseBranchName != "" {
-		if pushErr := s.gitService.PushSetUpstream(ctx, ws.Path, finalBranchName); pushErr != nil {
+		if pushErr := s.gitService.PushSetUpstream(ctx, wtPath, finalBranchName); pushErr != nil {
 			slog.WarnContext(ctx, "push --set-upstream failed", "branch", finalBranchName, "error", pushErr)
 			if warning == "" {
 				warning = fmt.Sprintf("upstream not set: %v", pushErr)

--- a/internal/session/sessionservice_setupsteps_test.go
+++ b/internal/session/sessionservice_setupsteps_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -243,4 +244,70 @@ func TestSessionService_RepairSession_StepsReset(t *testing.T) {
 	for _, s := range after {
 		require.Equal(t, SetupStepDone, s.Status, "step %q should be done after repair", s.Label)
 	}
+}
+
+// initBareWorkspaceWithPrePushHook builds a bare-workspace layout (.bare dir + .git
+// marker, the same layout cloneBareWorkspace produces) with an origin and a pre-push
+// hook that runs a work-tree-only command. Pushing the new branch from the workspace
+// root (a bare repo, no work tree) makes that hook fail with "this operation must be
+// run in a work tree"; pushing from the worktree succeeds. Returns the workspace path.
+func initBareWorkspaceWithPrePushHook(t *testing.T) string {
+	t.Helper()
+	gitEnv := append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	run := func(dir string, args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		cmd.Env = gitEnv
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "command %v failed: %s", args, string(out))
+	}
+
+	origin := t.TempDir()
+	run(origin, "git", "init", "--bare", "-b", "main")
+
+	seed := t.TempDir()
+	run(seed, "git", "init", "-b", "main")
+	run(seed, "git", "config", "user.email", "test@test.com")
+	run(seed, "git", "config", "user.name", "Test")
+	run(seed, "git", "config", "commit.gpgsign", "false")
+	run(seed, "git", "remote", "add", "origin", origin)
+	run(seed, "git", "commit", "--allow-empty", "-m", "init")
+	run(seed, "git", "push", "-u", "origin", "HEAD")
+
+	ws := t.TempDir()
+	run(ws, "git", "clone", "--bare", origin, ".bare")
+	require.NoError(t, os.WriteFile(filepath.Join(ws, ".git"), []byte("gitdir: ./.bare\n"), 0o644))
+	run(ws, "git", "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+	// Force repo-local hooks so a developer's global core.hooksPath can't suppress the hook.
+	hooksDir := filepath.Join(ws, ".bare", "hooks")
+	run(ws, "git", "config", "core.hooksPath", hooksDir)
+	run(ws, "git", "fetch", "origin")
+
+	hook := filepath.Join(hooksDir, "pre-push")
+	require.NoError(t, os.WriteFile(hook, []byte("#!/bin/sh\ngit status --porcelain >/dev/null\n"), 0o755))
+	return ws
+}
+
+func TestSessionService_SetupWorktree_PushesUpstreamFromWorktree(t *testing.T) {
+	wsPath := initBareWorkspaceWithPrePushHook(t)
+	service, sessionStore, _, wsGitID, database, _ := setupWorktreeSessionServiceFull(t, wsPath, t.TempDir())
+	require.NoError(t, database.Exec("UPDATE workspaces SET is_bare = 1 WHERE id = ?", wsGitID).Error)
+
+	sess, err := service.CreateSession(context.Background(), CreateSessionInput{
+		Name:       "bare-upstream",
+		Workspaces: []WorkspaceBranchSpec{{WorkspaceID: wsGitID, BaseBranch: "main"}},
+	})
+	require.NoError(t, err)
+	waitForStatus(t, sessionStore, sess.ID, StatusActive, 5*time.Second)
+
+	final, err := sessionStore.GetByID(sess.ID)
+	require.NoError(t, err)
+	require.NotContains(t, final.StatusError, "upstream not set",
+		"push --set-upstream must run from the worktree, not the bare workspace root")
+
+	// The new branch should now exist on origin.
+	cmd := exec.Command("git", "-C", wsPath, "ls-remote", "--heads", "origin", "refs/heads/eqt/bare-upstream")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "ls-remote failed: %s", string(out))
+	require.Contains(t, string(out), "eqt/bare-upstream", "expected branch pushed to origin")
 }


### PR DESCRIPTION
## Problem

Creating a new utena session sometimes errored at the set-upstream step with `fatal: this operation must be run in a work tree`.

`push --set-upstream` for a newly created session branch ran against the **workspace root** (`ws.Path`). For a bare workspace that path is the bare repo — there's no work tree — so any repo **pre-push hook** that inspects the tree (`git status`, lint, etc.) fails, the push aborts, and the upstream is never set. This is why it was intermittent: only repos with such a hook trip it. The rest of setup already special-cases bare workspaces via `ws.IsBare`; this one push didn't.

## Fix

Push from `wtPath` — the worktree `git worktree add` just created — instead of `ws.Path`. The worktree is a valid work tree in both the bare and non-bare layouts, so hooks (and submodule recursion) run correctly. One line.

## Test

`TestSessionService_SetupWorktree_PushesUpstreamFromWorktree` drives `CreateSession` against a bare workspace with a pre-push hook. It reproduces the exact error before the fix (red) and passes after (green) — existing tests missed this because `initTestRepo` builds a non-bare working tree where the root push works.

## Note

The eager push exists only to set the tracking ref for new branches. A leaner alternative is `git config push.autoSetupRemote true` (sets upstream on first real push, no eager empty-branch push, no setup-time network) — out of scope here; keeping current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)