### PR TITLE
feat(tui): separate archive/delete keys, footer status, sort hidden last

### DIFF
--- a/docs/superpowers/specs/2026-07-01-session-archive-delete-keys-design.md
+++ b/docs/superpowers/specs/2026-07-01-session-archive-delete-keys-design.md
@@ -1,0 +1,100 @@
+# Separate archive / delete keys in the session list
+
+## Goal
+
+Give the session list two distinct destructive shortcuts instead of today's
+single contextual `d`:
+
+- **`a`** — archive the selected session
+- **`d`** — hard-delete the selected session (removes worktrees), works on any
+  session in one step
+
+## Background
+
+The backend, controller, and TUI provider already support both operations:
+
+- `SessionService.DeleteSession(ctx, id, deleteBranch, force)` — `force=true`
+  bypasses the archive-first guard and hard-deletes an active/creating session
+  (`internal/session/sessionservice.go:1132`).
+- `DeleteSession` controller honors `?force=true` (`sessioncontroller.go:134`).
+- `provider.DeleteSession(id, force)` and `provider.ArchiveSession(id)` exist
+  (`internal/tui/provider/sessionsprovider.go:58`).
+
+So this is a **TUI-only** change in `internal/tui/sessionlist/`. No backend,
+controller, or provider changes.
+
+## Final keymap (`internal/tui/sessionlist/keys.go`)
+
+| Key | Action | Change |
+|-----|--------|--------|
+| `a` | Archive selected session | was: toggle archived view |
+| `d` | Delete selected session (force) | was: contextual archive/delete |
+| `.` | Toggle hidden (broken **and** archived) | was: toggle broken only |
+
+- Remove the `ToggleArchived` binding entirely.
+- `Close` binding renamed to `Delete` (`d`, help text `"delete"`); add a new
+  `Archive` binding (`a`, help text `"archive"`).
+- `ToggleBroken` renamed to `ToggleHidden` (`.`, help text `"toggle hidden"`).
+- Update `ShortHelp`/`FullHelp` lists accordingly.
+
+## Behavior (`internal/tui/sessionlist/sessionlist.go`)
+
+### State
+
+- Collapse `showBroken` + `showArchived` into a single `showHidden bool`.
+- Add `pendingArchiveID uint` alongside the existing `pendingDeleteID uint`.
+
+### `rebuildFiltered`
+
+Skip `StatusDeleted` always; skip `StatusBroken` and `StatusArchived` unless
+`showHidden` is set.
+
+### Confirm-reset logic (top of `OnKeyMsg`)
+
+Generalize the existing reset: on any key that is not `Archive` and not nav,
+clear `pendingArchiveID`; on any key that is not `Delete` and not nav, clear
+`pendingDeleteID`. Cursor movement clears both (unchanged).
+
+### `a` (Archive)
+
+- `sel == nil` → not handled.
+- attached → status `"cannot archive attached session"`.
+- already `StatusArchived` → status `"already archived"`.
+- first press → set `pendingArchiveID`, status `"press a again to archive <name>"`.
+- second press (same id) → clear pending, `provider.ArchiveSession(id)`.
+
+### `d` (Delete)
+
+- `sel == nil` → not handled.
+- attached → status `"cannot delete attached session"`.
+- `StatusPending` → `provider.DismissSession(id)` (holds no resources).
+- first press → set `pendingDeleteID`, status
+  `"press d again to delete <name> (removes worktrees)"`.
+- second press (same id) → clear pending, `provider.DeleteSession(id, true)`.
+
+`force=true` makes the delete path uniform, so the `CanDelete()` / `IsCreating()`
+branching and the `closeConfirmMessage` / `forceDeleteMessage` helpers are
+deleted.
+
+## Tests (`internal/tui/sessionlist/sessionlist_test.go`)
+
+Rework the existing delete tests to the new semantics:
+
+- `a` first press on active → `pendingArchiveID` set, `"archive <name>"` message.
+- `a` second press → `archiveSessionIntentMsg`.
+- `a` on already-archived → `"already archived"`, no command.
+- `d` first press on active → `pendingDeleteID` set, `"delete <name>"` message.
+- `d` second press on active → `deleteSessionIntentMsg` (force delete works on a
+  live session — the core new capability).
+- `d` on pending → `dismissSessionIntentMsg`.
+- attached session → `a` and `d` both blocked with status message, no command.
+- `.` reveals both broken and archived; default filters both out.
+
+Replace `TestSessionList_ToggleArchived_RevealsArchived` (asserts `showArchived`)
+with a `showHidden` equivalent driven by `.`.
+
+## Out of scope
+
+- The full-screen **session detail** view (`sessiondetail/model.go`, opened with
+  `i`) keeps its own contextual `d` flow. Mirror later if desired.
+- No changes to `workspacelist` / `todolist` delete flows.

--- a/internal/tui/sessionlist/keys.go
+++ b/internal/tui/sessionlist/keys.go
@@ -6,39 +6,39 @@ import (
 )
 
 type keyMap struct {
-	Up             key.Binding
-	Down           key.Binding
-	Select         key.Binding
-	Close          key.Binding
-	New            key.Binding
-	Info           key.Binding
-	Todos          key.Binding
-	Workspaces     key.Binding
-	ToggleBroken   key.Binding
-	ToggleArchived key.Binding
-	Quit           key.Binding
+	Up           key.Binding
+	Down         key.Binding
+	Select       key.Binding
+	Archive      key.Binding
+	Delete       key.Binding
+	New          key.Binding
+	Info         key.Binding
+	Todos        key.Binding
+	Workspaces   key.Binding
+	ToggleHidden key.Binding
+	Quit         key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Select, k.Close, k.New, k.Info, k.Todos, k.Workspaces, k.ToggleBroken, k.ToggleArchived, k.Quit}
+	return []key.Binding{k.Select, k.Archive, k.Delete, k.New, k.Info, k.Todos, k.Workspaces, k.ToggleHidden, k.Quit}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.Up, k.Down, k.Select, k.Close, k.New, k.Info, k.Todos, k.Workspaces, k.ToggleBroken, k.ToggleArchived, k.Quit}}
+	return [][]key.Binding{{k.Up, k.Down, k.Select, k.Archive, k.Delete, k.New, k.Info, k.Todos, k.Workspaces, k.ToggleHidden, k.Quit}}
 }
 
 var keys = keyMap{
-	Up:             key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
-	Down:           key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
-	Select:         key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
-	Close:          key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "archive/delete")),
-	New:            key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
-	Info:           key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "info")),
-	Todos:          key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "todos")),
-	Workspaces:     key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "workspaces")),
-	ToggleBroken:   key.NewBinding(key.WithKeys("."), key.WithHelp(".", "toggle broken")),
-	ToggleArchived: key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "toggle archived")),
-	Quit:           key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
+	Up:           key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
+	Down:         key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
+	Select:       key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+	Archive:      key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "archive")),
+	Delete:       key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
+	New:          key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
+	Info:         key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "info")),
+	Todos:        key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "todos")),
+	Workspaces:   key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "workspaces")),
+	ToggleHidden: key.NewBinding(key.WithKeys("."), key.WithHelp(".", "toggle hidden")),
+	Quit:         key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
 }
 
 var _ help.KeyMap = keys

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -22,19 +22,19 @@ import (
 const splitThreshold = 90
 
 type Model struct {
-	sessions        []session.Session
-	filtered        []session.Session
-	cursor          int
-	offset          int
-	showBroken      bool
-	showArchived    bool
-	pendingDeleteID uint
-	pendingRepairID uint
-	statusMsg       string
-	prs             []git.PullRequest
-	lastPRSessionID uint
-	width           int
-	height          int
+	sessions         []session.Session
+	filtered         []session.Session
+	cursor           int
+	offset           int
+	showHidden       bool
+	pendingArchiveID uint
+	pendingDeleteID  uint
+	pendingRepairID  uint
+	statusMsg        string
+	prs              []git.PullRequest
+	lastPRSessionID  uint
+	width            int
+	height           int
 }
 
 func New() Model {
@@ -98,10 +98,7 @@ func (m *Model) rebuildFiltered() {
 		if s.Status == session.StatusDeleted {
 			continue
 		}
-		if s.Status == session.StatusBroken && !m.showBroken {
-			continue
-		}
-		if s.Status == session.StatusArchived && !m.showArchived {
+		if (s.Status == session.StatusBroken || s.Status == session.StatusArchived) && !m.showHidden {
 			continue
 		}
 		m.filtered = append(m.filtered, s)
@@ -152,6 +149,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.rebuildFiltered()
 		newSel := m.selectedSession()
 		if prevSel == nil || newSel == nil || prevSel.ID != newSel.ID {
+			m.pendingArchiveID = 0
 			m.pendingDeleteID = 0
 			m.pendingRepairID = 0
 			m.statusMsg = ""
@@ -197,7 +195,10 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 	}
 
 	isNav := key.Matches(msg, keys.Up) || key.Matches(msg, keys.Down)
-	if !key.Matches(msg, keys.Close) && !isNav {
+	if !key.Matches(msg, keys.Archive) && !isNav {
+		m.pendingArchiveID = 0
+	}
+	if !key.Matches(msg, keys.Delete) && !isNav {
 		m.pendingDeleteID = 0
 	}
 	if !key.Matches(msg, keys.Select) && !isNav {
@@ -217,6 +218,7 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 			m.clampOffset()
 		}
 		if sel := m.selectedSession(); sel != nil && sel.ID != prevID {
+			m.pendingArchiveID = 0
 			m.pendingDeleteID = 0
 			m.pendingRepairID = 0
 			m.statusMsg = ""
@@ -230,6 +232,7 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 			m.clampOffset()
 		}
 		if sel := m.selectedSession(); sel != nil && sel.ID != prevID {
+			m.pendingArchiveID = 0
 			m.pendingDeleteID = 0
 			m.pendingRepairID = 0
 			m.statusMsg = ""
@@ -247,13 +250,8 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 			sessiondetail.Select(*sel),
 		), true
 
-	case key.Matches(msg, keys.ToggleBroken):
-		m.showBroken = !m.showBroken
-		m.rebuildFiltered()
-		return m, nil, true
-
-	case key.Matches(msg, keys.ToggleArchived):
-		m.showArchived = !m.showArchived
+	case key.Matches(msg, keys.ToggleHidden):
+		m.showHidden = !m.showHidden
 		m.rebuildFiltered()
 		return m, nil, true
 
@@ -302,13 +300,34 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 			return m, provider.ActivateSession(sel.ID), true
 		}
 
-	case key.Matches(msg, keys.Close):
+	case key.Matches(msg, keys.Archive):
 		sel := m.selectedSession()
 		if sel == nil {
 			return m, nil, false
 		}
 		if sel.IsAttached {
-			m.statusMsg = "cannot close attached session"
+			m.statusMsg = "cannot archive attached session"
+			return m, nil, true
+		}
+		if sel.Status == session.StatusArchived {
+			m.statusMsg = "already archived"
+			return m, nil, true
+		}
+		if m.pendingArchiveID == sel.ID {
+			m.pendingArchiveID = 0
+			return m, provider.ArchiveSession(sel.ID), true
+		}
+		m.pendingArchiveID = sel.ID
+		m.statusMsg = fmt.Sprintf("press a again to archive %s", sessionDisplayName(*sel))
+		return m, nil, true
+
+	case key.Matches(msg, keys.Delete):
+		sel := m.selectedSession()
+		if sel == nil {
+			return m, nil, false
+		}
+		if sel.IsAttached {
+			m.statusMsg = "cannot delete attached session"
 			return m, nil, true
 		}
 		// Pending sessions hold no real resources; dismiss them outright.
@@ -317,17 +336,10 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 		}
 		if m.pendingDeleteID == sel.ID {
 			m.pendingDeleteID = 0
-			switch {
-			case sel.CanDelete():
-				return m, provider.DeleteSession(sel.ID, false), true
-			case sel.IsCreating():
-				return m, provider.DeleteSession(sel.ID, true), true
-			default:
-				return m, provider.ArchiveSession(sel.ID), true
-			}
+			return m, provider.DeleteSession(sel.ID, true), true
 		}
 		m.pendingDeleteID = sel.ID
-		m.statusMsg = m.closeConfirmMessage(*sel)
+		m.statusMsg = fmt.Sprintf("press d again to delete %s (removes worktrees)", sessionDisplayName(*sel))
 		return m, nil, true
 	}
 
@@ -355,25 +367,6 @@ func sessionDisplayName(s session.Session) string {
 		return s.TmuxSession.Name
 	}
 	return fmt.Sprintf("%d", s.ID)
-}
-
-func forceDeleteMessage(name string) string {
-	return fmt.Sprintf("session is still creating — press d again to force delete %s", name)
-}
-
-// closeConfirmMessage prompts the appropriate destructive action for the
-// session's state: archive for a live session, delete for an already-archived
-// one, force-delete for a stuck creating session.
-func (m Model) closeConfirmMessage(s session.Session) string {
-	name := sessionDisplayName(s)
-	switch {
-	case s.CanDelete():
-		return fmt.Sprintf("press d again to delete %s (removes worktrees)", name)
-	case s.IsCreating():
-		return forceDeleteMessage(name)
-	default:
-		return fmt.Sprintf("press d again to archive %s", name)
-	}
 }
 
 func (m Model) renderRow(s session.Session, selected bool, width int) string {

--- a/internal/tui/sessionlist/sessionlist.go
+++ b/internal/tui/sessionlist/sessionlist.go
@@ -2,6 +2,7 @@ package sessionlist
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/help"
@@ -74,6 +75,27 @@ func (m Model) selectedSession() *session.Session {
 	return &s
 }
 
+func (m *Model) confirmTwoPress(pending *uint, id uint, action tea.Cmd, prompt string) tea.Cmd {
+	if *pending == id {
+		*pending = 0
+		return action
+	}
+	*pending = id
+	m.statusMsg = prompt
+	return nil
+}
+
+func (m *Model) clearPending() {
+	m.pendingArchiveID = 0
+	m.pendingDeleteID = 0
+	m.pendingRepairID = 0
+	m.statusMsg = ""
+}
+
+func isHidden(s session.Session) bool {
+	return s.Status == session.StatusBroken || s.Status == session.StatusArchived
+}
+
 func (m *Model) clampOffset() {
 	bh := m.bodyHeight()
 	if m.cursor < m.offset {
@@ -98,11 +120,14 @@ func (m *Model) rebuildFiltered() {
 		if s.Status == session.StatusDeleted {
 			continue
 		}
-		if (s.Status == session.StatusBroken || s.Status == session.StatusArchived) && !m.showHidden {
+		if isHidden(s) && !m.showHidden {
 			continue
 		}
 		m.filtered = append(m.filtered, s)
 	}
+	sort.SliceStable(m.filtered, func(i, j int) bool {
+		return !isHidden(m.filtered[i]) && isHidden(m.filtered[j])
+	})
 
 	if selectedID != 0 {
 		for i, s := range m.filtered {
@@ -149,10 +174,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.rebuildFiltered()
 		newSel := m.selectedSession()
 		if prevSel == nil || newSel == nil || prevSel.ID != newSel.ID {
-			m.pendingArchiveID = 0
-			m.pendingDeleteID = 0
-			m.pendingRepairID = 0
-			m.statusMsg = ""
+			m.clearPending()
 		}
 		return m, m.maybeFetchPRs()
 	case provider.PRsStateUpdatedMsg:
@@ -218,10 +240,7 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 			m.clampOffset()
 		}
 		if sel := m.selectedSession(); sel != nil && sel.ID != prevID {
-			m.pendingArchiveID = 0
-			m.pendingDeleteID = 0
-			m.pendingRepairID = 0
-			m.statusMsg = ""
+			m.clearPending()
 			return m, m.maybeFetchPRs(), true
 		}
 		return m, nil, true
@@ -232,10 +251,7 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 			m.clampOffset()
 		}
 		if sel := m.selectedSession(); sel != nil && sel.ID != prevID {
-			m.pendingArchiveID = 0
-			m.pendingDeleteID = 0
-			m.pendingRepairID = 0
-			m.statusMsg = ""
+			m.clearPending()
 			return m, m.maybeFetchPRs(), true
 		}
 		return m, nil, true
@@ -313,13 +329,9 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 			m.statusMsg = "already archived"
 			return m, nil, true
 		}
-		if m.pendingArchiveID == sel.ID {
-			m.pendingArchiveID = 0
-			return m, provider.ArchiveSession(sel.ID), true
-		}
-		m.pendingArchiveID = sel.ID
-		m.statusMsg = fmt.Sprintf("press a again to archive %s", sessionDisplayName(*sel))
-		return m, nil, true
+		cmd := m.confirmTwoPress(&m.pendingArchiveID, sel.ID, provider.ArchiveSession(sel.ID),
+			fmt.Sprintf("press a again to archive %s", sessionDisplayName(*sel)))
+		return m, cmd, true
 
 	case key.Matches(msg, keys.Delete):
 		sel := m.selectedSession()
@@ -334,13 +346,9 @@ func (m Model) OnKeyMsg(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 		if sel.Status == session.StatusPending {
 			return m, provider.DismissSession(sel.ID), true
 		}
-		if m.pendingDeleteID == sel.ID {
-			m.pendingDeleteID = 0
-			return m, provider.DeleteSession(sel.ID, true), true
-		}
-		m.pendingDeleteID = sel.ID
-		m.statusMsg = fmt.Sprintf("press d again to delete %s (removes worktrees)", sessionDisplayName(*sel))
-		return m, nil, true
+		cmd := m.confirmTwoPress(&m.pendingDeleteID, sel.ID, provider.DeleteSession(sel.ID, true),
+			fmt.Sprintf("press d again to delete %s (removes worktrees)", sessionDisplayName(*sel)))
+		return m, cmd, true
 	}
 
 	return m, nil, false
@@ -390,14 +398,7 @@ func (m Model) renderRow(s session.Session, selected bool, width int) string {
 	const cursorW = 2
 	nameW := max(width-cursorW-wsPartW-timePartW-badgeW, 1)
 
-	name := sessionDisplayName(s)
-	if lipgloss.Width(name) > nameW {
-		runes := []rune(name)
-		for lipgloss.Width(string(runes)) > nameW-1 && len(runes) > 0 {
-			runes = runes[:len(runes)-1]
-		}
-		name = string(runes) + "…"
-	}
+	name := truncateWidth(sessionDisplayName(s), nameW)
 	namePad := strings.Repeat(" ", max(nameW-lipgloss.Width(name), 0))
 
 	var cursorStr string
@@ -426,15 +427,8 @@ func (m Model) renderRow(s session.Session, selected bool, width int) string {
 
 	var wsStr string
 	if showWS {
-		ws := s.WorkspaceDisplay()
 		const wsTextW = 18
-		if lipgloss.Width(ws) > wsTextW {
-			runes := []rune(ws)
-			for lipgloss.Width(string(runes)) > wsTextW-1 && len(runes) > 0 {
-				runes = runes[:len(runes)-1]
-			}
-			ws = string(runes) + "…"
-		}
+		ws := truncateWidth(s.WorkspaceDisplay(), wsTextW)
 		wsPad := strings.Repeat(" ", max(wsTextW-lipgloss.Width(ws), 0))
 		wsStr = lipgloss.NewStyle().Foreground(theme.Current.Tertiary).Render(" " + ws + wsPad)
 	}
@@ -466,12 +460,28 @@ func (m Model) renderList(width int) string {
 		idx := i + m.offset
 		selected := idx == m.cursor
 		b.WriteString(m.renderRow(s, selected, width))
-		b.WriteString("\n")
+		if i < len(visible)-1 {
+			b.WriteString("\n")
+		}
 	}
 
-	b.WriteString(lipgloss.NewStyle().Foreground(theme.Current.TextMuted).Render(m.statusMsg))
-
 	return b.String()
+}
+
+func (m Model) renderFooter() string {
+	msg := truncateWidth(m.statusMsg, m.width)
+	return lipgloss.NewStyle().Foreground(theme.Current.TextMuted).Render(msg)
+}
+
+func truncateWidth(s string, width int) string {
+	if lipgloss.Width(s) <= width {
+		return s
+	}
+	runes := []rune(s)
+	for lipgloss.Width(string(runes)) > width-1 && len(runes) > 0 {
+		runes = runes[:len(runes)-1]
+	}
+	return string(runes) + "…"
 }
 
 func (m Model) View() string {
@@ -480,21 +490,24 @@ func (m Model) View() string {
 		listW = m.listWidth()
 	}
 	listStr := m.renderList(listW)
+	footer := m.renderFooter()
 
 	if !m.isSplit() {
-		return listStr
+		return listStr + "\n" + footer
 	}
 
+	bodyH := m.height - 1
 	panelW := m.width - listW - 2
 	divStyle := lipgloss.NewStyle().Foreground(theme.Current.TextMuted)
-	divLines := make([]string, m.height)
+	divLines := make([]string, bodyH)
 	for i := range divLines {
 		divLines[i] = divStyle.Render("│ ")
 	}
 	divider := strings.Join(divLines, "\n")
 
 	sel := m.selectedSession()
-	panelStr := sessiondetail.RenderPanel(sel, m.prs, panelW, m.height)
+	panelStr := sessiondetail.RenderPanel(sel, m.prs, panelW, bodyH)
 
-	return lipgloss.JoinHorizontal(lipgloss.Top, listStr, divider, panelStr)
+	body := lipgloss.JoinHorizontal(lipgloss.Top, listStr, divider, panelStr)
+	return body + "\n" + footer
 }

--- a/internal/tui/sessionlist/sessionlist_test.go
+++ b/internal/tui/sessionlist/sessionlist_test.go
@@ -136,6 +136,24 @@ func TestSessionList_FiltersArchivedByDefault(t *testing.T) {
 	assert.Equal(t, "live", m.filtered[0].Name)
 }
 
+func TestSessionList_SortsHiddenAfterActive(t *testing.T) {
+	m := New()
+	m.showHidden = true
+	m.sessions = []session.Session{
+		{Model: gorm.Model{ID: 1}, Name: "old", Status: session.StatusArchived},
+		{Model: gorm.Model{ID: 2}, Name: "live", Status: session.StatusActive},
+		{Model: gorm.Model{ID: 3}, Name: "bad", Status: session.StatusBroken},
+		{Model: gorm.Model{ID: 4}, Name: "live2", Status: session.StatusActive},
+	}
+	m.rebuildFiltered()
+
+	var names []string
+	for _, s := range m.filtered {
+		names = append(names, s.Name)
+	}
+	assert.Equal(t, []string{"live", "live2", "old", "bad"}, names)
+}
+
 func TestSessionList_ToggleHidden_RevealsArchivedAndBroken(t *testing.T) {
 	m := New()
 	m.sessions = []session.Session{

--- a/internal/tui/sessionlist/sessionlist_test.go
+++ b/internal/tui/sessionlist/sessionlist_test.go
@@ -21,6 +21,10 @@ func pressD(m Model) (Model, tea.Cmd, bool) {
 	return m.OnKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
 }
 
+func pressA(m Model) (Model, tea.Cmd, bool) {
+	return m.OnKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+}
+
 func TestSessionList_InfoKey_NavigatesToDetail(t *testing.T) {
 	m := New()
 	m.filtered = []session.Session{
@@ -31,46 +35,59 @@ func TestSessionList_InfoKey_NavigatesToDetail(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
-func TestSessionList_Delete_Creating_FirstPress_ShowsForceMessage(t *testing.T) {
-	m := New()
-	m.filtered = []session.Session{
-		{Model: gorm.Model{ID: 1}, Name: "stuck", Status: session.StatusCreating},
-	}
-
-	result, cmd, handled := m.OnKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
-	assert.True(t, handled)
-	assert.Nil(t, cmd)
-	assert.Equal(t, uint(1), result.pendingDeleteID)
-	assert.Contains(t, result.statusMsg, "force delete stuck")
-}
-
-func TestSessionList_Delete_Creating_SecondPress_ForceDeletes(t *testing.T) {
-	m := New()
-	m.filtered = []session.Session{
-		{Model: gorm.Model{ID: 1}, Name: "stuck", Status: session.StatusCreating},
-	}
-	m.pendingDeleteID = 1
-
-	result, cmd, handled := m.OnKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
-	assert.True(t, handled)
-	assert.NotNil(t, cmd)
-	assert.Equal(t, uint(0), result.pendingDeleteID)
-}
-
-func TestSessionList_Delete_Active_FirstPress_ShowsArchiveMessage(t *testing.T) {
+func TestSessionList_Archive_Active_FirstPress_ShowsArchiveMessage(t *testing.T) {
 	m := New()
 	m.filtered = []session.Session{
 		{Model: gorm.Model{ID: 1}, Name: "live", Status: session.StatusActive},
 	}
 
-	result, cmd, handled := pressD(m)
+	result, cmd, handled := pressA(m)
 	assert.True(t, handled)
 	assert.Nil(t, cmd)
-	assert.Equal(t, uint(1), result.pendingDeleteID)
+	assert.Equal(t, uint(1), result.pendingArchiveID)
 	assert.Contains(t, result.statusMsg, "archive live")
 }
 
-func TestSessionList_Delete_Active_SecondPress_Archives(t *testing.T) {
+func TestSessionList_Archive_Active_SecondPress_Archives(t *testing.T) {
+	m := New()
+	m.filtered = []session.Session{
+		{Model: gorm.Model{ID: 1}, Name: "live", Status: session.StatusActive},
+	}
+	m.pendingArchiveID = 1
+
+	result, cmd, handled := pressA(m)
+	assert.True(t, handled)
+	assert.Equal(t, "provider.archiveSessionIntentMsg", msgTypeName(cmd))
+	assert.Equal(t, uint(0), result.pendingArchiveID)
+}
+
+func TestSessionList_Archive_AlreadyArchived_NoOp(t *testing.T) {
+	m := New()
+	m.filtered = []session.Session{
+		{Model: gorm.Model{ID: 1}, Name: "old", Status: session.StatusArchived},
+	}
+
+	result, cmd, handled := pressA(m)
+	assert.True(t, handled)
+	assert.Nil(t, cmd)
+	assert.Equal(t, uint(0), result.pendingArchiveID)
+	assert.Contains(t, result.statusMsg, "already archived")
+}
+
+func TestSessionList_Delete_Active_FirstPress_ShowsDeleteMessage(t *testing.T) {
+	m := New()
+	m.filtered = []session.Session{
+		{Model: gorm.Model{ID: 1}, Name: "live", Status: session.StatusActive},
+	}
+
+	result, cmd, handled := pressD(m)
+	assert.True(t, handled)
+	assert.Nil(t, cmd)
+	assert.Equal(t, uint(1), result.pendingDeleteID)
+	assert.Contains(t, result.statusMsg, "delete live")
+}
+
+func TestSessionList_Delete_Active_SecondPress_ForceDeletes(t *testing.T) {
 	m := New()
 	m.filtered = []session.Session{
 		{Model: gorm.Model{ID: 1}, Name: "live", Status: session.StatusActive},
@@ -79,33 +96,21 @@ func TestSessionList_Delete_Active_SecondPress_Archives(t *testing.T) {
 
 	result, cmd, handled := pressD(m)
 	assert.True(t, handled)
-	assert.Equal(t, "provider.archiveSessionIntentMsg", msgTypeName(cmd))
+	assert.Equal(t, "provider.deleteSessionIntentMsg", msgTypeName(cmd))
 	assert.Equal(t, uint(0), result.pendingDeleteID)
 }
 
-func TestSessionList_Delete_Archived_FirstPress_ShowsDeleteMessage(t *testing.T) {
+func TestSessionList_Delete_Attached_Blocked(t *testing.T) {
 	m := New()
 	m.filtered = []session.Session{
-		{Model: gorm.Model{ID: 1}, Name: "old", Status: session.StatusArchived},
+		{Model: gorm.Model{ID: 1}, Name: "live", Status: session.StatusActive, IsAttached: true},
 	}
 
 	result, cmd, handled := pressD(m)
 	assert.True(t, handled)
 	assert.Nil(t, cmd)
-	assert.Equal(t, uint(1), result.pendingDeleteID)
-	assert.Contains(t, result.statusMsg, "delete old")
-}
-
-func TestSessionList_Delete_Archived_SecondPress_Deletes(t *testing.T) {
-	m := New()
-	m.filtered = []session.Session{
-		{Model: gorm.Model{ID: 1}, Name: "old", Status: session.StatusArchived},
-	}
-	m.pendingDeleteID = 1
-
-	_, cmd, handled := pressD(m)
-	assert.True(t, handled)
-	assert.Equal(t, "provider.deleteSessionIntentMsg", msgTypeName(cmd))
+	assert.Equal(t, uint(0), result.pendingDeleteID)
+	assert.Contains(t, result.statusMsg, "cannot delete attached")
 }
 
 func TestSessionList_Pending_Dismisses(t *testing.T) {
@@ -131,16 +136,17 @@ func TestSessionList_FiltersArchivedByDefault(t *testing.T) {
 	assert.Equal(t, "live", m.filtered[0].Name)
 }
 
-func TestSessionList_ToggleArchived_RevealsArchived(t *testing.T) {
+func TestSessionList_ToggleHidden_RevealsArchivedAndBroken(t *testing.T) {
 	m := New()
 	m.sessions = []session.Session{
 		{Model: gorm.Model{ID: 1}, Name: "live", Status: session.StatusActive},
 		{Model: gorm.Model{ID: 2}, Name: "old", Status: session.StatusArchived},
+		{Model: gorm.Model{ID: 3}, Name: "bad", Status: session.StatusBroken},
 	}
 	m.rebuildFiltered()
 
-	result, _, handled := m.OnKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	result, _, handled := m.OnKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(".")})
 	assert.True(t, handled)
-	assert.True(t, result.showArchived)
-	assert.Len(t, result.filtered, 2)
+	assert.True(t, result.showHidden)
+	assert.Len(t, result.filtered, 3)
 }


### PR DESCRIPTION
## Summary
- Split the session list's single contextual `d` into two keys: **`a`** archives the selected session, **`d`** hard-deletes it (force, removes worktrees) in one step regardless of status.
- **`.`** now toggles all hidden sessions (broken + archived) via one `showHidden` flag; dropped the separate toggle-archived binding.
- Broken/archived sessions always sort after active ones (stable within each group).
- Moved the "press X again to…" confirm message to a full-width footer so long prompts no longer widen the list column and reflow the split view.
- Extracted `truncateWidth` / `clearPending` / `confirmTwoPress` helpers to remove duplication.

Backend/provider force-delete + archive plumbing already existed (#99, #102); this is a TUI-only change.

## Test plan
- [ ] `a` on an active session → confirm prompt, second `a` archives
- [ ] `d` on an active session → confirm prompt, second `d` deletes (worktrees removed)
- [ ] `d` on a pending session dismisses it; attached sessions block both
- [ ] `.` reveals broken + archived; they render below active sessions
- [ ] long confirm message no longer shifts the detail panel in split view
- [ ] `task test` green
