### PR TITLE
feat(tmux): surface sessions needing attention in the status bar

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -35,6 +35,7 @@ func main() {
 	rootCmd.AddCommand(newTaskCmd())
 	rootCmd.AddCommand(statusCmd())
 	rootCmd.AddCommand(sessionsCmd())
+	rootCmd.AddCommand(statusLineCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/tui/sessions.go
+++ b/cmd/tui/sessions.go
@@ -56,11 +56,24 @@ func filterSessions(sessions []session.Session, all bool) []session.Session {
 }
 
 func fetchSessions(port string) ([]session.Session, error) {
+	resp, err := fetchSessionListResponse(port, 10*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("could not reach utena daemon at http://localhost:%s/sessions (is it running?): %w", port, err)
+	}
+
+	sessions := make([]session.Session, len(resp.Sessions))
+	for i, sr := range resp.Sessions {
+		sessions[i] = *sr.Session
+	}
+	return sessions, nil
+}
+
+func fetchSessionListResponse(port string, timeout time.Duration) (*session.SessionListResponse, error) {
 	url := fmt.Sprintf("http://localhost:%s/sessions", port)
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := &http.Client{Timeout: timeout}
 	res, err := client.Get(url)
 	if err != nil {
-		return nil, fmt.Errorf("could not reach utena daemon at %s (is it running?): %w", url, err)
+		return nil, err
 	}
 	defer res.Body.Close()
 
@@ -72,10 +85,5 @@ func fetchSessions(port string) ([]session.Session, error) {
 	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
 		return nil, err
 	}
-
-	sessions := make([]session.Session, len(resp.Sessions))
-	for i, sr := range resp.Sessions {
-		sessions[i] = *sr.Session
-	}
-	return sessions, nil
+	return &resp, nil
 }

--- a/cmd/tui/statusline.go
+++ b/cmd/tui/statusline.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/eleonorayaya/utena/internal/claude"
+	"github.com/eleonorayaya/utena/internal/session"
+)
+
+func statusLineCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "status-line",
+		Short:        "Print a one-line tmux status-bar segment for sessions waiting on you",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			port := resolveStatusLinePort(cmd)
+			rows, err := fetchStatusLineRows(port)
+			if err != nil {
+				return nil
+			}
+			fmt.Fprint(cmd.OutOrStdout(), formatStatusLine(rows))
+			return nil
+		},
+	}
+	return cmd
+}
+
+func resolveStatusLinePort(cmd *cobra.Command) string {
+	if cmd.Root().Flags().Changed("port") {
+		port, _ := cmd.Root().Flags().GetString("port")
+		return port
+	}
+	if envPort := os.Getenv("UTENA_PORT"); envPort != "" {
+		return envPort
+	}
+	return defaultPort
+}
+
+type barRow struct {
+	Name      string
+	Attention claude.ClaudeSessionStatus
+}
+
+func fetchStatusLineRows(port string) ([]barRow, error) {
+	url := fmt.Sprintf("http://localhost:%s/sessions", port)
+	client := &http.Client{Timeout: 1500 * time.Millisecond}
+	res, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch sessions: unexpected status %d", res.StatusCode)
+	}
+
+	var resp session.SessionListResponse
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return nil, err
+	}
+
+	rows := make([]barRow, 0, len(resp.Sessions))
+	for _, sr := range resp.Sessions {
+		if sr.Session == nil || !sr.ListVisible(false) {
+			continue
+		}
+		rows = append(rows, barRow{Name: sessionDisplayLabel(*sr.Session), Attention: sr.AttentionStatus})
+	}
+	return rows, nil
+}
+
+func sessionDisplayLabel(s session.Session) string {
+	if s.Name != "" {
+		return s.Name
+	}
+	return s.WorkspaceDisplay()
+}
+
+func formatStatusLine(rows []barRow) string {
+	var needsAttention, readyForReview []string
+	for _, r := range rows {
+		switch r.Attention {
+		case claude.StatusNeedsAttention:
+			needsAttention = append(needsAttention, fmt.Sprintf("#[fg=red,bold]! %s#[default]", r.Name))
+		case claude.StatusReadyForReview:
+			readyForReview = append(readyForReview, fmt.Sprintf("#[fg=green]✓ %s#[default]", r.Name))
+		}
+	}
+	return strings.Join(append(needsAttention, readyForReview...), " ")
+}

--- a/cmd/tui/statusline.go
+++ b/cmd/tui/statusline.go
@@ -1,17 +1,13 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/eleonorayaya/utena/internal/claude"
-	"github.com/eleonorayaya/utena/internal/session"
 )
 
 func statusLineCmd() *cobra.Command {
@@ -20,7 +16,7 @@ func statusLineCmd() *cobra.Command {
 		Short:        "Print a one-line tmux status-bar segment for sessions waiting on you",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			port := resolveStatusLinePort(cmd)
+			port, _ := cmd.Root().Flags().GetString("port")
 			rows, err := fetchStatusLineRows(port)
 			if err != nil {
 				return nil
@@ -32,37 +28,14 @@ func statusLineCmd() *cobra.Command {
 	return cmd
 }
 
-func resolveStatusLinePort(cmd *cobra.Command) string {
-	if cmd.Root().Flags().Changed("port") {
-		port, _ := cmd.Root().Flags().GetString("port")
-		return port
-	}
-	if envPort := os.Getenv("UTENA_PORT"); envPort != "" {
-		return envPort
-	}
-	return defaultPort
-}
-
 type barRow struct {
 	Name      string
 	Attention claude.ClaudeSessionStatus
 }
 
 func fetchStatusLineRows(port string) ([]barRow, error) {
-	url := fmt.Sprintf("http://localhost:%s/sessions", port)
-	client := &http.Client{Timeout: 1500 * time.Millisecond}
-	res, err := client.Get(url)
+	resp, err := fetchSessionListResponse(port, 1500*time.Millisecond)
 	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fetch sessions: unexpected status %d", res.StatusCode)
-	}
-
-	var resp session.SessionListResponse
-	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
 		return nil, err
 	}
 
@@ -71,16 +44,9 @@ func fetchStatusLineRows(port string) ([]barRow, error) {
 		if sr.Session == nil || !sr.ListVisible(false) {
 			continue
 		}
-		rows = append(rows, barRow{Name: sessionDisplayLabel(*sr.Session), Attention: sr.AttentionStatus})
+		rows = append(rows, barRow{Name: sr.DisplayLabel(), Attention: sr.AttentionStatus})
 	}
 	return rows, nil
-}
-
-func sessionDisplayLabel(s session.Session) string {
-	if s.Name != "" {
-		return s.Name
-	}
-	return s.WorkspaceDisplay()
 }
 
 func formatStatusLine(rows []barRow) string {

--- a/cmd/tui/statusline_test.go
+++ b/cmd/tui/statusline_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/eleonorayaya/utena/internal/claude"
+)
+
+func TestFormatStatusLine(t *testing.T) {
+	if got := formatStatusLine(nil); got != "" {
+		t.Fatalf("empty input: got %q, want empty string", got)
+	}
+
+	rows := []barRow{
+		{Name: "review", Attention: claude.StatusReadyForReview},
+		{Name: "busy", Attention: claude.StatusWorking},
+		{Name: "urgent", Attention: claude.StatusNeedsAttention},
+		{Name: "sleeping", Attention: claude.StatusIdle},
+		{Name: "finished", Attention: claude.StatusDone},
+	}
+
+	want := "#[fg=red,bold]! urgent#[default] #[fg=green]✓ review#[default]"
+	if got := formatStatusLine(rows); got != want {
+		t.Fatalf("needs_attention must sort before ready_for_review regardless of input order: got %q, want %q", got, want)
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -63,6 +63,13 @@ func (s *Session) IsCreating() bool {
 	return s.Status == StatusCreating
 }
 
+// AttentionStatus reports whether this session needs the user's attention.
+// It currently rolls up the session's Claude statuses; it exists as a distinct
+// method so future attention logic beyond a plain Claude rollup has a home.
+func (s *Session) AttentionStatus() claude.ClaudeSessionStatus {
+	return claude.AggregateStatus(s.ClaudeSessions)
+}
+
 // CanArchive reports whether the session is in a state that can be archived:
 // any live or finished session, including broken ones.
 func (s *Session) CanArchive() bool {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -63,9 +63,7 @@ func (s *Session) IsCreating() bool {
 	return s.Status == StatusCreating
 }
 
-// AttentionStatus reports whether this session needs the user's attention.
-// It currently rolls up the session's Claude statuses; it exists as a distinct
-// method so future attention logic beyond a plain Claude rollup has a home.
+// AttentionStatus rolls up the session's Claude statuses into a single value.
 func (s *Session) AttentionStatus() claude.ClaudeSessionStatus {
 	return claude.AggregateStatus(s.ClaudeSessions)
 }
@@ -101,6 +99,14 @@ func (s *Session) ListVisible(includeHidden bool) bool {
 		return false
 	}
 	return includeHidden || !s.IsHidden()
+}
+
+// DisplayLabel returns the session's name, or its workspace label if unnamed.
+func (s *Session) DisplayLabel() string {
+	if s.Name != "" {
+		return s.Name
+	}
+	return s.WorkspaceDisplay()
 }
 
 // WorkspaceDisplay returns the human-readable label naming the workspace(s)

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -4,14 +4,20 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/eleonorayaya/utena/internal/claude"
 )
 
 type SessionResponse struct {
 	*Session
+	AttentionStatus claude.ClaudeSessionStatus `json:"attention_status,omitempty"`
 }
 
 func NewSessionResponse(session *Session) *SessionResponse {
-	return &SessionResponse{Session: session}
+	return &SessionResponse{
+		Session:         session,
+		AttentionStatus: session.AttentionStatus(),
+	}
 }
 
 func (sr *SessionResponse) Render(w http.ResponseWriter, r *http.Request) error {

--- a/plugins/utena-tmux/utena.tmux
+++ b/plugins/utena-tmux/utena.tmux
@@ -4,7 +4,10 @@ plugin_dir=${TMUX_PLUGIN_MANAGER_PATH:-$HOME/.config/tmux/plugins}
 plugin_path="$plugin_dir/utena-tmux"
 script_dir="$plugin_path/scripts"
 
-tmux set -g status off
+tmux set -g status on
+tmux set -g status-interval 1
+tmux set -g status-left-length 200
+tmux set -g status-left "#(utena status-line)"
 tmux set -g focus-events on
 
 tmux set-hook -g session-created "run-shell '${script_dir}/hook.sh session-created \"#{hook_session_name}\"'"


### PR DESCRIPTION
## Summary
- Add a computed `attention_status` field to the session API response, rolling up each session's Claude statuses (`needs_attention` / `ready_for_review` / ...) — daemon-owned so it's a single source of truth, with room for logic beyond a plain rollup later.
- Add `utena status-line`: a fast, fail-silent CLI command that renders sessions waiting on the user as a colored tmux segment, with `needs_attention` sorted ahead of `ready_for_review`.
- Wire the tmux plugin's native status bar back on (`status-left`, `status-interval 1`) instead of leaving it disabled, so waiting sessions are visible without opening the TUI popup.

## Test plan
- [x] `task fmt && task test` — all packages pass, including new `TestFormatStatusLine`
- [x] `task lint` — no new findings
- [x] `task tui:build` — binary builds, `status-line` subcommand registered
- [x] Manually verified against a live daemon: `attention_status` present in `/sessions`, `utena status-line` renders the expected `#[fg=...]` segment, prints nothing (exit 0) when the daemon is unreachable
- [x] Verified live in tmux: `status-left` renders the segment, refreshing every second
- [ ] Verify a real `needs_attention` (permission-prompt) session renders first/leftmost ahead of `ready_for_review` sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)