### PR TITLE
chore(plugin): bump utena-claude to 1.1.0 for the monitors component

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "utena-claude",
       "source": "./plugins/utena-claude",
-      "description": "Claude Code integration hooks for Utena: reports session status (working, needs attention, completed) to the Utena daemon"
+      "description": "Utena integration for Claude Code: reports session status (working, needs attention, completed) to the daemon and streams session events (PR status changes) back to Claude via a background monitor"
     }
   ]
 }

--- a/plugins/utena-claude/.claude-plugin/plugin.json
+++ b/plugins/utena-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "utena-claude",
-  "description": "Claude Code integration hooks for Utena: reports session status to the Utena daemon",
-  "version": "1.0.0",
+  "description": "Utena integration for Claude Code: reports session status to the daemon and streams session events (PR status changes) back to Claude",
+  "version": "1.1.0",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

- Bump `utena-claude` to **1.1.0**. #107 added `monitors/monitors.json` but left the version at `1.0.0`, and the plugin cache is keyed by version (`~/.claude/plugins/cache/utena/utena-claude/1.0.0/`) — so `/plugin update utena-claude` reported "already at the latest version" and existing installs kept a plugin with no monitor.
- Describe the new component in both `plugin.json` and `.claude-plugin/marketplace.json`.

## Test plan

- [x] `claude plugin validate ./plugins/utena-claude` passes (pre-existing `author` warning only)
- [ ] After merge, `/plugin update utena-claude` fetches 1.1.0 into `cache/utena/utena-claude/1.1.0/` with `monitors/monitors.json` present
- [ ] A fresh session arms the monitor from the updated cache — `monitor client connected` in the daemon log

🤖 Generated with [Claude Code](https://claude.com/claude-code)
