### PR TITLE
feat(monitor): stream PR reviews, review comments and CI checks

### DIFF
--- a/docs/adding-features.md
+++ b/docs/adding-features.md
@@ -87,10 +87,12 @@ Reviews and comments authored by the daemon's own GitHub user, or by bots, are d
 
 `SessionService.SyncPRActivity` (job `session.pr_activity`, 60s) is the driver, not the git module: only PRs whose head branch belongs to a live session are worth polling, and session is the module that knows which those are. Each PR costs up to three GitHub calls per tick, so keep that scoping if you add a source.
 
-`GitService.SyncPRActivity` owns the GitHub calls and the change detection. Watermarks live on the `PullRequest` row (`LastReviewID`, `LastReviewCommentID`, `ChecksHeadSHA`, `ChecksState`), so a daemon restart does not replay old activity. Two rules worth preserving:
+`GitService.SyncPRActivity` owns the GitHub calls and the change detection. Watermarks live on the `PullRequest` row (`ActivityBaselined`, `LastReviewID`, `LastReviewCommentID`, `ChecksHeadSHA`, `ChecksState`), so a daemon restart does not replay old activity. Two rules worth preserving:
 
-- The first sync of a PR records a baseline and emits nothing for reviews and comments — otherwise adopting a PR would dump its whole history into Claude's context. Check state is a rollup rather than a history, so it does report once on first sight.
-- `syncGitHubPR` overwrites every PR column, so it explicitly carries the watermarks over. A new column that only the activity sync maintains needs the same treatment.
+- The first sync of a PR records a baseline and emits nothing — otherwise adopting a PR would dump its history into Claude's context, and a fleet of already-green PRs would each fire a rollup at once. `ActivityBaselined` is a separate flag rather than "watermark == 0", because a PR with no reviews yet also has 0 and would lose its *first* review.
+- `syncGitHubPR` rebuilds a PR from the GitHub payload and writes every other column, so it passes `activityColumns()` to `PRStore.Update` to leave these alone. A new activity column goes in that list.
+
+The wire shapes for all four PR event types live together in `internal/git/practivity.go` (`NotificationPullRequest` and friends, `PRNotification`, `ReviewActivity`, `ReviewCommentActivity`, `ChecksActivity`). Session decides *who* gets an event; git decides what one looks like.
 
 See: `internal/monitor/`, `internal/git/practivity.go`, `internal/session/sessionservice.go` (`notifyPRUpdated`, `SyncPRActivity`, `SessionSnapshot`)
 

--- a/docs/adding-features.md
+++ b/docs/adding-features.md
@@ -72,7 +72,27 @@ s.eventBus.Publish(ctx, eventbus.Event{
 
 On connect, the monitor asks `SnapshotProvider` (implemented by `SessionService.SessionSnapshot`) for the session's current state so a session that starts after a change is not left with silence. Add the same event type there when the current state matters at connect time.
 
-See: `internal/monitor/`, `internal/session/sessionservice.go` (`notifyPRUpdated`, `SessionSnapshot`)
+### Current event types
+
+| Type | Fires when |
+|---|---|
+| `pull_request` | PR state, title or assignment changes (`git.prs` job, 30s). Also sent on connect for the session's open PRs |
+| `pull_request_review` | Someone submits a review — `state` is `approved` / `changes_requested` / `commented` |
+| `pull_request_review_comment` | Someone leaves an inline comment, with `path` and `line` |
+| `ci_checks` | `failing` the first time a check fails, then `passed` / `failed` once every run completes, with the failed check names |
+
+Reviews and comments authored by the daemon's own GitHub user, or by bots, are dropped.
+
+### Polling activity without burning the API budget
+
+`SessionService.SyncPRActivity` (job `session.pr_activity`, 60s) is the driver, not the git module: only PRs whose head branch belongs to a live session are worth polling, and session is the module that knows which those are. Each PR costs up to three GitHub calls per tick, so keep that scoping if you add a source.
+
+`GitService.SyncPRActivity` owns the GitHub calls and the change detection. Watermarks live on the `PullRequest` row (`LastReviewID`, `LastReviewCommentID`, `ChecksHeadSHA`, `ChecksState`), so a daemon restart does not replay old activity. Two rules worth preserving:
+
+- The first sync of a PR records a baseline and emits nothing for reviews and comments — otherwise adopting a PR would dump its whole history into Claude's context. Check state is a rollup rather than a history, so it does report once on first sight.
+- `syncGitHubPR` overwrites every PR column, so it explicitly carries the watermarks over. A new column that only the activity sync maintains needs the same treatment.
+
+See: `internal/monitor/`, `internal/git/practivity.go`, `internal/session/sessionservice.go` (`notifyPRUpdated`, `SyncPRActivity`, `SessionSnapshot`)
 
 ## Adding a New Module
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,14 +18,17 @@ Utena consists of three main components:
 ### Module Dependencies
 
 ```
-workspace (no dependencies)
+git (no dependencies)
+workspace (depends on: git)
     ↓
-session (depends on: workspace, eventbus)
+session (depends on: workspace, git, tmux, eventbus)
     ↓
-tmux (depends on: session, eventbus)
+tmux (depends on: eventbus)
     ↓
 monitor (depends on: session, eventbus)
 ```
+
+`git` sits at the bottom: it never imports another domain, and everything above may call it directly. It notifies upward with `git.EventPRUpdated` on the event bus.
 
 **Key principle**: Dependencies flow downward. Lower modules never depend on higher modules directly. When a lower module needs to notify a higher one, it publishes an event.
 

--- a/internal/git/githubclient.go
+++ b/internal/git/githubclient.go
@@ -15,6 +15,9 @@ type GitHubClient interface {
 	GetPR(ctx context.Context, owner, repo string, number int) (*github.PullRequest, error)
 	GetPRDiff(ctx context.Context, owner, repo string, number int) (string, error)
 	GetCurrentUser(ctx context.Context) (string, error)
+	ListPRReviews(ctx context.Context, owner, repo string, number int) ([]*github.PullRequestReview, error)
+	ListPRReviewComments(ctx context.Context, owner, repo string, number int) ([]*github.PullRequestComment, error)
+	ListCheckRuns(ctx context.Context, owner, repo, ref string) ([]*github.CheckRun, error)
 }
 
 var getEnv = os.Getenv
@@ -74,6 +77,39 @@ func (c *githubSDKClient) GetPRDiff(ctx context.Context, owner, repo string, num
 		return "", err
 	}
 	return diff, nil
+}
+
+// ponytail: one page each, newest first where the API allows it. A PR with
+// more than 100 reviews would drop the oldest unseen ones; paginate if that
+// ever happens.
+func (c *githubSDKClient) ListPRReviews(ctx context.Context, owner, repo string, number int) ([]*github.PullRequestReview, error) {
+	reviews, _, err := c.client.PullRequests.ListReviews(ctx, owner, repo, number, &github.ListOptions{PerPage: 100})
+	if err != nil {
+		return nil, err
+	}
+	return reviews, nil
+}
+
+func (c *githubSDKClient) ListPRReviewComments(ctx context.Context, owner, repo string, number int) ([]*github.PullRequestComment, error) {
+	comments, _, err := c.client.PullRequests.ListComments(ctx, owner, repo, number, &github.PullRequestListCommentsOptions{
+		Sort:        "created",
+		Direction:   "desc",
+		ListOptions: github.ListOptions{PerPage: 100},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return comments, nil
+}
+
+func (c *githubSDKClient) ListCheckRuns(ctx context.Context, owner, repo, ref string) ([]*github.CheckRun, error) {
+	result, _, err := c.client.Checks.ListCheckRunsForRef(ctx, owner, repo, ref, &github.ListCheckRunsOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.CheckRuns, nil
 }
 
 func (c *githubSDKClient) GetCurrentUser(ctx context.Context) (string, error) {

--- a/internal/git/gitmodule_test.go
+++ b/internal/git/gitmodule_test.go
@@ -42,7 +42,7 @@ func TestGitModule_OnAppStart_SetsCurrentUser(t *testing.T) {
 
 	bus := &mockEventBus{}
 	module := NewGitModule(database, bus)
-	module.Service.githubClient = &mockGitHubClient{currentUser: "testuser"}
+	module.Service.githubClient = &MockGitHubClient{CurrentUser: "testuser"}
 
 	require.NoError(t, module.OnAppStart(context.Background()))
 	assert.Equal(t, "testuser", module.Service.currentUser)

--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -528,6 +528,12 @@ func (s *GitService) syncGitHubPR(ctx context.Context, ghPR *github.PullRequest,
 		previous = &PullRequest{}
 		*previous = *existing
 		pr.Model = existing.Model
+		// the PR sync overwrites every column, so carry the activity
+		// watermarks that only SyncPRActivity maintains
+		pr.LastReviewID = existing.LastReviewID
+		pr.LastReviewCommentID = existing.LastReviewCommentID
+		pr.ChecksHeadSHA = existing.ChecksHeadSHA
+		pr.ChecksState = existing.ChecksState
 		if err := s.prStore.Update(pr); err != nil {
 			return fmt.Errorf("failed to update PR #%d: %w", ghPR.GetNumber(), err)
 		}
@@ -609,6 +615,7 @@ func ghPRToPullRequest(ghPR *github.PullRequest, repoID uint, branchID uint, cur
 		RepoID:         repoID,
 		Number:         ghPR.GetNumber(),
 		HeadBranchID:   &branchID,
+		HeadSHA:        ghPR.GetHead().GetSHA(),
 		Title:          ghPR.GetTitle(),
 		State:          state,
 		IsAssignedToMe: assigned,

--- a/internal/git/gitservice.go
+++ b/internal/git/gitservice.go
@@ -528,13 +528,8 @@ func (s *GitService) syncGitHubPR(ctx context.Context, ghPR *github.PullRequest,
 		previous = &PullRequest{}
 		*previous = *existing
 		pr.Model = existing.Model
-		// the PR sync overwrites every column, so carry the activity
-		// watermarks that only SyncPRActivity maintains
-		pr.LastReviewID = existing.LastReviewID
-		pr.LastReviewCommentID = existing.LastReviewCommentID
-		pr.ChecksHeadSHA = existing.ChecksHeadSHA
-		pr.ChecksState = existing.ChecksState
-		if err := s.prStore.Update(pr); err != nil {
+		pr.ChecksState = existing.ChecksState // read back by NewPRNotification
+		if err := s.prStore.Update(pr, activityColumns()...); err != nil {
 			return fmt.Errorf("failed to update PR #%d: %w", ghPR.GetNumber(), err)
 		}
 	} else {

--- a/internal/git/gitservice_pr_test.go
+++ b/internal/git/gitservice_pr_test.go
@@ -13,11 +13,35 @@ import (
 )
 
 type mockGitHubClient struct {
-	repoPRs     []*github.PullRequest
-	prByNumber  map[int]*github.PullRequest
-	diffContent string
-	currentUser string
-	err         error
+	repoPRs        []*github.PullRequest
+	prByNumber     map[int]*github.PullRequest
+	diffContent    string
+	currentUser    string
+	reviews        []*github.PullRequestReview
+	reviewComments []*github.PullRequestComment
+	checkRuns      []*github.CheckRun
+	err            error
+}
+
+func (m *mockGitHubClient) ListPRReviews(ctx context.Context, owner, repo string, number int) ([]*github.PullRequestReview, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.reviews, nil
+}
+
+func (m *mockGitHubClient) ListPRReviewComments(ctx context.Context, owner, repo string, number int) ([]*github.PullRequestComment, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.reviewComments, nil
+}
+
+func (m *mockGitHubClient) ListCheckRuns(ctx context.Context, owner, repo, ref string) ([]*github.CheckRun, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.checkRuns, nil
 }
 
 func (m *mockGitHubClient) ListRepoPRs(ctx context.Context, owner, repo string) ([]*github.PullRequest, error) {

--- a/internal/git/gitservice_pr_test.go
+++ b/internal/git/gitservice_pr_test.go
@@ -12,69 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type mockGitHubClient struct {
-	repoPRs        []*github.PullRequest
-	prByNumber     map[int]*github.PullRequest
-	diffContent    string
-	currentUser    string
-	reviews        []*github.PullRequestReview
-	reviewComments []*github.PullRequestComment
-	checkRuns      []*github.CheckRun
-	err            error
-}
-
-func (m *mockGitHubClient) ListPRReviews(ctx context.Context, owner, repo string, number int) ([]*github.PullRequestReview, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
-	return m.reviews, nil
-}
-
-func (m *mockGitHubClient) ListPRReviewComments(ctx context.Context, owner, repo string, number int) ([]*github.PullRequestComment, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
-	return m.reviewComments, nil
-}
-
-func (m *mockGitHubClient) ListCheckRuns(ctx context.Context, owner, repo, ref string) ([]*github.CheckRun, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
-	return m.checkRuns, nil
-}
-
-func (m *mockGitHubClient) ListRepoPRs(ctx context.Context, owner, repo string) ([]*github.PullRequest, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
-	return m.repoPRs, nil
-}
-
-func (m *mockGitHubClient) GetPR(ctx context.Context, owner, repo string, number int) (*github.PullRequest, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
-	if pr, ok := m.prByNumber[number]; ok {
-		return pr, nil
-	}
-	return nil, ErrPRNotFound
-}
-
-func (m *mockGitHubClient) GetPRDiff(ctx context.Context, owner, repo string, number int) (string, error) {
-	if m.err != nil {
-		return "", m.err
-	}
-	return m.diffContent, nil
-}
-
-func (m *mockGitHubClient) GetCurrentUser(ctx context.Context) (string, error) {
-	if m.err != nil {
-		return "", m.err
-	}
-	return m.currentUser, nil
-}
-
 type mockEventBus struct {
 	events []eventbus.Event
 }
@@ -114,8 +51,8 @@ func makeGitHubPR(number int, title, headRef, state string, draft bool) *github.
 
 func TestSyncRepoPRs_CreatesNewPRs(t *testing.T) {
 	database, repo := setupGitServiceTest(t)
-	ghClient := &mockGitHubClient{
-		repoPRs: []*github.PullRequest{makeGitHubPR(1, "First PR", "feature-a", "open", false)},
+	ghClient := &MockGitHubClient{
+		RepoPRs: []*github.PullRequest{makeGitHubPR(1, "First PR", "feature-a", "open", false)},
 	}
 	svc := NewGitService(database, WithGitHubClient(ghClient))
 
@@ -146,8 +83,8 @@ func TestSyncRepoPRs_UpdatesExistingPRs(t *testing.T) {
 	}
 	require.NoError(t, prStore.Add(existing))
 
-	ghClient := &mockGitHubClient{
-		repoPRs: []*github.PullRequest{makeGitHubPR(1, "New Title", "feature-a", "open", false)},
+	ghClient := &MockGitHubClient{
+		RepoPRs: []*github.PullRequest{makeGitHubPR(1, "New Title", "feature-a", "open", false)},
 	}
 	svc := NewGitService(database, WithGitHubClient(ghClient))
 
@@ -180,7 +117,7 @@ func TestSyncRepoPRs_PublishesPRUpdatedOnStateChange(t *testing.T) {
 	raw := makeGitHubPR(1, "Some PR", "feature-a", "closed", false)
 	raw.MergedAt = &mergedAt
 
-	ghClient := &mockGitHubClient{repoPRs: []*github.PullRequest{raw}}
+	ghClient := &MockGitHubClient{RepoPRs: []*github.PullRequest{raw}}
 	bus := &mockEventBus{}
 	svc := NewGitService(database, WithGitHubClient(ghClient), WithEventBus(bus))
 
@@ -197,8 +134,8 @@ func TestSyncRepoPRs_PublishesPRUpdatedOnStateChange(t *testing.T) {
 
 func TestSyncRepoPRs_PublishesPRUpdatedForNewPR(t *testing.T) {
 	database, repo := setupGitServiceTest(t)
-	ghClient := &mockGitHubClient{
-		repoPRs: []*github.PullRequest{makeGitHubPR(1, "New PR", "feature-a", "open", false)},
+	ghClient := &MockGitHubClient{
+		RepoPRs: []*github.PullRequest{makeGitHubPR(1, "New PR", "feature-a", "open", false)},
 	}
 	bus := &mockEventBus{}
 	svc := NewGitService(database, WithGitHubClient(ghClient), WithEventBus(bus))
@@ -216,8 +153,8 @@ func TestSyncRepoPRs_PublishesPRUpdatedForNewPR(t *testing.T) {
 
 func TestSyncRepoPRs_CreatesBranchForUnknownHead(t *testing.T) {
 	database, repo := setupGitServiceTest(t)
-	ghClient := &mockGitHubClient{
-		repoPRs: []*github.PullRequest{makeGitHubPR(1, "PR", "new-branch", "open", false)},
+	ghClient := &MockGitHubClient{
+		RepoPRs: []*github.PullRequest{makeGitHubPR(1, "PR", "new-branch", "open", false)},
 	}
 	svc := NewGitService(database, WithGitHubClient(ghClient))
 
@@ -295,7 +232,7 @@ func TestGetPRDiff_ReturnsStructuredDiff(t *testing.T) {
 	pr, _ := prStore.GetByRepoAndNumber(repo.ID, 1)
 	diffText := "diff --git a/file.go b/file.go\n--- a/file.go\n+++ b/file.go\n@@ -1,3 +1,4 @@\n package main\n \n+import \"fmt\"\n func main() {}\n"
 
-	ghClient := &mockGitHubClient{diffContent: diffText}
+	ghClient := &MockGitHubClient{DiffContent: diffText}
 	svc := NewGitService(database, WithGitHubClient(ghClient))
 
 	diff, err := svc.GetPRDiff(context.Background(), pr.ID)
@@ -316,7 +253,7 @@ func TestSyncRepoPRs_SetsIsAssignedToMe(t *testing.T) {
 	database, repo := setupGitServiceTest(t)
 	raw := makeGitHubPR(1, "Assigned PR", "feature-a", "open", false)
 	raw.Assignees = []*github.User{{Login: github.Ptr("myself")}}
-	ghClient := &mockGitHubClient{repoPRs: []*github.PullRequest{raw}}
+	ghClient := &MockGitHubClient{RepoPRs: []*github.PullRequest{raw}}
 	svc := NewGitService(database, WithGitHubClient(ghClient))
 	svc.currentUser = "myself"
 
@@ -332,7 +269,7 @@ func TestSyncRepoPRs_NotAssigned(t *testing.T) {
 	database, repo := setupGitServiceTest(t)
 	raw := makeGitHubPR(1, "Someone elses PR", "feature-b", "open", false)
 	raw.Assignees = []*github.User{{Login: github.Ptr("someone-else")}}
-	ghClient := &mockGitHubClient{repoPRs: []*github.PullRequest{raw}}
+	ghClient := &MockGitHubClient{RepoPRs: []*github.PullRequest{raw}}
 	svc := NewGitService(database, WithGitHubClient(ghClient))
 	svc.currentUser = "myself"
 
@@ -348,7 +285,7 @@ func TestSyncRepoPRs_SetsIsAssignedToMe_WhenRequestedReviewer(t *testing.T) {
 	database, repo := setupGitServiceTest(t)
 	raw := makeGitHubPR(1, "Review request PR", "feature-a", "open", false)
 	raw.RequestedReviewers = []*github.User{{Login: github.Ptr("myself")}}
-	ghClient := &mockGitHubClient{repoPRs: []*github.PullRequest{raw}}
+	ghClient := &MockGitHubClient{RepoPRs: []*github.PullRequest{raw}}
 	svc := NewGitService(database, WithGitHubClient(ghClient))
 	svc.currentUser = "myself"
 
@@ -364,7 +301,7 @@ func TestSyncRepoPRs_TeamReviewRequest_DoesNotMarkAssigned(t *testing.T) {
 	database, repo := setupGitServiceTest(t)
 	raw := makeGitHubPR(1, "Team review PR", "feature-a", "open", false)
 	raw.RequestedTeams = []*github.Team{{Slug: github.Ptr("my-team")}}
-	ghClient := &mockGitHubClient{repoPRs: []*github.PullRequest{raw}}
+	ghClient := &MockGitHubClient{RepoPRs: []*github.PullRequest{raw}}
 	svc := NewGitService(database, WithGitHubClient(ghClient))
 	svc.currentUser = "myself"
 

--- a/internal/git/practivity.go
+++ b/internal/git/practivity.go
@@ -8,10 +8,13 @@ import (
 	"github.com/google/go-github/v72/github"
 )
 
+// Monitor notification types for the PR domain. The payload structs below are
+// the wire shapes Claude sees, so their json tags are a public contract.
 const (
-	ActivityReview        = "pull_request_review"
-	ActivityReviewComment = "pull_request_review_comment"
-	ActivityChecks        = "ci_checks"
+	NotificationPullRequest   = "pull_request"
+	NotificationReview        = "pull_request_review"
+	NotificationReviewComment = "pull_request_review_comment"
+	NotificationChecks        = "ci_checks"
 )
 
 const bodyLimit = 600
@@ -19,6 +22,31 @@ const bodyLimit = 600
 type PRActivity struct {
 	Type string
 	Data any
+}
+
+type PRNotification struct {
+	Number        int    `json:"number"`
+	Title         string `json:"title"`
+	State         string `json:"state"`
+	PreviousState string `json:"previous_state,omitempty"`
+	Branch        string `json:"branch,omitempty"`
+	Checks        string `json:"checks,omitempty"`
+	URL           string `json:"url"`
+}
+
+func NewPRNotification(pr *PullRequest, previous *PullRequest, branch string) PRNotification {
+	n := PRNotification{
+		Number: pr.Number,
+		Title:  pr.Title,
+		State:  string(pr.State),
+		Branch: branch,
+		Checks: string(pr.ChecksState),
+		URL:    pr.HTMLURL,
+	}
+	if previous != nil && previous.State != pr.State {
+		n.PreviousState = string(previous.State)
+	}
+	return n
 }
 
 type ReviewActivity struct {
@@ -64,14 +92,14 @@ func (s *GitService) SyncPRActivity(ctx context.Context, pr *PullRequest) ([]PRA
 		return nil, err
 	}
 
-	activity := make([]PRActivity, 0)
+	var activity []PRActivity
 	updated := false
 
 	reviews, err := s.githubClient.ListPRReviews(ctx, owner, name, pr.Number)
 	if err != nil {
 		return nil, err
 	}
-	if events, watermark := s.newReviews(pr, reviews); watermark > pr.LastReviewID || !pr.ActivityBaselined {
+	if events, watermark := s.newReviews(pr, reviews); watermark > pr.LastReviewID {
 		activity = append(activity, events...)
 		pr.LastReviewID = watermark
 		updated = true
@@ -81,7 +109,7 @@ func (s *GitService) SyncPRActivity(ctx context.Context, pr *PullRequest) ([]PRA
 	if err != nil {
 		return nil, err
 	}
-	if events, watermark := s.newReviewComments(pr, comments); watermark > pr.LastReviewCommentID || !pr.ActivityBaselined {
+	if events, watermark := s.newReviewComments(pr, comments); watermark > pr.LastReviewCommentID {
 		activity = append(activity, events...)
 		pr.LastReviewCommentID = watermark
 		updated = true
@@ -128,7 +156,7 @@ func (s *GitService) newReviews(pr *PullRequest, reviews []*github.PullRequestRe
 		if s.ignoredAuthor(author, review.GetUser().GetType()) {
 			continue
 		}
-		out = append(out, PRActivity{Type: ActivityReview, Data: ReviewActivity{
+		out = append(out, PRActivity{Type: NotificationReview, Data: ReviewActivity{
 			Number: pr.Number,
 			Title:  pr.Title,
 			State:  strings.ToLower(review.GetState()),
@@ -154,7 +182,7 @@ func (s *GitService) newReviewComments(pr *PullRequest, comments []*github.PullR
 		if s.ignoredAuthor(author, comment.GetUser().GetType()) {
 			continue
 		}
-		out = append(out, PRActivity{Type: ActivityReviewComment, Data: ReviewCommentActivity{
+		out = append(out, PRActivity{Type: NotificationReviewComment, Data: ReviewCommentActivity{
 			Number: pr.Number,
 			Title:  pr.Title,
 			Author: author,
@@ -164,7 +192,8 @@ func (s *GitService) newReviewComments(pr *PullRequest, comments []*github.PullR
 			URL:    comment.GetHTMLURL(),
 		}})
 	}
-	// the API gave us newest first, so flip to reading order
+	// ListPRReviewComments sorts newest first (ListReviews has no sort
+	// option), so flip to reading order
 	slices.Reverse(out)
 	return out, watermark
 }
@@ -173,11 +202,6 @@ func (s *GitService) newReviewComments(pr *PullRequest, comments []*github.PullR
 // event worth sending: the first failure while a run is still in flight, and
 // the rollup once every run has finished. A new head commit resets silently.
 func checksTransition(pr *PullRequest, runs []*github.CheckRun) (*PRActivity, ChecksState) {
-	if len(runs) == 0 {
-		return nil, ChecksStatePending
-	}
-
-	state := ChecksStatePassed
 	var failed []string
 	complete := true
 	for _, run := range runs {
@@ -191,34 +215,32 @@ func checksTransition(pr *PullRequest, runs []*github.CheckRun) (*PRActivity, Ch
 			failed = append(failed, run.GetName())
 		}
 	}
+
+	state := ChecksStatePending
 	switch {
 	case len(failed) > 0 && complete:
 		state = ChecksStateFailed
 	case len(failed) > 0:
 		state = ChecksStateFailing
-	case !complete:
-		state = ChecksStatePending
+	case complete && len(runs) > 0:
+		state = ChecksStatePassed
 	}
 
-	sameCommit := pr.ChecksHeadSHA == pr.HeadSHA
-	if sameCommit && state == pr.ChecksState {
-		return nil, state
+	previous := pr.ChecksState
+	if pr.ChecksHeadSHA != pr.HeadSHA {
+		previous = "" // a new head commit invalidates the old rollup
 	}
-	if state == ChecksStatePending {
-		return nil, state
-	}
-	// first sight of this PR only records a baseline, so adopting a batch of
-	// PRs does not fire a rollup for each one at once. The connect snapshot
-	// carries the current state instead.
-	if pr.ChecksHeadSHA == "" {
-		return nil, state
-	}
-	// a run that fails and finishes within one poll only needs the rollup
-	if state == ChecksStateFailing && sameCommit && pr.ChecksState.terminal() {
+	// Stay quiet while runs are in flight, on the first sight of a PR (the
+	// connect snapshot carries current state, so adopting a batch of PRs does
+	// not fire a rollup for each), on a repeat of what we already reported,
+	// and when a run fails and finishes inside one poll — that needs only the
+	// rollup.
+	if state == ChecksStatePending || state == previous || pr.ChecksHeadSHA == "" ||
+		(state == ChecksStateFailing && previous.terminal()) {
 		return nil, state
 	}
 
-	return &PRActivity{Type: ActivityChecks, Data: ChecksActivity{
+	return &PRActivity{Type: NotificationChecks, Data: ChecksActivity{
 		Number: pr.Number,
 		Title:  pr.Title,
 		State:  string(state),
@@ -228,13 +250,8 @@ func checksTransition(pr *PullRequest, runs []*github.CheckRun) (*PRActivity, Ch
 }
 
 func (s *GitService) ignoredAuthor(login, userType string) bool {
-	if login == "" {
-		return true
-	}
-	if login == s.currentUser {
-		return true
-	}
-	return userType == "Bot" || strings.HasSuffix(login, "[bot]")
+	return login == "" || login == s.currentUser ||
+		userType == "Bot" || strings.HasSuffix(login, "[bot]")
 }
 
 func truncate(body string) string {

--- a/internal/git/practivity.go
+++ b/internal/git/practivity.go
@@ -1,0 +1,247 @@
+package git
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/google/go-github/v72/github"
+)
+
+const (
+	ActivityReview        = "pull_request_review"
+	ActivityReviewComment = "pull_request_review_comment"
+	ActivityChecks        = "ci_checks"
+)
+
+const bodyLimit = 600
+
+type PRActivity struct {
+	Type string
+	Data any
+}
+
+type ReviewActivity struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	State  string `json:"state"`
+	Author string `json:"author"`
+	Body   string `json:"body,omitempty"`
+	URL    string `json:"url"`
+}
+
+type ReviewCommentActivity struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Author string `json:"author"`
+	Path   string `json:"path,omitempty"`
+	Line   int    `json:"line,omitempty"`
+	Body   string `json:"body,omitempty"`
+	URL    string `json:"url"`
+}
+
+type ChecksActivity struct {
+	Number int      `json:"number"`
+	Title  string   `json:"title"`
+	State  string   `json:"state"`
+	Failed []string `json:"failed,omitempty"`
+	URL    string   `json:"url"`
+}
+
+// SyncPRActivity fetches reviews, inline review comments and check runs for a
+// single PR and returns only what is new since the last sync. Watermarks are
+// persisted on the PR, so a daemon restart does not replay old activity.
+func (s *GitService) SyncPRActivity(ctx context.Context, pr *PullRequest) ([]PRActivity, error) {
+	if s.githubClient == nil {
+		return nil, ErrNoGitHubClient
+	}
+	repo, err := s.repoStore.GetByID(pr.RepoID)
+	if err != nil {
+		return nil, err
+	}
+	owner, name, err := repo.OwnerAndName()
+	if err != nil {
+		return nil, err
+	}
+
+	activity := make([]PRActivity, 0)
+	updated := false
+
+	reviews, err := s.githubClient.ListPRReviews(ctx, owner, name, pr.Number)
+	if err != nil {
+		return nil, err
+	}
+	if events, watermark := s.newReviews(pr, reviews); watermark > pr.LastReviewID || !pr.ActivityBaselined {
+		activity = append(activity, events...)
+		pr.LastReviewID = watermark
+		updated = true
+	}
+
+	comments, err := s.githubClient.ListPRReviewComments(ctx, owner, name, pr.Number)
+	if err != nil {
+		return nil, err
+	}
+	if events, watermark := s.newReviewComments(pr, comments); watermark > pr.LastReviewCommentID || !pr.ActivityBaselined {
+		activity = append(activity, events...)
+		pr.LastReviewCommentID = watermark
+		updated = true
+	}
+	if !pr.ActivityBaselined {
+		pr.ActivityBaselined = true
+		updated = true
+	}
+
+	if pr.HeadSHA != "" {
+		runs, err := s.githubClient.ListCheckRuns(ctx, owner, name, pr.HeadSHA)
+		if err != nil {
+			return nil, err
+		}
+		if event, state := checksTransition(pr, runs); state != pr.ChecksState || pr.ChecksHeadSHA != pr.HeadSHA {
+			if event != nil {
+				activity = append(activity, *event)
+			}
+			pr.ChecksState = state
+			pr.ChecksHeadSHA = pr.HeadSHA
+			updated = true
+		}
+	}
+
+	if updated {
+		if err := s.prStore.Update(pr); err != nil {
+			return nil, err
+		}
+	}
+	return activity, nil
+}
+
+func (s *GitService) newReviews(pr *PullRequest, reviews []*github.PullRequestReview) ([]PRActivity, int64) {
+	watermark := pr.LastReviewID
+	var out []PRActivity
+	for _, review := range reviews {
+		if review.GetID() > watermark {
+			watermark = review.GetID()
+		}
+		if !pr.ActivityBaselined || review.GetID() <= pr.LastReviewID {
+			continue
+		}
+		author := review.GetUser().GetLogin()
+		if s.ignoredAuthor(author, review.GetUser().GetType()) {
+			continue
+		}
+		out = append(out, PRActivity{Type: ActivityReview, Data: ReviewActivity{
+			Number: pr.Number,
+			Title:  pr.Title,
+			State:  strings.ToLower(review.GetState()),
+			Author: author,
+			Body:   truncate(review.GetBody()),
+			URL:    review.GetHTMLURL(),
+		}})
+	}
+	return out, watermark
+}
+
+func (s *GitService) newReviewComments(pr *PullRequest, comments []*github.PullRequestComment) ([]PRActivity, int64) {
+	watermark := pr.LastReviewCommentID
+	var out []PRActivity
+	for _, comment := range comments {
+		if comment.GetID() > watermark {
+			watermark = comment.GetID()
+		}
+		if !pr.ActivityBaselined || comment.GetID() <= pr.LastReviewCommentID {
+			continue
+		}
+		author := comment.GetUser().GetLogin()
+		if s.ignoredAuthor(author, comment.GetUser().GetType()) {
+			continue
+		}
+		out = append(out, PRActivity{Type: ActivityReviewComment, Data: ReviewCommentActivity{
+			Number: pr.Number,
+			Title:  pr.Title,
+			Author: author,
+			Path:   comment.GetPath(),
+			Line:   comment.GetLine(),
+			Body:   truncate(comment.GetBody()),
+			URL:    comment.GetHTMLURL(),
+		}})
+	}
+	// the API gave us newest first, so flip to reading order
+	slices.Reverse(out)
+	return out, watermark
+}
+
+// checksTransition reports the check state for the PR's head commit and the
+// event worth sending: the first failure while a run is still in flight, and
+// the rollup once every run has finished. A new head commit resets silently.
+func checksTransition(pr *PullRequest, runs []*github.CheckRun) (*PRActivity, ChecksState) {
+	if len(runs) == 0 {
+		return nil, ChecksStatePending
+	}
+
+	state := ChecksStatePassed
+	var failed []string
+	complete := true
+	for _, run := range runs {
+		if run.GetStatus() != "completed" {
+			complete = false
+			continue
+		}
+		switch run.GetConclusion() {
+		case "success", "neutral", "skipped":
+		default:
+			failed = append(failed, run.GetName())
+		}
+	}
+	switch {
+	case len(failed) > 0 && complete:
+		state = ChecksStateFailed
+	case len(failed) > 0:
+		state = ChecksStateFailing
+	case !complete:
+		state = ChecksStatePending
+	}
+
+	sameCommit := pr.ChecksHeadSHA == pr.HeadSHA
+	if sameCommit && state == pr.ChecksState {
+		return nil, state
+	}
+	if state == ChecksStatePending {
+		return nil, state
+	}
+	// first sight of this PR only records a baseline, so adopting a batch of
+	// PRs does not fire a rollup for each one at once. The connect snapshot
+	// carries the current state instead.
+	if pr.ChecksHeadSHA == "" {
+		return nil, state
+	}
+	// a run that fails and finishes within one poll only needs the rollup
+	if state == ChecksStateFailing && sameCommit && pr.ChecksState.terminal() {
+		return nil, state
+	}
+
+	return &PRActivity{Type: ActivityChecks, Data: ChecksActivity{
+		Number: pr.Number,
+		Title:  pr.Title,
+		State:  string(state),
+		Failed: failed,
+		URL:    pr.HTMLURL,
+	}}, state
+}
+
+func (s *GitService) ignoredAuthor(login, userType string) bool {
+	if login == "" {
+		return true
+	}
+	if login == s.currentUser {
+		return true
+	}
+	return userType == "Bot" || strings.HasSuffix(login, "[bot]")
+}
+
+func truncate(body string) string {
+	body = strings.TrimSpace(body)
+	runes := []rune(body)
+	if len(runes) <= bodyLimit {
+		return body
+	}
+	return string(runes[:bodyLimit]) + "…"
+}

--- a/internal/git/practivity_test.go
+++ b/internal/git/practivity_test.go
@@ -1,0 +1,244 @@
+package git
+
+import (
+	"context"
+	"testing"
+
+	"github.com/eleonorayaya/utena/internal/db/testdb"
+	"github.com/google/go-github/v72/github"
+	"github.com/stretchr/testify/require"
+)
+
+func activityEnv(t *testing.T, client *mockGitHubClient) (*GitService, *PullRequest) {
+	t.Helper()
+
+	database := testdb.New(t, &Repo{}, &Branch{}, &Worktree{}, &PullRequest{})
+	service := NewGitService(database, WithGitHubClient(client))
+	service.currentUser = "eleonorayaya"
+
+	repo := &Repo{Path: "/tmp/repo", FullName: "eleonorayaya/utena"}
+	require.NoError(t, database.Create(repo).Error)
+
+	pr := &PullRequest{RepoID: repo.ID, Number: 7, Title: "Test PR", State: PRStateOpen, HeadSHA: "abc123"}
+	require.NoError(t, database.Create(pr).Error)
+
+	return service, pr
+}
+
+func review(id int64, login, userType, state string) *github.PullRequestReview {
+	return &github.PullRequestReview{
+		ID:    github.Ptr(id),
+		State: github.Ptr(state),
+		Body:  github.Ptr("looks good"),
+		User:  &github.User{Login: github.Ptr(login), Type: github.Ptr(userType)},
+	}
+}
+
+func checkRun(name, status, conclusion string) *github.CheckRun {
+	return &github.CheckRun{
+		Name:       github.Ptr(name),
+		Status:     github.Ptr(status),
+		Conclusion: github.Ptr(conclusion),
+	}
+}
+
+func TestSyncPRActivity_FirstSyncOnlyBaselines(t *testing.T) {
+	client := &mockGitHubClient{
+		reviews:        []*github.PullRequestReview{review(10, "someone", "User", "APPROVED")},
+		reviewComments: []*github.PullRequestComment{{ID: github.Ptr(int64(5)), User: &github.User{Login: github.Ptr("someone")}}},
+	}
+	service, pr := activityEnv(t, client)
+
+	activity, err := service.SyncPRActivity(context.Background(), pr)
+	require.NoError(t, err)
+
+	require.Empty(t, activity, "existing activity must not be replayed on first sight")
+	require.True(t, pr.ActivityBaselined)
+	require.Equal(t, int64(10), pr.LastReviewID)
+	require.Equal(t, int64(5), pr.LastReviewCommentID)
+}
+
+func TestSyncPRActivity_FirstReviewOnAPRThatHadNone(t *testing.T) {
+	client := &mockGitHubClient{}
+	service, pr := activityEnv(t, client)
+
+	_, err := service.SyncPRActivity(context.Background(), pr)
+	require.NoError(t, err)
+	require.True(t, pr.ActivityBaselined)
+	require.Zero(t, pr.LastReviewID, "nothing to watermark yet")
+
+	client.reviews = []*github.PullRequestReview{review(500, "someone", "User", "CHANGES_REQUESTED")}
+	activity, err := service.SyncPRActivity(context.Background(), pr)
+	require.NoError(t, err)
+
+	require.Len(t, activity, 1, "the first review on a PR must not be mistaken for a baseline")
+	require.Equal(t, ActivityReview, activity[0].Type)
+	require.Equal(t, int64(500), pr.LastReviewID)
+}
+
+func TestSyncPRActivity_NewReview(t *testing.T) {
+	client := &mockGitHubClient{reviews: []*github.PullRequestReview{review(10, "someone", "User", "APPROVED")}}
+	service, pr := activityEnv(t, client)
+	pr.ActivityBaselined = true
+	pr.LastReviewID = 9
+
+	activity, err := service.SyncPRActivity(context.Background(), pr)
+	require.NoError(t, err)
+
+	require.Len(t, activity, 1)
+	require.Equal(t, ActivityReview, activity[0].Type)
+	require.Equal(t, ReviewActivity{
+		Number: 7,
+		Title:  "Test PR",
+		State:  "approved",
+		Author: "someone",
+		Body:   "looks good",
+	}, activity[0].Data)
+	require.Equal(t, int64(10), pr.LastReviewID)
+}
+
+func TestSyncPRActivity_SkipsBotsAndSelf(t *testing.T) {
+	client := &mockGitHubClient{reviews: []*github.PullRequestReview{
+		review(10, "coverage-bot", "Bot", "COMMENTED"),
+		review(11, "dependabot[bot]", "User", "COMMENTED"),
+		review(12, "eleonorayaya", "User", "APPROVED"),
+	}}
+	service, pr := activityEnv(t, client)
+	pr.ActivityBaselined = true
+	pr.LastReviewID = 9
+
+	activity, err := service.SyncPRActivity(context.Background(), pr)
+	require.NoError(t, err)
+
+	require.Empty(t, activity)
+	require.Equal(t, int64(12), pr.LastReviewID, "watermark must still advance past filtered activity")
+}
+
+func TestSyncPRActivity_NewReviewComment(t *testing.T) {
+	client := &mockGitHubClient{reviewComments: []*github.PullRequestComment{{
+		ID:      github.Ptr(int64(20)),
+		Path:    github.Ptr("internal/monitor/monitorservice.go"),
+		Line:    github.Ptr(42),
+		Body:    github.Ptr("this leaks"),
+		HTMLURL: github.Ptr("https://github.com/eleonorayaya/utena/pull/7#discussion_r20"),
+		User:    &github.User{Login: github.Ptr("someone"), Type: github.Ptr("User")},
+	}}}
+	service, pr := activityEnv(t, client)
+	pr.ActivityBaselined = true
+	pr.LastReviewCommentID = 19
+
+	activity, err := service.SyncPRActivity(context.Background(), pr)
+	require.NoError(t, err)
+
+	require.Len(t, activity, 1)
+	require.Equal(t, ActivityReviewComment, activity[0].Type)
+	require.Equal(t, ReviewCommentActivity{
+		Number: 7,
+		Title:  "Test PR",
+		Author: "someone",
+		Path:   "internal/monitor/monitorservice.go",
+		Line:   42,
+		Body:   "this leaks",
+		URL:    "https://github.com/eleonorayaya/utena/pull/7#discussion_r20",
+	}, activity[0].Data)
+}
+
+func TestChecksTransitions(t *testing.T) {
+	cases := []struct {
+		name       string
+		prev       ChecksState
+		prevSHA    string
+		runs       []*github.CheckRun
+		wantEvent  bool
+		wantState  ChecksState
+		wantFailed []string
+	}{
+		{
+			name:      "still running is silent",
+			runs:      []*github.CheckRun{checkRun("build", "in_progress", "")},
+			wantState: ChecksStatePending,
+		},
+		{
+			name:       "first failure while others run",
+			prev:       ChecksStatePending,
+			prevSHA:    "abc123",
+			runs:       []*github.CheckRun{checkRun("lint", "completed", "failure"), checkRun("build", "in_progress", "")},
+			wantEvent:  true,
+			wantState:  ChecksStateFailing,
+			wantFailed: []string{"lint"},
+		},
+		{
+			name:      "repeat failure is silent",
+			prev:      ChecksStateFailing,
+			prevSHA:   "abc123",
+			runs:      []*github.CheckRun{checkRun("lint", "completed", "failure"), checkRun("build", "in_progress", "")},
+			wantState: ChecksStateFailing,
+		},
+		{
+			name:      "all green rollup",
+			prev:      ChecksStatePending,
+			prevSHA:   "abc123",
+			runs:      []*github.CheckRun{checkRun("lint", "completed", "success"), checkRun("build", "completed", "skipped")},
+			wantEvent: true,
+			wantState: ChecksStatePassed,
+		},
+		{
+			name:       "failed rollup after first failure",
+			prev:       ChecksStateFailing,
+			prevSHA:    "abc123",
+			runs:       []*github.CheckRun{checkRun("lint", "completed", "failure"), checkRun("build", "completed", "timed_out")},
+			wantEvent:  true,
+			wantState:  ChecksStateFailed,
+			wantFailed: []string{"lint", "build"},
+		},
+		{
+			name:      "new commit resets without an event",
+			prev:      ChecksStateFailed,
+			prevSHA:   "old-sha",
+			runs:      []*github.CheckRun{checkRun("lint", "queued", "")},
+			wantState: ChecksStatePending,
+		},
+		{
+			name:      "no checks configured is silent",
+			prev:      ChecksStatePending,
+			prevSHA:   "abc123",
+			wantState: ChecksStatePending,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := &PullRequest{Number: 7, Title: "Test PR", HeadSHA: "abc123", ChecksState: tc.prev, ChecksHeadSHA: tc.prevSHA}
+
+			event, state := checksTransition(pr, tc.runs)
+
+			require.Equal(t, tc.wantState, state)
+			if !tc.wantEvent {
+				require.Nil(t, event)
+				return
+			}
+			require.NotNil(t, event)
+			require.Equal(t, ActivityChecks, event.Type)
+			data := event.Data.(ChecksActivity)
+			require.Equal(t, string(tc.wantState), data.State)
+			require.Equal(t, tc.wantFailed, data.Failed)
+		})
+	}
+}
+
+func TestSyncPRActivity_PersistsWatermarks(t *testing.T) {
+	client := &mockGitHubClient{
+		reviews:   []*github.PullRequestReview{review(10, "someone", "User", "APPROVED")},
+		checkRuns: []*github.CheckRun{checkRun("lint", "completed", "success")},
+	}
+	service, pr := activityEnv(t, client)
+
+	_, err := service.SyncPRActivity(context.Background(), pr)
+	require.NoError(t, err)
+
+	stored, err := service.prStore.GetByID(pr.ID)
+	require.NoError(t, err)
+	require.Equal(t, int64(10), stored.LastReviewID)
+	require.Equal(t, ChecksStatePassed, stored.ChecksState)
+	require.Equal(t, "abc123", stored.ChecksHeadSHA)
+}

--- a/internal/git/practivity_test.go
+++ b/internal/git/practivity_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func activityEnv(t *testing.T, client *mockGitHubClient) (*GitService, *PullRequest) {
+func activityEnv(t *testing.T, client *MockGitHubClient) (*GitService, *PullRequest) {
 	t.Helper()
 
 	database := testdb.New(t, &Repo{}, &Branch{}, &Worktree{}, &PullRequest{})
@@ -43,9 +43,9 @@ func checkRun(name, status, conclusion string) *github.CheckRun {
 }
 
 func TestSyncPRActivity_FirstSyncOnlyBaselines(t *testing.T) {
-	client := &mockGitHubClient{
-		reviews:        []*github.PullRequestReview{review(10, "someone", "User", "APPROVED")},
-		reviewComments: []*github.PullRequestComment{{ID: github.Ptr(int64(5)), User: &github.User{Login: github.Ptr("someone")}}},
+	client := &MockGitHubClient{
+		Reviews:        []*github.PullRequestReview{review(10, "someone", "User", "APPROVED")},
+		ReviewComments: []*github.PullRequestComment{{ID: github.Ptr(int64(5)), User: &github.User{Login: github.Ptr("someone")}}},
 	}
 	service, pr := activityEnv(t, client)
 
@@ -59,7 +59,7 @@ func TestSyncPRActivity_FirstSyncOnlyBaselines(t *testing.T) {
 }
 
 func TestSyncPRActivity_FirstReviewOnAPRThatHadNone(t *testing.T) {
-	client := &mockGitHubClient{}
+	client := &MockGitHubClient{}
 	service, pr := activityEnv(t, client)
 
 	_, err := service.SyncPRActivity(context.Background(), pr)
@@ -67,17 +67,17 @@ func TestSyncPRActivity_FirstReviewOnAPRThatHadNone(t *testing.T) {
 	require.True(t, pr.ActivityBaselined)
 	require.Zero(t, pr.LastReviewID, "nothing to watermark yet")
 
-	client.reviews = []*github.PullRequestReview{review(500, "someone", "User", "CHANGES_REQUESTED")}
+	client.Reviews = []*github.PullRequestReview{review(500, "someone", "User", "CHANGES_REQUESTED")}
 	activity, err := service.SyncPRActivity(context.Background(), pr)
 	require.NoError(t, err)
 
 	require.Len(t, activity, 1, "the first review on a PR must not be mistaken for a baseline")
-	require.Equal(t, ActivityReview, activity[0].Type)
+	require.Equal(t, NotificationReview, activity[0].Type)
 	require.Equal(t, int64(500), pr.LastReviewID)
 }
 
 func TestSyncPRActivity_NewReview(t *testing.T) {
-	client := &mockGitHubClient{reviews: []*github.PullRequestReview{review(10, "someone", "User", "APPROVED")}}
+	client := &MockGitHubClient{Reviews: []*github.PullRequestReview{review(10, "someone", "User", "APPROVED")}}
 	service, pr := activityEnv(t, client)
 	pr.ActivityBaselined = true
 	pr.LastReviewID = 9
@@ -86,7 +86,7 @@ func TestSyncPRActivity_NewReview(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, activity, 1)
-	require.Equal(t, ActivityReview, activity[0].Type)
+	require.Equal(t, NotificationReview, activity[0].Type)
 	require.Equal(t, ReviewActivity{
 		Number: 7,
 		Title:  "Test PR",
@@ -98,7 +98,7 @@ func TestSyncPRActivity_NewReview(t *testing.T) {
 }
 
 func TestSyncPRActivity_SkipsBotsAndSelf(t *testing.T) {
-	client := &mockGitHubClient{reviews: []*github.PullRequestReview{
+	client := &MockGitHubClient{Reviews: []*github.PullRequestReview{
 		review(10, "coverage-bot", "Bot", "COMMENTED"),
 		review(11, "dependabot[bot]", "User", "COMMENTED"),
 		review(12, "eleonorayaya", "User", "APPROVED"),
@@ -115,7 +115,7 @@ func TestSyncPRActivity_SkipsBotsAndSelf(t *testing.T) {
 }
 
 func TestSyncPRActivity_NewReviewComment(t *testing.T) {
-	client := &mockGitHubClient{reviewComments: []*github.PullRequestComment{{
+	client := &MockGitHubClient{ReviewComments: []*github.PullRequestComment{{
 		ID:      github.Ptr(int64(20)),
 		Path:    github.Ptr("internal/monitor/monitorservice.go"),
 		Line:    github.Ptr(42),
@@ -131,7 +131,7 @@ func TestSyncPRActivity_NewReviewComment(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, activity, 1)
-	require.Equal(t, ActivityReviewComment, activity[0].Type)
+	require.Equal(t, NotificationReviewComment, activity[0].Type)
 	require.Equal(t, ReviewCommentActivity{
 		Number: 7,
 		Title:  "Test PR",
@@ -218,7 +218,7 @@ func TestChecksTransitions(t *testing.T) {
 				return
 			}
 			require.NotNil(t, event)
-			require.Equal(t, ActivityChecks, event.Type)
+			require.Equal(t, NotificationChecks, event.Type)
 			data := event.Data.(ChecksActivity)
 			require.Equal(t, string(tc.wantState), data.State)
 			require.Equal(t, tc.wantFailed, data.Failed)
@@ -227,9 +227,9 @@ func TestChecksTransitions(t *testing.T) {
 }
 
 func TestSyncPRActivity_PersistsWatermarks(t *testing.T) {
-	client := &mockGitHubClient{
-		reviews:   []*github.PullRequestReview{review(10, "someone", "User", "APPROVED")},
-		checkRuns: []*github.CheckRun{checkRun("lint", "completed", "success")},
+	client := &MockGitHubClient{
+		Reviews:   []*github.PullRequestReview{review(10, "someone", "User", "APPROVED")},
+		CheckRuns: []*github.CheckRun{checkRun("lint", "completed", "success")},
 	}
 	service, pr := activityEnv(t, client)
 

--- a/internal/git/prstore.go
+++ b/internal/git/prstore.go
@@ -93,7 +93,7 @@ func (s *PRStore) Upsert(pr *PullRequest) error {
 	return s.db.Save(pr).Error
 }
 
-func (s *PRStore) Update(pr *PullRequest) error {
+func (s *PRStore) Update(pr *PullRequest, omitColumns ...string) error {
 	if pr == nil {
 		return errors.New("pull request cannot be nil")
 	}
@@ -109,7 +109,11 @@ func (s *PRStore) Update(pr *PullRequest) error {
 		return err
 	}
 
-	if err := s.db.Save(pr).Error; err != nil {
+	writer := s.db.Save
+	if len(omitColumns) > 0 {
+		writer = s.db.Omit(omitColumns...).Save
+	}
+	if err := writer(pr).Error; err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) || db.IsUniqueConstraintError(err) {
 			return common.WrapConflict(
 				fmt.Sprintf("pull request #%d is already tracked for this repo", pr.Number),

--- a/internal/git/pullrequest.go
+++ b/internal/git/pullrequest.go
@@ -32,4 +32,24 @@ type PullRequest struct {
 	IsAssignedToMe bool    `json:"is_assigned_to_me"`
 	HTMLURL        string  `json:"html_url"`
 	AuthorLogin    string  `json:"author_login"`
+
+	HeadSHA             string      `json:"head_sha,omitempty"`
+	ActivityBaselined   bool        `json:"-"`
+	LastReviewID        int64       `json:"-"`
+	LastReviewCommentID int64       `json:"-"`
+	ChecksHeadSHA       string      `json:"-"`
+	ChecksState         ChecksState `json:"checks_state,omitempty"`
+}
+
+type ChecksState string
+
+const (
+	ChecksStatePending ChecksState = "pending"
+	ChecksStateFailing ChecksState = "failing"
+	ChecksStatePassed  ChecksState = "passed"
+	ChecksStateFailed  ChecksState = "failed"
+)
+
+func (c ChecksState) terminal() bool {
+	return c == ChecksStatePassed || c == ChecksStateFailed
 }

--- a/internal/git/pullrequest.go
+++ b/internal/git/pullrequest.go
@@ -41,6 +41,22 @@ type PullRequest struct {
 	ChecksState         ChecksState `json:"checks_state,omitempty"`
 }
 
+// activityColumns are maintained only by SyncPRActivity. The PR sync rebuilds
+// a PullRequest from the GitHub payload and would otherwise blank them.
+func activityColumns() []string {
+	return []string{
+		"activity_baselined",
+		"last_review_id",
+		"last_review_comment_id",
+		"checks_head_sha",
+		"checks_state",
+	}
+}
+
+func (s PRState) IsOpen() bool {
+	return s == PRStateOpen || s == PRStateDraft
+}
+
 type ChecksState string
 
 const (

--- a/internal/git/testing.go
+++ b/internal/git/testing.go
@@ -1,0 +1,54 @@
+package git
+
+import (
+	"context"
+
+	"github.com/google/go-github/v72/github"
+)
+
+// MockGitHubClient is a GitHubClient for tests. It lives outside _test.go so
+// other packages' tests can use it too, the same way tmux.NewMockRunner does.
+type MockGitHubClient struct {
+	RepoPRs        []*github.PullRequest
+	PRByNumber     map[int]*github.PullRequest
+	DiffContent    string
+	CurrentUser    string
+	Reviews        []*github.PullRequestReview
+	ReviewComments []*github.PullRequestComment
+	CheckRuns      []*github.CheckRun
+	Err            error
+}
+
+func (m *MockGitHubClient) ListRepoPRs(context.Context, string, string) ([]*github.PullRequest, error) {
+	return m.RepoPRs, m.Err
+}
+
+func (m *MockGitHubClient) GetPR(_ context.Context, _, _ string, number int) (*github.PullRequest, error) {
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	if pr, ok := m.PRByNumber[number]; ok {
+		return pr, nil
+	}
+	return nil, ErrPRNotFound
+}
+
+func (m *MockGitHubClient) GetPRDiff(context.Context, string, string, int) (string, error) {
+	return m.DiffContent, m.Err
+}
+
+func (m *MockGitHubClient) GetCurrentUser(context.Context) (string, error) {
+	return m.CurrentUser, m.Err
+}
+
+func (m *MockGitHubClient) ListPRReviews(context.Context, string, string, int) ([]*github.PullRequestReview, error) {
+	return m.Reviews, m.Err
+}
+
+func (m *MockGitHubClient) ListPRReviewComments(context.Context, string, string, int) ([]*github.PullRequestComment, error) {
+	return m.ReviewComments, m.Err
+}
+
+func (m *MockGitHubClient) ListCheckRuns(context.Context, string, string, string) ([]*github.CheckRun, error) {
+	return m.CheckRuns, m.Err
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -50,6 +50,15 @@ type Session struct {
 	TmuxSession    *utmux.TmuxSession     `json:"tmux_session,omitempty" gorm:"foreignKey:TmuxSessionID"`
 }
 
+func (s *Session) watchesPRActivity() bool {
+	switch s.Status {
+	case StatusDeleted, StatusArchived, StatusCompleted, StatusPending, StatusCreating:
+		return false
+	default:
+		return true
+	}
+}
+
 type SessionWorktree struct {
 	gorm.Model
 	SessionID  uint                 `json:"session_id" gorm:"uniqueIndex:idx_session_worktree;index;not null"`

--- a/internal/session/sessionmodule.go
+++ b/internal/session/sessionmodule.go
@@ -116,7 +116,18 @@ func (t *completedCleanupTask) Run(ctx context.Context) error {
 	return nil
 }
 
+type prActivityTask struct {
+	service *SessionService
+}
+
+func (t *prActivityTask) Name() string            { return "session.pr_activity" }
+func (t *prActivityTask) Interval() time.Duration { return time.Minute }
+func (t *prActivityTask) Run(ctx context.Context) error {
+	return t.service.SyncPRActivity(ctx)
+}
+
 func (m *SessionModule) RegisterJobs(svc *jobs.JobService) {
 	svc.Register(&reconcileSyncTask{service: m.Service})
 	svc.Register(&completedCleanupTask{service: m.Service})
+	svc.Register(&prActivityTask{service: m.Service})
 }

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -1581,17 +1581,8 @@ func (s *SessionService) handlePRUpdated(ctx context.Context, event eventbus.Eve
 }
 
 func (s *SessionService) notifyPRUpdated(ctx context.Context, sess *Session, pr *git.PullRequest, previous *git.PullRequest) {
-	event := eventbus.Event{
-		Type: eventbus.SessionNotification,
-		Data: eventbus.SessionNotificationEvent{
-			SessionID: sess.ID,
-			Type:      notificationTypePullRequest,
-			Data:      newPRNotification(pr, previous, sessionBranchName(sess, *pr.HeadBranchID)),
-		},
-	}
-	if err := s.eventBus.Publish(ctx, event); err != nil {
-		slog.Warn("failed to publish session notification", "session", sess.ID, "pr", pr.Number, "error", err)
-	}
+	data := newPRNotification(pr, previous, sessionBranchName(sess, *pr.HeadBranchID))
+	s.publishNotification(ctx, sess.ID, notificationTypePullRequest, data)
 }
 
 func (s *SessionService) SessionSnapshot(ctx context.Context, sessionID uint) []eventbus.SessionNotificationEvent {
@@ -1617,6 +1608,72 @@ func (s *SessionService) SessionSnapshot(ctx context.Context, sessionID uint) []
 	return out
 }
 
+// SyncPRActivity polls reviews, review comments and CI checks for the PRs of
+// live sessions and pushes whatever is new to that session's monitor. Only
+// session PRs are polled — a PR with no session has nowhere to deliver.
+func (s *SessionService) SyncPRActivity(ctx context.Context) error {
+	sessions, err := s.store.List()
+	if err != nil {
+		return err
+	}
+
+	// several sessions can sit on one branch, and detecting activity consumes
+	// the PR's watermark, so sync each PR once and fan the result out
+	order := make([]uint, 0, len(sessions))
+	prs := make(map[uint]*git.PullRequest)
+	watchers := make(map[uint][]uint)
+	for i := range sessions {
+		sess := &sessions[i]
+		if !sess.watchesPRActivity() {
+			continue
+		}
+		for _, branchID := range s.sessionBranchIDs(sess) {
+			for _, pr := range s.gitService.GetPRsForBranch(branchID) {
+				if pr.State != git.PRStateOpen && pr.State != git.PRStateDraft {
+					continue
+				}
+				if _, seen := prs[pr.ID]; !seen {
+					prs[pr.ID] = &pr
+					order = append(order, pr.ID)
+				}
+				watchers[pr.ID] = append(watchers[pr.ID], sess.ID)
+			}
+		}
+	}
+
+	for _, prID := range order {
+		pr := prs[prID]
+		activity, err := s.gitService.SyncPRActivity(ctx, pr)
+		if errors.Is(err, git.ErrNoGitHubClient) {
+			return err
+		}
+		if err != nil {
+			slog.Warn("failed to sync PR activity", "pr", pr.Number, "error", err)
+			continue
+		}
+		for _, item := range activity {
+			for _, sessionID := range watchers[prID] {
+				s.publishNotification(ctx, sessionID, item.Type, item.Data)
+			}
+		}
+	}
+	return nil
+}
+
+func (s *SessionService) publishNotification(ctx context.Context, sessionID uint, notificationType string, data any) {
+	event := eventbus.Event{
+		Type: eventbus.SessionNotification,
+		Data: eventbus.SessionNotificationEvent{
+			SessionID: sessionID,
+			Type:      notificationType,
+			Data:      data,
+		},
+	}
+	if err := s.eventBus.Publish(ctx, event); err != nil {
+		slog.Warn("failed to publish session notification", "session", sessionID, "type", notificationType, "error", err)
+	}
+}
+
 func sessionBranchName(sess *Session, branchID uint) string {
 	for i := range sess.Worktrees {
 		wt := sess.Worktrees[i].Worktree
@@ -1633,6 +1690,7 @@ func newPRNotification(pr *git.PullRequest, previous *git.PullRequest, branch st
 		Title:  pr.Title,
 		State:  string(pr.State),
 		Branch: branch,
+		Checks: string(pr.ChecksState),
 		URL:    pr.HTMLURL,
 	}
 	if previous != nil && previous.State != pr.State {

--- a/internal/session/sessionservice.go
+++ b/internal/session/sessionservice.go
@@ -1581,8 +1581,8 @@ func (s *SessionService) handlePRUpdated(ctx context.Context, event eventbus.Eve
 }
 
 func (s *SessionService) notifyPRUpdated(ctx context.Context, sess *Session, pr *git.PullRequest, previous *git.PullRequest) {
-	data := newPRNotification(pr, previous, sessionBranchName(sess, *pr.HeadBranchID))
-	s.publishNotification(ctx, sess.ID, notificationTypePullRequest, data)
+	data := git.NewPRNotification(pr, previous, sessionBranchName(sess, *pr.HeadBranchID))
+	s.publishNotification(ctx, sess.ID, git.NotificationPullRequest, data)
 }
 
 func (s *SessionService) SessionSnapshot(ctx context.Context, sessionID uint) []eventbus.SessionNotificationEvent {
@@ -1595,13 +1595,13 @@ func (s *SessionService) SessionSnapshot(ctx context.Context, sessionID uint) []
 	for _, branchID := range s.sessionBranchIDs(sess) {
 		branch := sessionBranchName(sess, branchID)
 		for _, pr := range s.gitService.GetPRsForBranch(branchID) {
-			if pr.State != git.PRStateOpen && pr.State != git.PRStateDraft {
+			if !pr.State.IsOpen() {
 				continue
 			}
 			out = append(out, eventbus.SessionNotificationEvent{
 				SessionID: sessionID,
-				Type:      notificationTypePullRequest,
-				Data:      newPRNotification(&pr, nil, branch),
+				Type:      git.NotificationPullRequest,
+				Data:      git.NewPRNotification(&pr, nil, branch),
 			})
 		}
 	}
@@ -1618,9 +1618,8 @@ func (s *SessionService) SyncPRActivity(ctx context.Context) error {
 	}
 
 	// several sessions can sit on one branch, and detecting activity consumes
-	// the PR's watermark, so sync each PR once and fan the result out
+	// the PR's watermark, so walk each branch once and fan the result out
 	order := make([]uint, 0, len(sessions))
-	prs := make(map[uint]*git.PullRequest)
 	watchers := make(map[uint][]uint)
 	for i := range sessions {
 		sess := &sessions[i]
@@ -1628,32 +1627,30 @@ func (s *SessionService) SyncPRActivity(ctx context.Context) error {
 			continue
 		}
 		for _, branchID := range s.sessionBranchIDs(sess) {
-			for _, pr := range s.gitService.GetPRsForBranch(branchID) {
-				if pr.State != git.PRStateOpen && pr.State != git.PRStateDraft {
-					continue
-				}
-				if _, seen := prs[pr.ID]; !seen {
-					prs[pr.ID] = &pr
-					order = append(order, pr.ID)
-				}
-				watchers[pr.ID] = append(watchers[pr.ID], sess.ID)
+			if _, seen := watchers[branchID]; !seen {
+				order = append(order, branchID)
 			}
+			watchers[branchID] = append(watchers[branchID], sess.ID)
 		}
 	}
 
-	for _, prID := range order {
-		pr := prs[prID]
-		activity, err := s.gitService.SyncPRActivity(ctx, pr)
-		if errors.Is(err, git.ErrNoGitHubClient) {
-			return err
-		}
-		if err != nil {
-			slog.Warn("failed to sync PR activity", "pr", pr.Number, "error", err)
-			continue
-		}
-		for _, item := range activity {
-			for _, sessionID := range watchers[prID] {
-				s.publishNotification(ctx, sessionID, item.Type, item.Data)
+	for _, branchID := range order {
+		for _, pr := range s.gitService.GetPRsForBranch(branchID) {
+			if !pr.State.IsOpen() {
+				continue
+			}
+			activity, err := s.gitService.SyncPRActivity(ctx, &pr)
+			if errors.Is(err, git.ErrNoGitHubClient) {
+				return err
+			}
+			if err != nil {
+				slog.Warn("failed to sync PR activity", "pr", pr.Number, "error", err)
+				continue
+			}
+			for _, item := range activity {
+				for _, sessionID := range watchers[branchID] {
+					s.publishNotification(ctx, sessionID, item.Type, item.Data)
+				}
 			}
 		}
 	}
@@ -1682,21 +1679,6 @@ func sessionBranchName(sess *Session, branchID uint) string {
 		}
 	}
 	return ""
-}
-
-func newPRNotification(pr *git.PullRequest, previous *git.PullRequest, branch string) prNotification {
-	n := prNotification{
-		Number: pr.Number,
-		Title:  pr.Title,
-		State:  string(pr.State),
-		Branch: branch,
-		Checks: string(pr.ChecksState),
-		URL:    pr.HTMLURL,
-	}
-	if previous != nil && previous.State != pr.State {
-		n.PreviousState = string(previous.State)
-	}
-	return n
 }
 
 func (s *SessionService) maybeCreatePendingSession(ctx context.Context, data git.PRUpdatedEvent) {

--- a/internal/session/sessionservice_monitor_test.go
+++ b/internal/session/sessionservice_monitor_test.go
@@ -51,8 +51,8 @@ func TestHandlePRUpdated_PublishesSessionNotification(t *testing.T) {
 	require.Len(t, got(), 1)
 	notification := got()[0]
 	require.Equal(t, sess.ID, notification.SessionID)
-	require.Equal(t, notificationTypePullRequest, notification.Type)
-	require.Equal(t, prNotification{
+	require.Equal(t, git.NotificationPullRequest, notification.Type)
+	require.Equal(t, git.PRNotification{
 		Number:        42,
 		Title:         "Test PR",
 		State:         "closed",
@@ -81,38 +81,8 @@ func TestHandlePRUpdated_NoSessionForBranch_PublishesNothing(t *testing.T) {
 	require.Empty(t, got())
 }
 
-type fakeGitHub struct {
-	reviews []*github.PullRequestReview
-}
-
-func (f *fakeGitHub) ListRepoPRs(context.Context, string, string) ([]*github.PullRequest, error) {
-	return nil, nil
-}
-
-func (f *fakeGitHub) GetPR(context.Context, string, string, int) (*github.PullRequest, error) {
-	return nil, nil
-}
-
-func (f *fakeGitHub) GetPRDiff(context.Context, string, string, int) (string, error) {
-	return "", nil
-}
-
-func (f *fakeGitHub) GetCurrentUser(context.Context) (string, error) { return "eleonorayaya", nil }
-
-func (f *fakeGitHub) ListPRReviews(context.Context, string, string, int) ([]*github.PullRequestReview, error) {
-	return f.reviews, nil
-}
-
-func (f *fakeGitHub) ListPRReviewComments(context.Context, string, string, int) ([]*github.PullRequestComment, error) {
-	return nil, nil
-}
-
-func (f *fakeGitHub) ListCheckRuns(context.Context, string, string, string) ([]*github.CheckRun, error) {
-	return nil, nil
-}
-
 func TestSyncPRActivity_FansOutToEverySessionOnTheBranch(t *testing.T) {
-	client := &fakeGitHub{reviews: []*github.PullRequestReview{{
+	client := &git.MockGitHubClient{Reviews: []*github.PullRequestReview{{
 		ID:    github.Ptr(int64(101)),
 		State: github.Ptr("CHANGES_REQUESTED"),
 		Body:  github.Ptr("please fix"),
@@ -148,7 +118,7 @@ func TestSyncPRActivity_FansOutToEverySessionOnTheBranch(t *testing.T) {
 	sessionIDs := []uint{got()[0].SessionID, got()[1].SessionID}
 	require.NotEqual(t, sessionIDs[0], sessionIDs[1])
 	for _, n := range got() {
-		require.Equal(t, git.ActivityReview, n.Type)
+		require.Equal(t, git.NotificationReview, n.Type)
 	}
 }
 
@@ -173,8 +143,8 @@ func TestSessionSnapshot_ReturnsSessionPRs(t *testing.T) {
 
 	require.Len(t, snapshot, 1)
 	require.Equal(t, sess.ID, snapshot[0].SessionID)
-	require.Equal(t, notificationTypePullRequest, snapshot[0].Type)
-	require.Equal(t, prNotification{
+	require.Equal(t, git.NotificationPullRequest, snapshot[0].Type)
+	require.Equal(t, git.PRNotification{
 		Number: 7,
 		Title:  "Snapshot PR",
 		State:  "open",
@@ -203,7 +173,7 @@ func TestSessionSnapshot_SkipsClosedAndMergedPRs(t *testing.T) {
 	snapshot := env.service.SessionSnapshot(ctx, sess.ID)
 
 	require.Len(t, snapshot, 1)
-	require.Equal(t, "draft", snapshot[0].Data.(prNotification).State)
+	require.Equal(t, "draft", snapshot[0].Data.(git.PRNotification).State)
 }
 
 func TestSessionSnapshot_UnknownSession(t *testing.T) {

--- a/internal/session/sessionservice_monitor_test.go
+++ b/internal/session/sessionservice_monitor_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/eleonorayaya/utena/internal/eventbus"
 	"github.com/eleonorayaya/utena/internal/git"
+	"github.com/google/go-github/v72/github"
 	"github.com/stretchr/testify/require"
 )
 
@@ -78,6 +79,77 @@ func TestHandlePRUpdated_NoSessionForBranch_PublishesNothing(t *testing.T) {
 	require.NoError(t, env.service.handlePRUpdated(ctx, event))
 
 	require.Empty(t, got())
+}
+
+type fakeGitHub struct {
+	reviews []*github.PullRequestReview
+}
+
+func (f *fakeGitHub) ListRepoPRs(context.Context, string, string) ([]*github.PullRequest, error) {
+	return nil, nil
+}
+
+func (f *fakeGitHub) GetPR(context.Context, string, string, int) (*github.PullRequest, error) {
+	return nil, nil
+}
+
+func (f *fakeGitHub) GetPRDiff(context.Context, string, string, int) (string, error) {
+	return "", nil
+}
+
+func (f *fakeGitHub) GetCurrentUser(context.Context) (string, error) { return "eleonorayaya", nil }
+
+func (f *fakeGitHub) ListPRReviews(context.Context, string, string, int) ([]*github.PullRequestReview, error) {
+	return f.reviews, nil
+}
+
+func (f *fakeGitHub) ListPRReviewComments(context.Context, string, string, int) ([]*github.PullRequestComment, error) {
+	return nil, nil
+}
+
+func (f *fakeGitHub) ListCheckRuns(context.Context, string, string, string) ([]*github.CheckRun, error) {
+	return nil, nil
+}
+
+func TestSyncPRActivity_FansOutToEverySessionOnTheBranch(t *testing.T) {
+	client := &fakeGitHub{reviews: []*github.PullRequestReview{{
+		ID:    github.Ptr(int64(101)),
+		State: github.Ptr("CHANGES_REQUESTED"),
+		Body:  github.Ptr("please fix"),
+		User:  &github.User{Login: github.Ptr("reviewer"), Type: github.Ptr("User")},
+	}}}
+	env := setupPRTestEnv(t, git.WithGitHubClient(client))
+	got := collectNotifications(env)
+
+	// worktrees.branch_id is unique, so two sessions share a branch by sharing
+	// the worktree row
+	branchID := env.branch.ID
+	first := &Session{Name: "first", Status: StatusActive, LastUsedAt: time.Now()}
+	require.NoError(t, env.sessionStore.Add(first))
+	worktree := env.attachBranchWorktree(t, first.ID, branchID, 0)
+
+	second := &Session{Name: "second", Status: StatusActive, LastUsedAt: time.Now()}
+	require.NoError(t, env.sessionStore.Add(second))
+	require.NoError(t, env.swtStore.Add(&SessionWorktree{SessionID: second.ID, WorktreeID: worktree.ID}))
+	require.NoError(t, env.database.Create(&git.PullRequest{
+		RepoID:            env.repo.ID,
+		Number:            9,
+		HeadBranchID:      &branchID,
+		State:             git.PRStateOpen,
+		HeadSHA:           "sha1",
+		ActivityBaselined: true,
+		LastReviewID:      100,
+	}).Error)
+
+	require.NoError(t, env.service.SyncPRActivity(context.Background()))
+
+	// the fake client returns one review newer than the watermark
+	require.Len(t, got(), 2, "both sessions on the branch must be notified")
+	sessionIDs := []uint{got()[0].SessionID, got()[1].SessionID}
+	require.NotEqual(t, sessionIDs[0], sessionIDs[1])
+	for _, n := range got() {
+		require.Equal(t, git.ActivityReview, n.Type)
+	}
 }
 
 func TestSessionSnapshot_ReturnsSessionPRs(t *testing.T) {

--- a/internal/session/sessionservice_pr_test.go
+++ b/internal/session/sessionservice_pr_test.go
@@ -51,7 +51,7 @@ func (env *prTestEnv) attachBranchWorktree(t *testing.T, sessionID uint, branchI
 	return wt
 }
 
-func setupPRTestEnv(t *testing.T) *prTestEnv {
+func setupPRTestEnv(t *testing.T, gitOpts ...git.GitServiceOption) *prTestEnv {
 	t.Helper()
 
 	database := testdb.New(t,
@@ -73,7 +73,7 @@ func setupPRTestEnv(t *testing.T) *prTestEnv {
 	sessionStore := NewSessionStore(database)
 	dismissedPRStore := NewDismissedPRStore(database)
 	workspaceStore := workspace.NewWorkspaceStore(database, afero.NewMemMapFs(), "/config")
-	gitService := git.NewGitService(database)
+	gitService := git.NewGitService(database, gitOpts...)
 	workspaceService := workspace.NewWorkspaceService(workspaceStore, gitService)
 
 	repoPath := initTestRepo(t)

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -40,18 +40,6 @@ func (slr *SessionListResponse) Render(w http.ResponseWriter, r *http.Request) e
 	return nil
 }
 
-const notificationTypePullRequest = "pull_request"
-
-type prNotification struct {
-	Number        int    `json:"number"`
-	Title         string `json:"title"`
-	State         string `json:"state"`
-	PreviousState string `json:"previous_state,omitempty"`
-	Branch        string `json:"branch,omitempty"`
-	Checks        string `json:"checks,omitempty"`
-	URL           string `json:"url"`
-}
-
 type WorkspaceBranchSpec struct {
 	WorkspaceID uint   `json:"workspace_id"`
 	Branch      string `json:"branch,omitempty"`

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -48,6 +48,7 @@ type prNotification struct {
 	State         string `json:"state"`
 	PreviousState string `json:"previous_state,omitempty"`
 	Branch        string `json:"branch,omitempty"`
+	Checks        string `json:"checks,omitempty"`
 	URL           string `json:"url"`
 }
 


### PR DESCRIPTION
## Summary

Three new event types on the session monitor, following the extension point from #107 — no changes to `internal/monitor/` or the client were needed:

| Type | Fires when |
|---|---|
| `pull_request_review` | A review is submitted — `state` is `approved` / `changes_requested` / `commented`, with the body |
| `pull_request_review_comment` | An inline comment lands, with `path` and `line` |
| `ci_checks` | `failing` the first time a check fails, then `passed` / `failed` once every run completes, with the failed check names |

- **Polling is driven from session, not git.** `SessionService.SyncPRActivity` (job `session.pr_activity`, 60s) only polls PRs whose head branch belongs to a live session — the only PRs with somewhere to deliver. ~3 GitHub calls per session PR per minute, versus ~4800/hr if we polled every open PR in every tracked repo.
- **A PR backing several sessions is synced once and fanned out**, because detection consumes the watermark — syncing per session would give the review to whichever session won the race and silently drop it for the others.
- **`GitService.SyncPRActivity` owns the calls and change detection.** Watermarks (`ActivityBaselined`, `LastReviewID`, `LastReviewCommentID`, `ChecksHeadSHA`, `ChecksState`) live on the `PullRequest` row, so a restart doesn't replay old activity.
- First sync of a PR records a baseline and emits nothing, so adopting a PR doesn't dump its history into Claude's context. `ActivityBaselined` is a separate flag rather than "watermark == 0" — a PR with no reviews yet also has 0, and using that as the baseline test would swallow its *first* review.
- Reviews and comments from bots or the daemon's own GitHub user are dropped. Bodies are truncated at 600 runes.
- The connect snapshot now carries `checks` on each open PR, so a session that starts while CI is red sees it without waiting for a transition.

## Test plan

- [x] `go test ./...` — 21 new tests: the full check-state transition table, watermark persistence, baseline-vs-first-review, bot/self filtering, and the shared-branch fan-out (which fails on the pre-fix loop)
- [x] `task lint` clean in new files (4 pre-existing errcheck issues untouched)
- [x] Migration verified against the **existing** live DB, not just fresh test DBs: `PRAGMA table_info(pull_requests)` shows all six new columns after `task daemon:install`, and the 30s PR sync keeps running without errors
- [x] Live: `session.pr_activity` ran against real GitHub and recorded baselines for all 4 session PRs (real review/comment IDs, `checks_state=passed`), no API errors
- [ ] Confirm a live review and a live CI transition arrive as notifications

Note: `TestSessionService_AddWorkspace_FullIntegration` is flaky independent of this branch (~4/6 on a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
