### PR TITLE
fix(monitor): keep bot reviews, and stop calling a daemon restart a failure

### DIFF
--- a/cmd/tui/monitor.go
+++ b/cmd/tui/monitor.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -36,7 +38,7 @@ func monitorCmd() *cobra.Command {
 			for ctx.Err() == nil {
 				if err := streamSessionEvents(ctx, url, os.Stdout); err != nil && ctx.Err() == nil {
 					// ponytail: stdout lines are events, so retry noise goes to stderr only
-					fmt.Fprintf(os.Stderr, "utena monitor: %v, retrying in %s\n", err, monitorRetryDelay)
+					fmt.Fprintf(os.Stderr, "utena monitor: %s, reconnecting in %s\n", describeDisconnect(err), monitorRetryDelay)
 				}
 				select {
 				case <-ctx.Done():
@@ -46,6 +48,16 @@ func monitorCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// describeDisconnect keeps the expected case — the daemon restarting, which
+// drops the socket without a close handshake — from reading like a failure.
+func describeDisconnect(err error) string {
+	if errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) ||
+		websocket.CloseStatus(err) != -1 || strings.Contains(err.Error(), "connection refused") {
+		return "daemon connection closed (daemon restarting?)"
+	}
+	return err.Error()
 }
 
 func streamSessionEvents(ctx context.Context, url string, out io.Writer) error {

--- a/docs/adding-features.md
+++ b/docs/adding-features.md
@@ -81,7 +81,7 @@ On connect, the monitor asks `SnapshotProvider` (implemented by `SessionService.
 | `pull_request_review_comment` | Someone leaves an inline comment, with `path` and `line` |
 | `ci_checks` | `failing` the first time a check fails, then `passed` / `failed` once every run completes, with the failed check names |
 
-Reviews and comments authored by the daemon's own GitHub user, or by bots, are dropped.
+Reviews and comments authored by the daemon's own GitHub user are dropped — you just wrote them. Bots are kept: review bots like `gusto-fresh-eyes` do most of the reviewing, and filtering them silently swallowed the majority of real feedback. If a genuinely noisy bot shows up, add a denylist then rather than blanket-filtering by account type.
 
 ### Polling activity without burning the API budget
 

--- a/internal/git/practivity.go
+++ b/internal/git/practivity.go
@@ -153,7 +153,7 @@ func (s *GitService) newReviews(pr *PullRequest, reviews []*github.PullRequestRe
 			continue
 		}
 		author := review.GetUser().GetLogin()
-		if s.ignoredAuthor(author, review.GetUser().GetType()) {
+		if s.ignoredAuthor(author) {
 			continue
 		}
 		out = append(out, PRActivity{Type: NotificationReview, Data: ReviewActivity{
@@ -179,7 +179,7 @@ func (s *GitService) newReviewComments(pr *PullRequest, comments []*github.PullR
 			continue
 		}
 		author := comment.GetUser().GetLogin()
-		if s.ignoredAuthor(author, comment.GetUser().GetType()) {
+		if s.ignoredAuthor(author) {
 			continue
 		}
 		out = append(out, PRActivity{Type: NotificationReviewComment, Data: ReviewCommentActivity{
@@ -249,9 +249,11 @@ func checksTransition(pr *PullRequest, runs []*github.CheckRun) (*PRActivity, Ch
 	}}, state
 }
 
-func (s *GitService) ignoredAuthor(login, userType string) bool {
-	return login == "" || login == s.currentUser ||
-		userType == "Bot" || strings.HasSuffix(login, "[bot]")
+// ignoredAuthor drops only our own activity. Bots are kept: the review bots
+// are the ones doing most of the reviewing, and their comments are as
+// actionable as a human's.
+func (s *GitService) ignoredAuthor(login string) bool {
+	return login == "" || login == s.currentUser
 }
 
 func truncate(body string) string {

--- a/internal/git/practivity_test.go
+++ b/internal/git/practivity_test.go
@@ -97,11 +97,11 @@ func TestSyncPRActivity_NewReview(t *testing.T) {
 	require.Equal(t, int64(10), pr.LastReviewID)
 }
 
-func TestSyncPRActivity_SkipsBotsAndSelf(t *testing.T) {
+func TestSyncPRActivity_SkipsOwnActivityButKeepsBots(t *testing.T) {
 	client := &MockGitHubClient{Reviews: []*github.PullRequestReview{
-		review(10, "coverage-bot", "Bot", "COMMENTED"),
-		review(11, "dependabot[bot]", "User", "COMMENTED"),
-		review(12, "eleonorayaya", "User", "APPROVED"),
+		// review bots do most of the reviewing, so their feedback is wanted
+		review(10, "gusto-fresh-eyes[bot]", "Bot", "COMMENTED"),
+		review(11, "eleonorayaya", "User", "APPROVED"),
 	}}
 	service, pr := activityEnv(t, client)
 	pr.ActivityBaselined = true
@@ -110,8 +110,9 @@ func TestSyncPRActivity_SkipsBotsAndSelf(t *testing.T) {
 	activity, err := service.SyncPRActivity(context.Background(), pr)
 	require.NoError(t, err)
 
-	require.Empty(t, activity)
-	require.Equal(t, int64(12), pr.LastReviewID, "watermark must still advance past filtered activity")
+	require.Len(t, activity, 1)
+	require.Equal(t, "gusto-fresh-eyes[bot]", activity[0].Data.(ReviewActivity).Author)
+	require.Equal(t, int64(11), pr.LastReviewID, "watermark must still advance past our own activity")
 }
 
 func TestSyncPRActivity_NewReviewComment(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #109, from watching it run against real PRs for a few days.

**Bot reviews were being swallowed.** Filtering by account type dropped `gusto-fresh-eyes[bot]`, which is **70 of the 102** review items across the 30 current session PRs — an automated reviewer whose inline comments are as actionable as a human's. The remaining 32 were 21 from the daemon's own GitHub user and 11 from human reviewers. Net effect: reviews and comments looked dead. Now only our own activity is skipped.

Diagnosed from the watermarks rather than guessed: `Gusto/flagger#28` had advanced `last_review_comment_id` to exactly `3685605016`, which is a `gusto-fresh-eyes[bot]` comment — so detection was working and the author filter was discarding the result.

**A daemon restart reported itself as a failure.** `http.Server.Shutdown` doesn't wait for hijacked websockets, so the socket drops without a close handshake and the client logged:

```
utena monitor: failed to get reader: failed to read frame header: EOF, retrying in 5s
```

It then reconnects 5s later, which is correct — only the wording was wrong. Now:

```
utena monitor: daemon connection closed (daemon restarting?), reconnecting in 5s
```

## Test plan

- [x] `go test ./cmd/tui/... ./internal/git/...` — 117 pass. `TestSyncPRActivity_SkipsBotsAndSelf` flipped to `TestSyncPRActivity_SkipsOwnActivityButKeepsBots`, now asserting a bot review produces an event and the watermark still advances past our own
- [x] `task lint` clean in the touched files
- [x] Installed live; monitor clients reconnected within 5s of the restart
- [ ] Confirm the next real `gusto-fresh-eyes` comment arrives as a notification

Note: already-posted bot comments won't replay — their IDs sit below the watermark, which is the no-history-dump behaviour from #109. To force one for a look: `update pull_requests set last_review_comment_id = last_review_comment_id - 1 where number = 28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
