### PR TITLE
feat(session): disable auto-archive of completed sessions

### DIFF
--- a/internal/session/sessionmodule.go
+++ b/internal/session/sessionmodule.go
@@ -128,6 +128,5 @@ func (t *prActivityTask) Run(ctx context.Context) error {
 
 func (m *SessionModule) RegisterJobs(svc *jobs.JobService) {
 	svc.Register(&reconcileSyncTask{service: m.Service})
-	svc.Register(&completedCleanupTask{service: m.Service})
 	svc.Register(&prActivityTask{service: m.Service})
 }


### PR DESCRIPTION
## Summary
- Unregister `completedCleanupTask` so completed sessions are no longer auto-archived 5 minutes after a PR merge
- Sessions marked `completed` on merge now stay `completed` until archived manually (TUI, or `PUT /sessions/{id}/archive`)
- Kept the task type and its tests — re-enabling is a one-line change

## Test plan
- [ ] `task test` — `internal/session` passes except the pre-existing `TestSessionService_AddWorkspace_FullIntegration` failure (sandboxed `git push` in that integration test, unrelated to this change)
- [ ] Merge a PR with an attached session, wait >5 min, confirm the session stays `completed` instead of moving to `archived`
- [ ] Confirm manual archive from the session list / detail view still works
